### PR TITLE
Added the ability to specify a writer node selection order into the --write-node option

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -214,7 +214,6 @@ do
       WRITE_NODES=`echo "$2" | sed 's/,/ /g'`
       WRITE_NODE=`echo "$WRITE_NODES" | cut -d' ' -f1`
 	  enable_priority=1
-	  echo "Enabled priority: ${WRITE_NODES}"
     else
       WRITE_NODE=$2
     fi
@@ -612,9 +611,10 @@ enable_proxysql(){
       echo '# Specify nodes in order from highest priority to lowest' >> $HOST_PRIORITY_FILE
 	  check_cmd $? "Failed to create the host priority file, verify the directory permissions: $HOST_PRIORITY_FILE"
       # Add the specified hosts to the file
-	  echo "Writers: $WRITE_NODES"
+	  echo -e "\nConfiguring $MODE mode with the following nodes designated as priority order:"
       for i in $WRITE_NODES;do
         echo $i >> $HOST_PRIORITY_FILE
+		echo " $i"
       done
     fi
 	

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -609,7 +609,7 @@ enable_proxysql(){
     # Create the host priority file if multiple write nodes were specified
     if [ -n $enable_priority ];then
       # Create empty priority config file
-	  echo '# ProxySQL Host Priority File' > $HOST_PRIORITY_FILE
+      echo '# ProxySQL Host Priority File' > $HOST_PRIORITY_FILE
       echo '# Specify nodes in order from highest priority to lowest' >> $HOST_PRIORITY_FILE
       check_cmd $? "Failed to create the host priority file, verify the directory permissions: $HOST_PRIORITY_FILE"
       # Add the specified hosts to the file

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -611,9 +611,9 @@ enable_proxysql(){
       # Create empty priority config file
 	  echo '# ProxySQL Host Priority File' > $HOST_PRIORITY_FILE
       echo '# Specify nodes in order from highest priority to lowest' >> $HOST_PRIORITY_FILE
-	  check_cmd $? "Failed to create the host priority file, verify the directory permissions: $HOST_PRIORITY_FILE"
+      check_cmd $? "Failed to create the host priority file, verify the directory permissions: $HOST_PRIORITY_FILE"
       # Add the specified hosts to the file
-	  echo -e "\nConfiguring $MODE mode with the following nodes designated as priority order:"
+      echo -e "\nConfiguring $MODE mode with the following nodes designated as priority order:"
       for i in $WRITE_NODES;do
         echo $i >> $HOST_PRIORITY_FILE
         echo " $i"

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -58,6 +58,8 @@ usage () {
   echo "  --node-check-interval=3000         Interval for monitoring node checker script (in milliseconds)"
   echo "  --mode=[loadbal|singlewrite]       ProxySQL read/write configuration mode, currently supporting: 'loadbal' and 'singlewrite' (the default) modes"
   echo "  --write-node=host_name:port        Writer node to accept write statments. This option is supported only when using --mode=singlewrite"
+  echo "                                     Can accept comma delimited list with the first listed being the highest priority"
+### Consider adding a select or prompt option for --write-node that will let you select from discovered nodes during setup ###
   echo "  --adduser                          Adds the Percona XtraDB Cluster application user to the ProxySQL database"
   echo "  --version, -v                      Print version info"
 }
@@ -208,7 +210,14 @@ do
     fi
     ;;
     --write-node )
-    WRITE_NODE="$2"
+    if [ `grep -o ',' <<< $2 | wc -l` -gt 0 ];then
+      WRITE_NODES=`echo "$2" | sed 's/,/ /g'`
+      WRITE_NODE=`echo "$WRITE_NODES" | cut -d' ' -f1`
+	  enable_priority=1
+	  echo "Enabled priority: ${WRITE_NODES}"
+    else
+      WRITE_NODE=$2
+    fi
     shift 2
     ;;
     --quick-demo )
@@ -595,6 +604,20 @@ enable_proxysql(){
       echo -e "Please configure ProxySQL manually.. Terminating!"
       exit 1
     fi
+
+    # Create the host priority file if multiple write nodes were specified
+    if [ -n $enable_priority ];then
+      # Create empty priority config file
+	  echo '# ProxySQL Host Priority File' > $HOST_PRIORITY_FILE
+      echo '# Specify nodes in order from highest priority to lowest' >> $HOST_PRIORITY_FILE
+	  check_cmd $? "Failed to create the host priority file, verify the directory permissions: $HOST_PRIORITY_FILE"
+      # Add the specified hosts to the file
+	  echo "Writers: $WRITE_NODES"
+      for i in $WRITE_NODES;do
+        echo $i >> $HOST_PRIORITY_FILE
+      done
+    fi
+	
     for i in "${wsrep_address[@]}"; do	
       ws_ip=$(echo $i | cut -d':' -f1)
       ws_port=$(echo $i | cut -d':' -f2)

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -671,7 +671,8 @@ disable_proxysql(){
   proxysql_exec "DELETE FROM mysql_query_rules WHERE destination_hostgroup in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID)"
   check_cmd $? "Failed to delete the query rules from ProxySQL. Please check username, password and other options for connecting to ProxySQL database"
   proxysql_exec "LOAD MYSQL USERS TO RUNTIME;SAVE MYSQL USERS TO DISK;LOAD SCHEDULER TO RUNTIME;SAVE SCHEDULER TO DISK;LOAD MYSQL SERVERS TO RUNTIME; SAVE MYSQL SERVERS TO DISK;LOAD MYSQL QUERY RULES TO RUNTIME;SAVE MYSQL QUERY RULES TO DISK;"
-
+  # Delete the host priority file
+  rm -f $HOST_PRIORITY_FILE
 }
 
 adduser(){

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -213,7 +213,7 @@ do
     if [ `grep -o ',' <<< $2 | wc -l` -gt 0 ];then
       WRITE_NODES=`echo "$2" | sed 's/,/ /g'`
       WRITE_NODE=`echo "$WRITE_NODES" | cut -d' ' -f1`
-	  enable_priority=1
+      enable_priority=1
     else
       WRITE_NODE="$2"
     fi
@@ -616,7 +616,7 @@ enable_proxysql(){
 	  echo -e "\nConfiguring $MODE mode with the following nodes designated as priority order:"
       for i in $WRITE_NODES;do
         echo $i >> $HOST_PRIORITY_FILE
-		echo " $i"
+        echo " $i"
       done
     fi
 	

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -215,7 +215,7 @@ do
       WRITE_NODE=`echo "$WRITE_NODES" | cut -d' ' -f1`
 	  enable_priority=1
     else
-      WRITE_NODE=$2
+      WRITE_NODE="$2"
     fi
     shift 2
     ;;

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -559,6 +559,8 @@ enable_proxysql(){
 
   # Adding Percona XtraDB Cluster nodes to ProxySQL
   echo -e "\nAdding the Percona XtraDB Cluster server nodes to ProxySQL"
+  # Delete an existing host priority file if its there
+  rm -f $HOST_PRIORITY_FILE
   if [ $MODE == "loadbal" ]; then
     proxysql_exec "DELETE FROM mysql_servers WHERE hostgroup_id=$WRITE_HOSTGROUP_ID"
     wsrep_address=(`mysql_exec "show status like 'wsrep_incoming_addresses'" | awk '{print $2}' | sed 's|,| |g'`)

--- a/proxysql-admin.cnf
+++ b/proxysql-admin.cnf
@@ -24,3 +24,6 @@ export READ_HOSTGROUP_ID="11"
 
 # ProxySQL read/write configuration mode.
 export MODE="singlewrite"
+
+# ProxySQL Cluster Node Priority File
+export HOST_PRIORITY_FILE="/var/lib/proxysql/host_priority.conf"

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -104,6 +104,10 @@ mode_change_check(){
   # YARDI ###
   # Define the file containing the server priority order
   host_priority_file="/var/lib/proxysql/host_priority"
+  if [ -f $host_priority_file ];then
+    # Get the list of hosts from the host_priority file ignoring blanks and any lines that start with '#'
+    ordered_hosts=(`cat $host_priority_file | grep ^[^#]`)
+  fi
   # Perhaps this could be created by the proxysql-admin script during setup if its desired
   #   File sample:
   #   10.11.12.21:3306
@@ -119,7 +123,7 @@ mode_change_check(){
     # YARDI ###
     #
     # If that temp file exists use it otherwise choose random as is done now
-    if [ ! -f $host_priority_file ];then
+    if [ -z $ordered_hosts ];then
       # Order file wasn't found, behave as before
       current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'  ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
     else
@@ -127,14 +131,19 @@ mode_change_check(){
       current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'" | sed 's|\t|:|g' | tr '\n' ' '`)
 
       # Find the highest priority host from the online reader hosts
-      ordered_hosts=(`cat $host_priority_file`)
       for i in "${ordered_hosts[@]}"; do
         if [[ " ${current_hosts[@]} " =~ " ${i} " ]]; then
           # This host in ordered_hosts was found in the list of current_hosts
           current_hosts=${i}
+		  found_host=1
           break
         fi
       done
+	  if [ -z $found_host ];then
+        # None of the priority hosts were found as active, picking the first on the list from what is available.
+		current_hosts=(`echo $current_hosts | cut -d' ' -f1`)
+        unset found_host
+      fi
     fi
     # END YARDI ###
 
@@ -144,7 +153,7 @@ mode_change_check(){
     check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
   else
     # YARDI ###
-    if [ ! -f $server_order_file ];then
+    if [ -z $ordered_hosts ];then
       # Order file wasn't found, behave as before 
       CHECK_STATUS=1
     else
@@ -152,32 +161,35 @@ mode_change_check(){
       # Get the list of all ONLINE nodes in ProxySQL
       current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE'" | sed 's|\t|:|g' | tr '\n' ' '`)
 
-      # Get the ordered list from the host_priority_file
-      ordered_hosts=(`cat $host_priority_file`)
-
       # Find the highest priority host from the online hosts
       for i in "${ordered_hosts[@]}"; do
         if [[ " ${current_hosts[@]} " =~ " ${i} " ]]; then
           # This host in ordered_hosts was found in the list of current_hosts
           current_hosts=${i}
+          found_host=1
           break
         fi
       done
 
-      # Check to see if the host in 'current_host' is the writer
-      current_writer=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='WRITE'" | sed 's|\t|:|g' | tr '\n' ' '`)
-      if [ "$current_hosts" != "$current_writer" ];then
-        # Switch the writer around
-        # Move the current writer host to reader hostgroup
-        ws_ip=$(echo $current_writer | cut -d':' -f1)
-        ws_port=$(echo $current_writer | cut -d':' -f2)
-        proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
-        check_cmd $? "Cannot update Percona XtraDB Cluster reader node in ProxySQL database, Please check proxysql credentials"
-        # Move the priority host to the writer hostgroup
-        ws_ip=$(echo $current_hosts | cut -d':' -f1)
-        ws_port=$(echo $current_hosts | cut -d':' -f2)
-        proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
-        check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+      # Only initiate changing hosts if a more priority host was found
+      if [ -n $found_host ];then
+        # Check to see if the host in 'current_host' is the writer
+        current_writer=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='WRITE'" | sed 's|\t|:|g' | tr '\n' ' '`)
+        if [ "$current_hosts" != "$current_writer" ];then
+          # Switch the writer around
+          # Move the current writer host to reader hostgroup
+          ws_ip=$(echo $current_writer | cut -d':' -f1)
+          ws_port=$(echo $current_writer | cut -d':' -f2)
+          proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
+          check_cmd $? "Cannot update Percona XtraDB Cluster reader node in ProxySQL database, Please check proxysql credentials"
+          # Move the priority host to the writer hostgroup
+          ws_ip=$(echo $current_hosts | cut -d':' -f1)
+          ws_port=$(echo $current_hosts | cut -d':' -f2)
+          proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
+          check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+        else
+          CHECK_STATUS=1
+        fi
       else
         CHECK_STATUS=1
       fi

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -129,13 +129,13 @@ mode_change_check(){
         if [[ " ${current_hosts[@]} " =~ " ${i} " ]]; then
           # This host in priority_hosts was found in the list of current_hosts
           current_hosts=${i}
-		  found_host=1
+          found_host=1
           break
         fi
       done
 	  if [ -z $found_host ];then
         # None of the priority hosts were found as active, picking the first on the list from what is available.
-		current_hosts=(`echo $current_hosts | cut -d' ' -f1`)
+        current_hosts=(`echo $current_hosts | cut -d' ' -f1`)
         unset found_host
       fi
     fi

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -101,29 +101,23 @@ update_cluster(){
 
 mode_change_check(){
   checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment='WRITE' and status='OFFLINE_SOFT'"`
-  # YARDI ###
-  # Define the file containing the server priority order
-  host_priority_file="/var/lib/proxysql/host_priority"
-  if [ -f $host_priority_file ];then
+
+  if [ -f $HOST_PRIORITY_FILE ];then
     # Get the list of hosts from the host_priority file ignoring blanks and any lines that start with '#'
-    ordered_hosts=(`cat $host_priority_file | grep ^[^#]`)
+    priority_hosts=(`cat $HOST_PRIORITY_FILE | grep ^[^#]`)
   fi
-  # Perhaps this could be created by the proxysql-admin script during setup if its desired
   #   File sample:
   #   10.11.12.21:3306
   #   10.21.12.21:3306
   #   10.31.12.21:3306
   #
-  # END YARDI ###
 
   if [[ -n "$checkwriter_hid" ]]; then
     proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE comment='WRITE' and status='OFFLINE_SOFT'"
     check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
 
-    # YARDI ###
-    #
     # If that temp file exists use it otherwise choose random as is done now
-    if [ -z $ordered_hosts ];then
+    if [ -z $priority_hosts ];then
       # Order file wasn't found, behave as before
       current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'  ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
     else
@@ -131,9 +125,9 @@ mode_change_check(){
       current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'" | sed 's|\t|:|g' | tr '\n' ' '`)
 
       # Find the highest priority host from the online reader hosts
-      for i in "${ordered_hosts[@]}"; do
+      for i in "${priority_hosts[@]}"; do
         if [[ " ${current_hosts[@]} " =~ " ${i} " ]]; then
-          # This host in ordered_hosts was found in the list of current_hosts
+          # This host in priority_hosts was found in the list of current_hosts
           current_hosts=${i}
 		  found_host=1
           break
@@ -145,15 +139,13 @@ mode_change_check(){
         unset found_host
       fi
     fi
-    # END YARDI ###
 
     ws_ip=$(echo $current_hosts | cut -d':' -f1)
     ws_port=$(echo $current_hosts | cut -d':' -f2)
     proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
     check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
   else
-    # YARDI ###
-    if [ -z $ordered_hosts ];then
+    if [ -z $priority_hosts ];then
       # Order file wasn't found, behave as before 
       CHECK_STATUS=1
     else
@@ -162,9 +154,9 @@ mode_change_check(){
       current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE'" | sed 's|\t|:|g' | tr '\n' ' '`)
 
       # Find the highest priority host from the online hosts
-      for i in "${ordered_hosts[@]}"; do
+      for i in "${priority_hosts[@]}"; do
         if [[ " ${current_hosts[@]} " =~ " ${i} " ]]; then
-          # This host in ordered_hosts was found in the list of current_hosts
+          # This host in priority_hosts was found in the list of current_hosts
           current_hosts=${i}
           found_host=1
           break
@@ -194,7 +186,6 @@ mode_change_check(){
         CHECK_STATUS=1
       fi
 	fi
-    # END YARDI ###
   fi
 }
 

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -101,16 +101,88 @@ update_cluster(){
 
 mode_change_check(){
   checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment='WRITE' and status='OFFLINE_SOFT'"`
+  # YARDI ###
+  # Define the file containing the server priority order
+  host_priority_file="/var/lib/proxysql/host_priority"
+  # Perhaps this could be created by the proxysql-admin script during setup if its desired
+  #   File sample:
+  #   10.11.12.21:3306
+  #   10.21.12.21:3306
+  #   10.31.12.21:3306
+  #
+  # END YARDI ###
+
   if [[ -n "$checkwriter_hid" ]]; then
     proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE comment='WRITE' and status='OFFLINE_SOFT'"
     check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
-    current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'  ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+
+    # YARDI ###
+    #
+    # If that temp file exists use it otherwise choose random as is done now
+    if [ ! -f $host_priority_file ];then
+      # Order file wasn't found, behave as before
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'  ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+    else
+      # Get the list of all ONLINE reader nodes in ProxySQL
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'" | sed 's|\t|:|g' | tr '\n' ' '`)
+
+      # Find the highest priority host from the online reader hosts
+      ordered_hosts=(`cat $host_priority_file`)
+      for i in "${ordered_hosts[@]}"; do
+        if [[ " ${current_hosts[@]} " =~ " ${i} " ]]; then
+          # This host in ordered_hosts was found in the list of current_hosts
+          current_hosts=${i}
+          break
+        fi
+      done
+    fi
+    # END YARDI ###
+
     ws_ip=$(echo $current_hosts | cut -d':' -f1)
     ws_port=$(echo $current_hosts | cut -d':' -f2)
     proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
     check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
   else
-    CHECK_STATUS=1
+    # YARDI ###
+    if [ ! -f $server_order_file ];then
+      # Order file wasn't found, behave as before 
+      CHECK_STATUS=1
+    else
+      # Check here if the highest priority node is the writer
+      # Get the list of all ONLINE nodes in ProxySQL
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE'" | sed 's|\t|:|g' | tr '\n' ' '`)
+
+      # Get the ordered list from the host_priority_file
+      ordered_hosts=(`cat $host_priority_file`)
+
+      # Find the highest priority host from the online hosts
+      for i in "${ordered_hosts[@]}"; do
+        if [[ " ${current_hosts[@]} " =~ " ${i} " ]]; then
+          # This host in ordered_hosts was found in the list of current_hosts
+          current_hosts=${i}
+          break
+        fi
+      done
+
+      # Check to see if the host in 'current_host' is the writer
+      current_writer=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='WRITE'" | sed 's|\t|:|g' | tr '\n' ' '`)
+      if [ "$current_hosts" != "$current_writer" ];then
+        # Switch the writer around
+        # Move the current writer host to reader hostgroup
+        ws_ip=$(echo $current_writer | cut -d':' -f1)
+        ws_port=$(echo $current_writer | cut -d':' -f2)
+        proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
+        check_cmd $? "Cannot update Percona XtraDB Cluster reader node in ProxySQL database, Please check proxysql credentials"
+        # Move the priority host to the writer hostgroup
+        ws_ip=$(echo $current_hosts | cut -d':' -f1)
+        ws_port=$(echo $current_hosts | cut -d':' -f2)
+        proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
+        check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+      else
+        CHECK_STATUS=1
+      fi
+	fi
+    # END YARDI ###
   fi
 }
 


### PR DESCRIPTION
On node failure the random selection of the next writer is fine when the nodes are equal and they are all local.  In one cluster I setup there is 3 nodes spread across 3 data centers thousands of miles apart.  I needed to be able to assign a priority so the local node is always the one in the writer hostgroup if its up, and if its not up I wanted to specify which node would be next in line to takeover reading/writing in that data center since the latency is lower to one data center than the other.

This is of course just one way of doing it, but figured I would throw it out there.  Piggy backing on the existing --write-node option seemed reasonable as opposed to adding a new option.