### PR TITLE
Adding --include-slaves and improving --write-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ Options:
   --node-check-interval=3000         Interval for monitoring node checker script (in milliseconds)
   --mode=[loadbal|singlewrite]       ProxySQL read/write configuration mode, currently supporting: 'loadbal' and 'singlewrite' (the default) modes
   --write-node=host_name:port        Writer node to accept write statments. This option is supported only when using --mode=singlewrite
-                                     Can accept comma delimited list with the first listed being the highest priority
-                                     If this is used make sure 'read_only=1' is in the slave's my.cnf
+                                     Can accept comma delimited list with the first listed being the highest priority, priority failover requires
+                                     two or more nodes to be specified.
   --include-slaves=host_name:port    Add specified slave node(s) to ProxySQL, these nodes will go into the reader hostgroup and will only be put into
-                                     the writer hostgroup if all cluster nodes are down.  Slaves must read only.  Can accept comma delimited list.
+                                     the writer hostgroup if all cluster nodes are down.  Slaves must be read only.  Can accept comma delimited list.
+                                     If this is used make sure 'read_only=1' is in the slave's my.cnf
   --adduser                          Adds the Percona XtraDB Cluster application user to the ProxySQL database
   --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL (deletes ProxySQL users not in MySQL)
   --version, -v                      Print version info

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Options:
   --node-check-interval=3000         Interval for monitoring node checker script (in milliseconds)
   --mode=[loadbal|singlewrite]       ProxySQL read/write configuration mode, currently supporting: 'loadbal' and 'singlewrite' (the default) modes
   --write-node=host_name:port        Writer node to accept write statments. This option is supported only when using --mode=singlewrite
+                                     Can accept comma delimited list with the first listed being the highest priority
+                                     If this is used make sure 'read_only=1' is in the slave's my.cnf
+  --include-slaves=host_name:port    Add specified slave node(s) to ProxySQL, these nodes will go into the reader hostgroup and will only be put into
+                                     the writer hostgroup if all cluster nodes are down.  Slaves must read only.  Can accept comma delimited list.
   --adduser                          Adds the Percona XtraDB Cluster application user to the ProxySQL database
   --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL (deletes ProxySQL users not in MySQL)
   --version, -v                      Print version info

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Options:
   --node-check-interval=3000         Interval for monitoring node checker script (in milliseconds)
   --mode=[loadbal|singlewrite]       ProxySQL read/write configuration mode, currently supporting: 'loadbal' and 'singlewrite' (the default) modes
   --write-node=host_name:port        Writer node to accept write statments. This option is supported only when using --mode=singlewrite
-                                     Can accept comma delimited list with the first listed being the highest priority, priority failover requires
-                                     two or more nodes to be specified.
+                                     Can accept comma delimited list with the first listed being the highest priority.
   --include-slaves=host_name:port    Add specified slave node(s) to ProxySQL, these nodes will go into the reader hostgroup and will only be put into
                                      the writer hostgroup if all cluster nodes are down.  Slaves must be read only.  Can accept comma delimited list.
                                      If this is used make sure 'read_only=1' is in the slave's my.cnf

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -58,6 +58,8 @@ usage () {
   echo "  --node-check-interval=3000         Interval for monitoring node checker script (in milliseconds)"
   echo "  --mode=[loadbal|singlewrite]       ProxySQL read/write configuration mode, currently supporting: 'loadbal' and 'singlewrite' (the default) modes"
   echo "  --write-node=host_name:port        Writer node to accept write statments. This option is supported only when using --mode=singlewrite"
+  echo "                                     Can accept comma delimited list with the first listed being the highest priority"
+### Consider adding a select or prompt option for --write-node that will let you select from discovered nodes during setup ###
   echo "  --adduser                          Adds the Percona XtraDB Cluster application user to the ProxySQL database"
   echo "  --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL (deletes ProxySQL users not in MySQL)"
   echo "  --version, -v                      Print version info"
@@ -215,7 +217,13 @@ do
     fi
     ;;
     --write-node )
-    WRITE_NODE="$2"
+    if [ `grep -o ',' <<< $2 | wc -l` -gt 0 ];then
+      WRITE_NODES=`echo "$2" | sed 's/,/ /g'`
+      WRITE_NODE=`echo "$WRITE_NODES" | cut -d' ' -f1`
+      enable_priority=1
+    else
+      WRITE_NODE="$2"
+    fi
     shift 2
     ;;
     --quick-demo )
@@ -558,6 +566,8 @@ enable_proxysql(){
 
   # Adding Percona XtraDB Cluster nodes to ProxySQL
   echo -e "\nAdding the Percona XtraDB Cluster server nodes to ProxySQL"
+  # Delete an existing host priority file if its there
+  rm -f $HOST_PRIORITY_FILE
   if [ $MODE == "loadbal" ]; then
     proxysql_exec "DELETE FROM mysql_servers WHERE hostgroup_id=$WRITE_HOSTGROUP_ID"
     wsrep_address=($(mysql_exec "show status like 'wsrep_incoming_addresses'" | awk '{print $2}' | sed 's|,| |g'))
@@ -602,6 +612,21 @@ enable_proxysql(){
       echo -e "Please configure ProxySQL manually.. Terminating!"
       exit 1
     fi
+
+    # Create the host priority file if multiple write nodes were specified
+    if [ -n $enable_priority ];then
+      # Create empty priority config file
+      echo '# ProxySQL Host Priority File' > $HOST_PRIORITY_FILE
+      echo '# Specify nodes in order from highest priority to lowest' >> $HOST_PRIORITY_FILE
+      check_cmd $? "Failed to create the host priority file, verify the directory permissions: $HOST_PRIORITY_FILE"
+      # Add the specified hosts to the file
+      echo -e "\nConfiguring $MODE mode with the following nodes designated as priority order:"
+      for i in $WRITE_NODES;do
+        echo $i >> $HOST_PRIORITY_FILE
+        echo " $i"
+      done
+    fi
+	
     for i in "${wsrep_address[@]}"; do	
       ws_ip=$(echo "$i" | cut -d':' -f1)
       ws_port=$(echo "$i" | cut -d':' -f2)
@@ -655,7 +680,8 @@ disable_proxysql(){
   proxysql_exec "DELETE FROM mysql_query_rules WHERE destination_hostgroup in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID)"
   check_cmd $? "Failed to delete the query rules from ProxySQL. Please check username, password and other options for connecting to ProxySQL database"
   proxysql_exec "LOAD MYSQL USERS TO RUNTIME;SAVE MYSQL USERS TO DISK;LOAD SCHEDULER TO RUNTIME;SAVE SCHEDULER TO DISK;LOAD MYSQL SERVERS TO RUNTIME; SAVE MYSQL SERVERS TO DISK;LOAD MYSQL QUERY RULES TO RUNTIME;SAVE MYSQL QUERY RULES TO DISK;"
-
+  # Delete the host priority file
+  rm -f $HOST_PRIORITY_FILE
 }
 
 adduser(){

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -373,16 +373,17 @@ else
   fi
 fi
 
+# Set default hostgroup values if not set in the config file
+if [ -z $WRITE_HOSTGROUP_ID ];then WRITE_HOSTGROUP_ID=10;fi
+if [ -z $WRITE_HOSTGROUP_ID ];then READ_HOSTGROUP_ID=11;fi
+
 if [ $MODE == "loadbal" ]; then
   SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
-#  WRITE_HOSTGROUP_ID=10
   READ_HOSTGROUP_ID=$WRITE_HOSTGROUP_ID
   if [ -e "${CONFIG_FILE}" ]; then
     sudo sed -i "0,/^[ \t]*export MODE[ \t]*=.*$/s|^[ \t]*export MODE[ \t]*=.*$|export MODE=\"loadbal\"|" "${CONFIG_FILE}"
   fi
 elif [ $MODE == "singlewrite" ]; then
-#  WRITE_HOSTGROUP_ID=10
-#  READ_HOSTGROUP_ID=11
   SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
   if [ -e "${CONFIG_FILE}" ]; then
     sudo sed -i "0,/^[ \t]*export MODE[ \t]*=.*$/s|^[ \t]*export MODE[ \t]*=.*$|export MODE=\"singlewrite\"|" "${CONFIG_FILE}"

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -59,7 +59,10 @@ usage () {
   echo "  --mode=[loadbal|singlewrite]       ProxySQL read/write configuration mode, currently supporting: 'loadbal' and 'singlewrite' (the default) modes"
   echo "  --write-node=host_name:port        Writer node to accept write statments. This option is supported only when using --mode=singlewrite"
   echo "                                     Can accept comma delimited list with the first listed being the highest priority"
+  echo "                                     If this is used make sure 'read_only=1' is in the slave's my.cnf"
 ### Consider adding a select or prompt option for --write-node that will let you select from discovered nodes during setup ###
+  echo "  --include-slaves=host_name:port    Add specified slave node(s) to ProxySQL, these nodes will go into the reader hostgroup and will only be put into"
+  echo "                                     the writer hostgroup if all cluster nodes are down.  Slaves must read only.  Can accept comma delimited list."
   echo "  --adduser                          Adds the Percona XtraDB Cluster application user to the ProxySQL database"
   echo "  --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL (deletes ProxySQL users not in MySQL)"
   echo "  --version, -v                      Print version info"
@@ -68,7 +71,7 @@ usage () {
 # Check if we have a functional getopt(1)
 if ! getopt --test
   then
-  go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,enable,disable,adduser,syncusers,version,help \
+  go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,include-slaves:,enable,disable,adduser,syncusers,version,help \
   --name="$(basename "$0")" -- "$@")"
   test $? -eq 0 || exit 1
   eval set -- "$go_out"
@@ -226,6 +229,11 @@ do
     fi
     shift 2
     ;;
+    --include-slaves )
+      SLAVE_NODES=`echo "$2" | sed 's/,/ /g'`
+#     enable_slaves=1
+    shift 2
+    ;;
     --quick-demo )
     shift
     QUICK_DEMO="YES"
@@ -367,14 +375,16 @@ else
 fi
 
 if [ $MODE == "loadbal" ]; then
-  WRITE_HOSTGROUP_ID=10
-  READ_HOSTGROUP_ID=10
+  SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
+#  WRITE_HOSTGROUP_ID=10
+  READ_HOSTGROUP_ID=$WRITE_HOSTGROUP_ID
   if [ -e "${CONFIG_FILE}" ]; then
     sudo sed -i "0,/^[ \t]*export MODE[ \t]*=.*$/s|^[ \t]*export MODE[ \t]*=.*$|export MODE=\"loadbal\"|" "${CONFIG_FILE}"
   fi
 elif [ $MODE == "singlewrite" ]; then
-  WRITE_HOSTGROUP_ID=10
-  READ_HOSTGROUP_ID=11
+#  WRITE_HOSTGROUP_ID=10
+#  READ_HOSTGROUP_ID=11
+  SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
   if [ -e "${CONFIG_FILE}" ]; then
     sudo sed -i "0,/^[ \t]*export MODE[ \t]*=.*$/s|^[ \t]*export MODE[ \t]*=.*$|export MODE=\"singlewrite\"|" "${CONFIG_FILE}"
   fi
@@ -392,6 +402,12 @@ proxysql_exec() {
 mysql_exec() {
   query=$1
   printf "[client]\nuser=${CLUSTER_USERNAME}\npassword=${CLUSTER_PASSWORD}\nhost=${CLUSTER_HOSTNAME}\nport=${CLUSTER_PORT}\n" | \
+      mysql --defaults-file=/dev/stdin --protocol=tcp -Bse "${query}" 2>/dev/null
+}
+
+slave_exec() {
+  query=$1
+  printf "[client]\nuser=${CLUSTER_USERNAME}\npassword=${CLUSTER_PASSWORD}\nhost=${SLAVE_HOSTNAME}\nport=${SLAVE_PORT}\n" | \
       mysql --defaults-file=/dev/stdin --protocol=tcp -Bse "${query}" 2>/dev/null
 }
 
@@ -564,13 +580,47 @@ enable_proxysql(){
   echo -e "\nConfiguring the Percona XtraDB Cluster application user to connect through ProxySQL"
   user_input_check CLUSTER_APP "Percona XtraDB Cluster application user" $WRITE_HOSTGROUP_ID
 
+  # Get the nodes in the cluster
+  wsrep_address=($(mysql_exec "show status like 'wsrep_incoming_addresses'" | awk '{print $2}' | sed 's|,| |g'))
+
+  # If any slave nodes were specified, verify they are replicating from a valid cluster node
+  if [ -n "$SLAVE_NODES" ];then
+    echo -e "\nVerifying specified slave nodes"
+    for i in $SLAVE_NODES;do
+      SLAVE_HOSTNAME=`echo $i | cut -d: -f1`
+      SLAVE_PORT=`echo $i | cut -d: -f2`
+      # Verify we can connect to the slave
+      slave_exec 'show slave status\G' > /dev/null
+      check_cmd $? "Failed to connect to $i, please check username, password and other options for connecting to the slave"
+      # Check each of the specified slaves and verify they are a slave of one of the XtraDB cluster nodes
+      slave_master=$(slave_exec 'show slave status\G'| egrep "Master_Host|Master_Port" | sed 's/ //g' | cut -d: -f2 | tr '\n' ':' | sed 's/:$//g')
+      if [[ ${wsrep_address[*]} != *"$slave_master"* ]]; then
+        echo -e "\nERROR: The slave node's master ($slave_master) does not exist in WSREP incoming address(${wsrep_address[*]})."
+        echo -e "The specified slave is not replicating from any of the XDtraDB cluster nodes, this is not supported"
+        echo -e "Please configure ProxySQL manually.. Terminating!"
+        exit 1
+      fi
+      # Verify the slave read-only variable is set to '1'
+      slave_ro=$(slave_exec 'SELECT @@read_only')
+      if [ "$slave_ro" != "1" ];then
+        echo -e "\nERROR: The slave $i is not set to read only.  Add 'read_only=1' to the my.cnf on the slave"
+        echo -e "and restart MySQL.  Execute 'SET GLOBAL read_only = 1' on the slave to avoid the restart"
+        echo -e "Correct this on slave nodes and run proxysql-admin again. Terminating!"
+        exit 1
+      fi
+    done
+    # GRANT REPLICATION CLIENT permissions to the monitoring user account
+    echo -e "\nGranting 'REPLICATION CLIENT' privilege to $MONITOR_USERNAME@$USER_HOST_RANGE"
+    mysql_exec "GRANT REPLICATION CLIENT ON *.* TO $MONITOR_USERNAME@'$USER_HOST_RANGE';"
+    check_cmd $? "$CLUSTER_USERNAME@'$CLUSTER_HOSTNAME' does not have the GRANT privilege required to assign the requested permissions"
+  fi
+
   # Adding Percona XtraDB Cluster nodes to ProxySQL
   echo -e "\nAdding the Percona XtraDB Cluster server nodes to ProxySQL"
   # Delete an existing host priority file if its there
   rm -f $HOST_PRIORITY_FILE
   if [ $MODE == "loadbal" ]; then
     proxysql_exec "DELETE FROM mysql_servers WHERE hostgroup_id=$WRITE_HOSTGROUP_ID"
-    wsrep_address=($(mysql_exec "show status like 'wsrep_incoming_addresses'" | awk '{print $2}' | sed 's|,| |g'))
     for i in "${wsrep_address[@]}"; do	
       ws_ip=$(echo "$i" | cut -d':' -f1)
       ws_port=$(echo "$i" | cut -d':' -f2)
@@ -605,7 +655,6 @@ enable_proxysql(){
       writer_ws_port=$CLUSTER_PORT
     fi
     proxysql_exec "DELETE FROM mysql_servers WHERE hostgroup_id=$WRITE_HOSTGROUP_ID"
-    wsrep_address=($(mysql_exec "show status like 'wsrep_incoming_addresses'" | awk '{print $2}' | sed 's|,| |g'))
     if [[ ${wsrep_address[*]} != *"$writer_ws_ip:$writer_ws_port"* ]]; then
       echo -e "\nERROR: Writer node cluster address($writer_ws_ip:$writer_ws_port) does not exist in WSREP incoming address(${wsrep_address[*]})."
       echo -e "Different wsrep incoming and cluster IP addresses are not supported by proxysql-admin at this time"
@@ -626,7 +675,7 @@ enable_proxysql(){
         echo " $i"
       done
     fi
-	
+
     for i in "${wsrep_address[@]}"; do	
       ws_ip=$(echo "$i" | cut -d':' -f1)
       ws_port=$(echo "$i" | cut -d':' -f2)
@@ -643,6 +692,18 @@ enable_proxysql(){
     proxysql_exec "INSERT INTO mysql_query_rules (username,destination_hostgroup,active,match_digest,apply) values('$CLUSTER_APP_USERNAME',$WRITE_HOSTGROUP_ID,1,'^SELECT.*FOR UPDATE',1),('$CLUSTER_APP_USERNAME',$READ_HOSTGROUP_ID,1,'^SELECT ',1);"
     check_cmd $? "Failed to add the read query rule. Please check username, password and other options for connecting to ProxySQL database"
     proxysql_exec "LOAD MYSQL SERVERS TO RUNTIME; SAVE MYSQL SERVERS TO DISK;LOAD MYSQL QUERY RULES TO RUNTIME;SAVE MYSQL QUERY RULES TO DISK;"
+  fi
+
+  # Adding slave nodes here if specified
+  if [ -n "$SLAVE_NODES" ];then
+    echo -e "\nAdding the following slave server nodes to ProxySQL:"
+    for i in $SLAVE_NODES;do
+      ws_ip=$(echo "$i" | cut -d':' -f1)
+      ws_port=$(echo "$i" | cut -d':' -f2)
+      proxysql_exec "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$SLAVEREAD_HOSTGROUP_ID,$ws_port,1000,'SLAVEREAD');"
+      check_cmd $? "Failed to add the slave node $ws_ip:$ws_port. Please check username, password and other options for connecting to ProxySQL database"
+      echo " $i"
+    done
   fi
 
   # Adding Percona XtraDB Cluster monitoring scripts

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -58,11 +58,12 @@ usage () {
   echo "  --node-check-interval=3000         Interval for monitoring node checker script (in milliseconds)"
   echo "  --mode=[loadbal|singlewrite]       ProxySQL read/write configuration mode, currently supporting: 'loadbal' and 'singlewrite' (the default) modes"
   echo "  --write-node=host_name:port        Writer node to accept write statments. This option is supported only when using --mode=singlewrite"
-  echo "                                     Can accept comma delimited list with the first listed being the highest priority"
-  echo "                                     If this is used make sure 'read_only=1' is in the slave's my.cnf"
+  echo "                                     Can accept comma delimited list with the first listed being the highest priority, priority failover requires"
+  echo "                                     two or more nodes to be specified.
 ### Consider adding a select or prompt option for --write-node that will let you select from discovered nodes during setup ###
   echo "  --include-slaves=host_name:port    Add specified slave node(s) to ProxySQL, these nodes will go into the reader hostgroup and will only be put into"
-  echo "                                     the writer hostgroup if all cluster nodes are down.  Slaves must read only.  Can accept comma delimited list."
+  echo "                                     the writer hostgroup if all cluster nodes are down.  Slaves must be read only.  Can accept comma delimited list."
+  echo "                                     If this is used make sure 'read_only=1' is in the slave's my.cnf"
   echo "  --adduser                          Adds the Percona XtraDB Cluster application user to the ProxySQL database"
   echo "  --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL (deletes ProxySQL users not in MySQL)"
   echo "  --version, -v                      Print version info"

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -231,7 +231,6 @@ do
     ;;
     --include-slaves )
       SLAVE_NODES=`echo "$2" | sed 's/,/ /g'`
-#     enable_slaves=1
     shift 2
     ;;
     --quick-demo )

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -702,6 +702,7 @@ enable_proxysql(){
       ws_port=$(echo "$i" | cut -d':' -f2)
       proxysql_exec "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$SLAVEREAD_HOSTGROUP_ID,$ws_port,1000,'SLAVEREAD');"
       check_cmd $? "Failed to add the slave node $ws_ip:$ws_port. Please check username, password and other options for connecting to ProxySQL database"
+      proxysql_exec "LOAD MYSQL SERVERS TO RUNTIME; SAVE MYSQL SERVERS TO DISK;"
       echo " $i"
     done
   fi

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -58,8 +58,7 @@ usage () {
   echo "  --node-check-interval=3000         Interval for monitoring node checker script (in milliseconds)"
   echo "  --mode=[loadbal|singlewrite]       ProxySQL read/write configuration mode, currently supporting: 'loadbal' and 'singlewrite' (the default) modes"
   echo "  --write-node=host_name:port        Writer node to accept write statments. This option is supported only when using --mode=singlewrite"
-  echo "                                     Can accept comma delimited list with the first listed being the highest priority, priority failover requires"
-  echo "                                     two or more nodes to be specified."
+  echo "                                     Can accept comma delimited list with the first listed being the highest priority."
 ### Consider adding a select or prompt option for --write-node that will let you select from discovered nodes during setup ###
   echo "  --include-slaves=host_name:port    Add specified slave node(s) to ProxySQL, these nodes will go into the reader hostgroup and will only be put into"
   echo "                                     the writer hostgroup if all cluster nodes are down.  Slaves must be read only.  Can accept comma delimited list."

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -375,7 +375,7 @@ fi
 
 # Set default hostgroup values if not set in the config file
 if [ -z $WRITE_HOSTGROUP_ID ];then WRITE_HOSTGROUP_ID=10;fi
-if [ -z $WRITE_HOSTGROUP_ID ];then READ_HOSTGROUP_ID=11;fi
+if [ -z $READ_HOSTGROUP_ID ];then READ_HOSTGROUP_ID=11;fi
 
 if [ $MODE == "loadbal" ]; then
   SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -59,7 +59,7 @@ usage () {
   echo "  --mode=[loadbal|singlewrite]       ProxySQL read/write configuration mode, currently supporting: 'loadbal' and 'singlewrite' (the default) modes"
   echo "  --write-node=host_name:port        Writer node to accept write statments. This option is supported only when using --mode=singlewrite"
   echo "                                     Can accept comma delimited list with the first listed being the highest priority, priority failover requires"
-  echo "                                     two or more nodes to be specified.
+  echo "                                     two or more nodes to be specified."
 ### Consider adding a select or prompt option for --write-node that will let you select from discovered nodes during setup ###
   echo "  --include-slaves=host_name:port    Add specified slave node(s) to ProxySQL, these nodes will go into the reader hostgroup and will only be put into"
   echo "                                     the writer hostgroup if all cluster nodes are down.  Slaves must be read only.  Can accept comma delimited list."
@@ -221,13 +221,13 @@ do
     fi
     ;;
     --write-node )
-    if [ `grep -o ',' <<< $2 | wc -l` -gt 0 ];then
+#    if [ `grep -o ',' <<< $2 | wc -l` -gt 0 ];then
       WRITE_NODES=`echo "$2" | sed 's/,/ /g'`
       WRITE_NODE=`echo "$WRITE_NODES" | cut -d' ' -f1`
       enable_priority=1
-    else
-      WRITE_NODE="$2"
-    fi
+#    else
+#      WRITE_NODE="$2"
+#    fi
     shift 2
     ;;
     --include-slaves )

--- a/proxysql-admin.cnf
+++ b/proxysql-admin.cnf
@@ -24,3 +24,6 @@ export READ_HOSTGROUP_ID="11"
 
 # ProxySQL read/write configuration mode.
 export MODE="singlewrite"
+
+# ProxySQL Cluster Node Priority File
+export HOST_PRIORITY_FILE="/var/lib/proxysql/host_priority.conf"

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -150,7 +150,7 @@ function change_server_status() {
 
 echo "`date` ###### HANDLE WRITER NODES ######" >> ${ERR_FILE}
 NUMBER_WRITERS_ONLINE=0
-proxysql_exec "SELECT hostgroup_id, hostname, port, status FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_WRITER_ID) AND status <> 'OFFLINE_HARD' ORDER BY hostgroup_id, weight DESC, hostname, port" | while read hostgroup server port stat
+proxysql_exec "SELECT hostgroup_id, hostname, port, status FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_WRITER_ID) AND status <> 'OFFLINE_HARD' AND comment <> 'SLAVEREAD' ORDER BY hostgroup_id, weight DESC, hostname, port" | while read hostgroup server port stat
 do
   WSREP_STATUS=$(mysql_exec "SHOW STATUS LIKE 'wsrep_local_state'" 2>>${ERR_FILE}| tail -1 2>>${ERR_FILE})
   PXC_MAIN_MODE=$(mysql_exec "SHOW VARIABLES LIKE 'pxc_maint_mode'" 2>>${ERR_FILE} | tail -1 2>>${ERR_FILE})
@@ -246,7 +246,7 @@ do
 done
 
 # NUMBER_WRITERS_ONLINE is lost after loop
-NUMBER_WRITERS_ONLINE=$(proxysql_exec "SELECT count(*) FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_WRITER_ID) AND status = 'ONLINE'" 2>>${ERR_FILE}| tail -1 2>>${ERR_FILE})
+NUMBER_WRITERS_ONLINE=$(proxysql_exec "SELECT count(*) FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_WRITER_ID) AND status = 'ONLINE' AND comment <> 'SLAVEREAD'" 2>>${ERR_FILE}| tail -1 2>>${ERR_FILE})
 
 
 NUMBER_READERS_ONLINE=0
@@ -254,7 +254,7 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
 
   echo "`date` ###### HANDLE READER NODES ######" >> ${ERR_FILE}
   if [ $WRITER_IS_READER -eq 1 ]; then
-    READER_PROXYSQL_QUERY="SELECT hostgroup_id, hostname, port, status, 'NULL' FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_READER_ID) AND status <> 'OFFLINE_HARD' ORDER BY weight DESC, hostname, port"
+    READER_PROXYSQL_QUERY="SELECT hostgroup_id, hostname, port, status, 'NULL' FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_READER_ID) AND status <> 'OFFLINE_HARD' AND comment <> 'SLAVEREAD' ORDER BY weight DESC, hostname, port"
   elif [ $WRITER_IS_READER -eq 0 ]; then
     # We will not try to change reader state of nodes that are writer ONLINE, so what we do is we ORDER BY writer.status ASC because by accident ONLINE is last in the line
     READER_PROXYSQL_QUERY="SELECT reader.hostgroup_id,
@@ -269,6 +269,7 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
     AND writer.port = reader.port
   WHERE reader.hostgroup_id = $HOSTGROUP_READER_ID
     AND reader.status <> 'OFFLINE_HARD'
+	AND reader.comment <> 'SLAVEREAD'
   ORDER BY writer.status ASC,
            reader.weight DESC,
            reader.hostname,
@@ -374,7 +375,7 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
     fi
   done
 
-  NUMBER_READERS_ONLINE=$(proxysql_exec "SELECT count(*) FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_READER_ID) AND status = 'ONLINE'" 2>>${ERR_FILE}| tail -1 2>>${ERR_FILE})
+  NUMBER_READERS_ONLINE=$(proxysql_exec "SELECT count(*) FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_READER_ID) AND status = 'ONLINE' AND comment <> 'SLAVEREAD'" 2>>${ERR_FILE}| tail -1 2>>${ERR_FILE})
 fi
 
 echo "`date` ###### SUMMARY ######" >> ${ERR_FILE}
@@ -388,7 +389,7 @@ cnt=0
 if [ ${NUMBER_WRITERS_ONLINE} -eq 0 ]; then
   echo "`date` ###### TRYING TO FIX MISSING WRITERS ######"
   echo "`date` No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)" >> ${ERR_FILE}
-  proxysql_exec "SELECT hostgroup_id, hostname, port, status FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_WRITER_ID) AND status <> 'OFFLINE_HARD'" | while read hostgroup server port stat
+  proxysql_exec "SELECT hostgroup_id, hostname, port, status FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_WRITER_ID) AND status <> 'OFFLINE_HARD' AND comment <> 'SLAVEREAD'" | while read hostgroup server port stat
   do
     safety_cnt=0
       while [ ${cnt} -le $NUMBER_WRITERS -a ${safety_cnt} -lt 5 ]
@@ -411,7 +412,7 @@ cnt=0
 if [  ${HOSTGROUP_READER_ID} -ne -1 -a ${NUMBER_READERS_ONLINE} -eq 0 ]; then
   echo "`date` ###### TRYING TO FIX MISSING READERS ######"
   echo "`date` --> No readers found, Trying to enable last available node of the cluster (in Donor/Desync state) or pick the master" >> ${ERR_FILE}
-  proxysql_exec "SELECT hostgroup_id, hostname, port, status FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_WRITER_ID) AND status <> 'OFFLINE_HARD'" | while read hostgroup server port stat
+  proxysql_exec "SELECT hostgroup_id, hostname, port, status FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_WRITER_ID) AND status <> 'OFFLINE_HARD' AND comment <> 'SLAVEREAD'" | while read hostgroup server port stat
   do
     safety_cnt=0
       while [ ${cnt} -eq 0 -a ${safety_cnt} -lt 5 ]

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -11,16 +11,19 @@ else
   exit 1
 fi
 
-SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
 WRITE_HOSTGROUP_ID="${1:-0}"
 READ_HOSTGROUP_ID="${2:-0}"
+SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
+if [ $SLAVEREAD_HOSTGROUP_ID -eq $WRITE_HOSTGROUP_ID ];then
+  let SLAVEREAD_HOSTGROUP_ID+=1
+fi
 ERR_FILE="${3:-/dev/null}"
 CHECK_STATUS=0
 SLAVE_SECONDS_BEHIND=3600 #How far behind can a slave be before its put into OFFLINE_SOFT state
 
-if [ $debug -eq 1 ];then echo "`date` DEBUG RW_MODE: $RW_MODE" >> $ERR_FILE;fi
+if [ $debug -eq 1 ];then echo "`date` DEBUG MODE: $MODE" >> $ERR_FILE;fi
 
-if [ "$RW_MODE" == "loadbal" ]; then
+if [ "$MODE" == "loadbal" ]; then
   MODE_COMMENT="READWRITE"
   WRITE_WEIGHT="1000"
 else
@@ -221,8 +224,8 @@ mode_change_check(){
   # Check if the current writer is in an OFFLINE_SOFT state
   checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment in ('WRITE', 'READWRITE') and status='OFFLINE_SOFT'"`
   if [[ -n "$checkwriter_hid" ]]; then
-    # Found a writer node that was in 'OFFLINE_SOFT' state, move it to the READ hostgroup unless the RW_MODE is 'loadbal'
-    if [ "$RW_MODE" != "loadbal" ];then
+    # Found a writer node that was in 'OFFLINE_SOFT' state, move it to the READ hostgroup unless the MODE is 'loadbal'
+    if [ "$MODE" != "loadbal" ];then
       if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check: Found OFFLINE_SOFT writer, changing to READ status and hostgroup $READ_HOSTGROUP_ID" >> $ERR_FILE;fi
       proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE comment='WRITE' and status='OFFLINE_SOFT'"
       check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
@@ -277,8 +280,8 @@ mode_change_check(){
       proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
       check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
       echo "`date` $ws_ip:$ws_port (slave) is ONLINE, switching to write hostgroup" >> $ERR_FILE
-    elif [ "$RW_MODE" != "loadbal" ] && [ -n "$current_hosts" ];then
-      # Only do this if the RW_MODE is not 'loadbal'
+    elif [ "$MODE" != "loadbal" ] && [ -n "$current_hosts" ];then
+      # Only do this if the MODE is not 'loadbal'
       if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check1: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
       proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
       check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
@@ -306,8 +309,8 @@ mode_change_check(){
 
     if [ -z $priority_hosts ];then
       # Order file wasn't found
-      # Do not change the config of a cluster node if the RW_MODE is 'loadbal'
-      if [ -n "$available_cluster_hosts" ] && [ -n "$writer_was_slave" ] && [ "$RW_MODE" != "loadbal" ];then
+      # Do not change the config of a cluster node if the MODE is 'loadbal'
+      if [ -n "$available_cluster_hosts" ] && [ -n "$writer_was_slave" ] && [ "$MODE" != "loadbal" ];then
         # There is a regular cluster node available, put it back in the writer hostgroup
         ws_ip=$(echo $available_cluster_hosts | cut -d':' -f1)
         ws_port=$(echo $available_cluster_hosts | cut -d':' -f2)

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -101,16 +101,91 @@ update_cluster(){
 
 mode_change_check(){
   checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment='WRITE' and status='OFFLINE_SOFT'"`
+
+  if [ -f $HOST_PRIORITY_FILE ];then
+    # Get the list of hosts from the host_priority file ignoring blanks and any lines that start with '#'
+    priority_hosts=(`cat $HOST_PRIORITY_FILE | grep ^[^#]`)
+  fi
+  #   File sample:
+  #   10.11.12.21:3306
+  #   10.21.12.21:3306
+  #   10.31.12.21:3306
+  #
+
   if [[ -n "$checkwriter_hid" ]]; then
     proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE comment='WRITE' and status='OFFLINE_SOFT'"
     check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
-    current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'  ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+
+    # If that temp file exists use it otherwise choose random as is done now
+    if [ -z $priority_hosts ];then
+      # Order file wasn't found, behave as before
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'  ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+    else
+      # Get the list of all ONLINE reader nodes in ProxySQL
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'" | sed 's|\t|:|g' | tr '\n' ' '`)
+
+      # Find the highest priority host from the online reader hosts
+      for i in "${priority_hosts[@]}"; do
+        if [[ " ${current_hosts[@]} " =~ " ${i} " ]]; then
+          # This host in priority_hosts was found in the list of current_hosts
+          current_hosts=${i}
+          found_host=1
+          break
+        fi
+      done
+	  if [ -z $found_host ];then
+        # None of the priority hosts were found as active, picking the first on the list from what is available.
+        current_hosts=(`echo $current_hosts | cut -d' ' -f1`)
+        unset found_host
+      fi
+    fi
+
     ws_ip=$(echo $current_hosts | cut -d':' -f1)
     ws_port=$(echo $current_hosts | cut -d':' -f2)
     proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
     check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
   else
-    CHECK_STATUS=1
+    if [ -z $priority_hosts ];then
+      # Order file wasn't found, behave as before 
+      CHECK_STATUS=1
+    else
+      # Check here if the highest priority node is the writer
+      # Get the list of all ONLINE nodes in ProxySQL
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE'" | sed 's|\t|:|g' | tr '\n' ' '`)
+
+      # Find the highest priority host from the online hosts
+      for i in "${priority_hosts[@]}"; do
+        if [[ " ${current_hosts[@]} " =~ " ${i} " ]]; then
+          # This host in priority_hosts was found in the list of current_hosts
+          current_hosts=${i}
+          found_host=1
+          break
+        fi
+      done
+
+      # Only initiate changing hosts if a more priority host was found
+      if [ -n $found_host ];then
+        # Check to see if the host in 'current_host' is the writer
+        current_writer=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='WRITE'" | sed 's|\t|:|g' | tr '\n' ' '`)
+        if [ "$current_hosts" != "$current_writer" ];then
+          # Switch the writer around
+          # Move the current writer host to reader hostgroup
+          ws_ip=$(echo $current_writer | cut -d':' -f1)
+          ws_port=$(echo $current_writer | cut -d':' -f2)
+          proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
+          check_cmd $? "Cannot update Percona XtraDB Cluster reader node in ProxySQL database, Please check proxysql credentials"
+          # Move the priority host to the writer hostgroup
+          ws_ip=$(echo $current_hosts | cut -d':' -f1)
+          ws_port=$(echo $current_hosts | cut -d':' -f2)
+          proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
+          check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+        else
+          CHECK_STATUS=1
+        fi
+      else
+        CHECK_STATUS=1
+      fi
+	fi
   fi
 }
 

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -2,6 +2,8 @@
 # This script will assist to setup Percona XtraDB cluster ProxySQL monitoring script.
 #####################################################################################
 
+debug=0
+
 if [ -f /etc/proxysql-admin.cnf ]; then
   source /etc/proxysql-admin.cnf
 else
@@ -9,14 +11,21 @@ else
   exit 1
 fi
 
+SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
 WRITE_HOSTGROUP_ID="${1:-0}"
 READ_HOSTGROUP_ID="${2:-0}"
 ERR_FILE="${3:-/dev/null}"
 CHECK_STATUS=0
+SLAVE_SECONDS_BEHIND=3600 #How far behind can a slave be before its put into OFFLINE_SOFT state
+
+if [ $debug -eq 1 ];then echo "`date` DEBUG RW_MODE: $RW_MODE" >> $ERR_FILE;fi
+
 if [ "$RW_MODE" == "loadbal" ]; then
   MODE_COMMENT="READWRITE"
+  WRITE_WEIGHT="1000"
 else
   MODE_COMMENT="READ"
+  WRITE_WEIGHT="1000000"
 fi
 
 check_cmd(){
@@ -39,17 +48,101 @@ mysql_exec() {
       mysql --defaults-file=/dev/stdin --protocol=tcp -Bse "${query}" 2>/dev/null
 }
 
+set_slave_status() {
+  # This function checks the status of slave machines and sets their status field
+  # The ws_ip and ws_port variables are used and must be set before calling this function
+  if [ $debug -eq 1 ];then echo "`date` DEBUG START set_slave_status" >> $ERR_FILE;fi
+  # This function will get and return a status of a slave node, 4=GOOD, 2=BEHIND, 0=OTHER
+  SLAVE_STATUS=$(printf "[client]\nuser=${CLUSTER_USERNAME}\npassword=${CLUSTER_PASSWORD}\nhost=${ws_ip}\nport=${ws_port}\n" | mysql --defaults-file=/dev/stdin --protocol=tcp -Bse 'SHOW SLAVE STATUS\G' 2>/dev/null | sed 's/ //g')
+  check_cmd $? "Cannot get staus from the slave $ws_ip:$ws_port, Please check cluster login credentials"
+  echo "$SLAVE_STATUS" | grep "^Master_Host:" >/dev/null
+  if [ $? -ne 0 ];then
+    # No status was found, this is not replicating
+    if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: No slave status found, setting to OFFLINE_HARD, status was: $ws_status" >> $ERR_FILE;fi
+    # Only changing the status here as another node might be in the writer hostgroup
+    proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_HARD', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
+    check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+    echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_HARD status to ProxySQL database." >> $ERR_FILE
+  else
+    slave_master_host=$(echo "$SLAVE_STATUS" | grep "^Master_Host:" | cut -d: -f2)
+    slave_io_running=$(echo "$SLAVE_STATUS" | grep "^Slave_IO_Running:" | cut -d: -f2)
+    slave_sql_running=$(echo "$SLAVE_STATUS" | grep "^Slave_SQL_Running:" | cut -d: -f2)
+    seconds_behind=$(echo "$SLAVE_STATUS" | grep "^Seconds_Behind_Master:" | cut -d: -f2)
+    if [ "$seconds_behind" == "NULL" ];then
+      # When slave_io is not working, the seconds behind value will read 'NULL', convert this to a number higher than the max
+      let seconds_behind=SLAVE_SECONDS_BEHIND+1
+    fi
+    if [ "$slave_io_running" != "Yes" ] && [ "$slave_sql_running" == "Yes" ];then
+      # Cannot connect to the master
+      if [ "$ws_status" == "ONLINE" ];then
+        echo "`date` Slave node (${ws_hg_id}:${i}) This slave cannot connect to it's master: $slave_master_host" >> $ERR_FILE
+        if [ -z "$CLUSTER_OFFLINE" ];then
+          # The cluster is up so this slave should go to OFFLINE_SOFT state
+          proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, status = 'OFFLINE_SOFT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
+          check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+          echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_SOFT status to ProxySQL database." >> $ERR_FILE
+        fi
+      else
+        if [ -n "$CLUSTER_OFFLINE" ];then
+          # The slave is not currently online and cannot connect to its master, but we are here because all cluster nodes are down so put the slave ONLINE
+          if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Forcing slave $ws_ip:$ws_port ONLINE because cluster is offline" >> $ERR_FILE;fi
+          proxysql_exec "UPDATE mysql_servers set status = 'ONLINE', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
+          check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+          echo "`date` ${SLAVEREAD_HOSTGROUP_ID}:$ws_ip:$ws_port Slave node set to ONLINE status to ProxySQL database." >> $ERR_FILE
+        fi
+      fi
+    elif [ "$slave_sql_running" != "Yes" ];then
+      # Slave is not replicating
+      if [ "$ws_status" != "OFFLINE_HARD" ];then
+        if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Setting to OFFLINE_HARD, status was: $ws_status" >> $ERR_FILE;fi
+        proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, status = 'OFFLINE_HARD', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
+        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+        echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_HARD status to ProxySQL database." >> $ERR_FILE
+      else
+        echo "`date` Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE
+      fi
+    elif [ $seconds_behind -gt $SLAVE_SECONDS_BEHIND ];then
+      # Slave is more than the set number of seconds behind, return status 2
+      if [ "$ws_status" != "OFFLINE_SOFT" ];then
+        if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Setting to OFFLINE_SOFT, status was: $ws_status" >> $ERR_FILE;fi
+        proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, status = 'OFFLINE_SOFT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
+        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+        echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_SOFT status to ProxySQL database." >> $ERR_FILE
+      else
+        echo "`date` Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE
+      fi
+    else
+      if [ "$ws_status" != "ONLINE" ];then
+        if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Setting to ONLINE, status was: $ws_status" >> $ERR_FILE;fi
+        proxysql_exec "UPDATE mysql_servers set status = 'ONLINE', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
+        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+        echo "`date` ${ws_hg_id}:${i} Slave node set to ONLINE status to ProxySQL database." >> $ERR_FILE
+      else
+        echo "`date` Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE
+      fi
+    fi
+  fi
+  if [ $debug -eq 1 ];then echo "`date` DEBUG END set_slave_status" >> $ERR_FILE;fi
+}
+
 # Update Percona XtraDB Cluster nodes in ProxySQL database
 update_cluster(){
-  current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers where hostgroup_id in ( $WRITE_HOSTGROUP_ID, $READ_HOSTGROUP_ID )" | sed 's|\t|:|g' | tr '\n' ' '`)
+  if [ $debug -eq 1 ];then echo "`date` DEBUG START update_cluster" >> $ERR_FILE;fi
+  current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers where hostgroup_id in ( $WRITE_HOSTGROUP_ID, $READ_HOSTGROUP_ID, $SLAVEREAD_HOSTGROUP_ID )" | sed 's|\t|:|g' | tr '\n' ' '`)
   wsrep_address=(`mysql_exec "SHOW STATUS LIKE 'wsrep_incoming_addresses'" | awk '{print $2}' | sed 's|,| |g'`)
+
   if [ ${#wsrep_address[@]} -eq 0 ]; then
-    echo "`date` Alert! wsrep_incoming_addresses is empty. Terminating!" >> $ERR_FILE
-    exit 1
+    # Cluster might be down, but is there a slave to fall back to?
+    slave_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers where hostgroup_id in ( $WRITE_HOSTGROUP_ID, $SLAVEREAD_HOSTGROUP_ID ) and comment = 'SLAVEREAD'" | sed 's|\t|:|g' | tr '\n' ' '`)
+    if [ ${#slave_hosts[@]} -eq 0 ]; then
+      echo "`date` Alert! wsrep_incoming_addresses is empty. Terminating!" >> $ERR_FILE
+      exit 1
+    fi
   fi
 
   for i in "${wsrep_address[@]}"; do
     if [[ ! " ${current_hosts[@]} " =~ " ${i} " ]]; then
+      if [ $debug -eq 1 ];then echo "`date` DEBUG Host $i in cluster membership was not found in ProxySQL, adding it" >> $ERR_FILE;fi
       ws_ip=$(echo $i | cut -d':' -f1)
       ws_port=$(echo $i | cut -d':' -f2)
       ws_hg_status=$(echo `proxysql_exec "SELECT hostgroup_id,status from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port"`)
@@ -66,15 +159,24 @@ update_cluster(){
 
   for i in "${current_hosts[@]}"; do
     if [[ ! " ${wsrep_address[@]} " =~ " ${i} " ]]; then
+      if [ $debug -eq 1 ];then echo "`date` DEBUG Host $i not found in cluster membership" >> $ERR_FILE;fi
+      # The current host in current_hosts was not found in cluster membership, set it OFFLINE_HARD unless its a slave node
       ws_ip=$(echo $i | cut -d':' -f1)
       ws_port=$(echo $i | cut -d':' -f2)
-      ws_hg_status=$(echo `proxysql_exec "SELECT hostgroup_id,status from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port"`)
+      ws_hg_status=$(echo `proxysql_exec "SELECT hostgroup_id,status,comment from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port"`)
       ws_hg_id=$(echo $ws_hg_status | cut -d' ' -f1)
       ws_status=$(echo $ws_hg_status | cut -d' ' -f2)
-      echo "`date` Node ${ws_hg_id}:${i} does not exists in cluster membership!" >> $ERR_FILE
-      proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_HARD', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
-      check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials"
-      echo "`date` ${ws_hg_id}:${i} node set to OFFLINE_HARD status to ProxySQL database." >> $ERR_FILE 
+      comment=$(echo $ws_hg_status | cut -d' ' -f3)
+      if [ "$comment" == "SLAVEREAD" ];then
+        if [ $debug -eq 1 ];then echo "`date` DEBUG Host $i is a slave, checking its health" >> $ERR_FILE;fi
+        #This is a slave, check health differently
+        set_slave_status
+      else
+        echo "`date` Node ${ws_hg_id}:${i} does not exists in cluster membership!" >> $ERR_FILE
+        proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_HARD', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
+        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials"
+        echo "`date` ${ws_hg_id}:${i} node set to OFFLINE_HARD status to ProxySQL database." >> $ERR_FILE
+      fi
     else
       CHECK_STATUS=1 
     fi
@@ -82,6 +184,8 @@ update_cluster(){
 
   for i in "${wsrep_address[@]}"; do
     if [[ ! " ${current_hosts[@]} " == " ${i} " ]]; then
+      if [ $debug -eq 1 ];then echo "`date` DEBUG Host $i was found in cluster membership" >> $ERR_FILE;fi
+      # current_hosts contains the node in wsrep_addresses
       ws_ip=$(echo $i | cut -d':' -f1)
       ws_port=$(echo $i | cut -d':' -f2)
       ws_hg_status=$(echo `proxysql_exec "SELECT hostgroup_id,status from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port"`)
@@ -89,7 +193,8 @@ update_cluster(){
       ws_status=$(echo $ws_hg_status | cut -d' ' -f2)
       echo "`date` Cluster node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE 
       if [ "$ws_status" == "OFFLINE_HARD" ]; then
-	proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_SOFT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
+        # The node was OFFLINE_HARD, but its now in the cluster list so lets make it OFFLINE_SOFT
+        proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_SOFT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
         check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
         echo "`date` ${ws_hg_id}:${i} node set to OFFLINE_SOFT status to ProxySQL database." >> $ERR_FILE
       else
@@ -97,10 +202,11 @@ update_cluster(){
       fi
     fi
   done
+  if [ $debug -eq 1 ];then echo "`date` DEBUG End update_cluster" >> $ERR_FILE;fi
 }
 
 mode_change_check(){
-  checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment='WRITE' and status='OFFLINE_SOFT'"`
+  if [ $debug -eq 1 ];then echo "`date` DEBUG START mode_change_check" >> $ERR_FILE;fi
 
   if [ -f $HOST_PRIORITY_FILE ];then
     # Get the list of hosts from the host_priority file ignoring blanks and any lines that start with '#'
@@ -112,17 +218,24 @@ mode_change_check(){
   #   10.31.12.21:3306
   #
 
+  # Check if the current writer is in an OFFLINE_SOFT state
+  checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment in ('WRITE', 'READWRITE') and status='OFFLINE_SOFT'"`
   if [[ -n "$checkwriter_hid" ]]; then
-    proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE comment='WRITE' and status='OFFLINE_SOFT'"
-    check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+    # Found a writer node that was in 'OFFLINE_SOFT' state, move it to the READ hostgroup unless the RW_MODE is 'loadbal'
+    if [ "$RW_MODE" != "loadbal" ];then
+      if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check: Found OFFLINE_SOFT writer, changing to READ status and hostgroup $READ_HOSTGROUP_ID" >> $ERR_FILE;fi
+      proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE comment='WRITE' and status='OFFLINE_SOFT'"
+      check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+    fi
 
     # If that temp file exists use it otherwise choose random as is done now
+    unset current_hosts
     if [ -z $priority_hosts ];then
       # Order file wasn't found, behave as before
-      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'  ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment in ('READ', 'READWRITE') ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
     else
       # Get the list of all ONLINE reader nodes in ProxySQL
-      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'" | sed 's|\t|:|g' | tr '\n' ' '`)
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='READ'" | sed 's|\t|:|g' | tr '\n' ' '`)
 
       # Find the highest priority host from the online reader hosts
       for i in "${priority_hosts[@]}"; do
@@ -133,25 +246,83 @@ mode_change_check(){
           break
         fi
       done
-	  if [ -z $found_host ];then
+      if [ -z $found_host ];then
         # None of the priority hosts were found as active, picking the first on the list from what is available.
         current_hosts=(`echo $current_hosts | cut -d' ' -f1`)
         unset found_host
       fi
     fi
 
+    # If the $current_hosts variabe is empty here then it's time to put the SLAVEREAD node in if there is one
+    if [ -z "$current_hosts" ];then
+      # Verify a slave is not already in the write hostgroup
+      if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check: No cluster members available, check if any slaves are already in the writer hostgroup" >> $ERR_FILE;fi
+      slave_check=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='SLAVEREAD' and hostgroup_id=$WRITE_HOSTGROUP_ID ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+      if [ -z "$slave_check" ];then
+        # no slaves were currently in the writer group
+        if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check: No slaves currently in the writer group" >> $ERR_FILE;fi
+        current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='SLAVEREAD' ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+        slave_write="1"
+      else
+        if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check: A slave is already in the writer hostgroup" >> $ERR_FILE;fi
+      fi
+    fi
+
     ws_ip=$(echo $current_hosts | cut -d':' -f1)
     ws_port=$(echo $current_hosts | cut -d':' -f2)
-    proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
-    check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
-  else
-    if [ -z $priority_hosts ];then
-      # Order file wasn't found, behave as before 
+
+    # If the cluster is failed and a slave was already in as writer, the current_hosts variable will be empty
+    if [ "$slave_write" == "1" ] && [ -n "$current_hosts" ];then
+      if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check1: Changing $ws_ip:$ws_port to hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
+      proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
+      check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+      echo "`date` $ws_ip:$ws_port (slave) is ONLINE, switching to write hostgroup" >> $ERR_FILE
+    elif [ "$RW_MODE" != "loadbal" ] && [ -n "$current_hosts" ];then
+      # Only do this if the RW_MODE is not 'loadbal'
+      if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check1: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
+      proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
+      check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+      echo "`date` $ws_ip:$ws_port is ONLINE, switching to write hostgroup" >> $ERR_FILE
+    else
       CHECK_STATUS=1
+    fi
+  else
+    # The current writer was not in OFFLINE_SOFT state
+    # Now check if the current writer is a slave node and pull it out if other nodes are available
+    # Should check if a slave is the current writer and pull it out if a cluster node is available
+    checkslave_hid=`proxysql_exec "select hostgroup_id from mysql_servers where hostgroup_id='$WRITE_HOSTGROUP_ID' AND comment='SLAVEREAD'"`
+    # Set a variable containing a random available cluster node
+    available_cluster_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment in ('READ', 'READWRITE') ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+    if [[ -n "$checkslave_hid" ]]; then
+      # The current writer is a slave, check for other ONLINE nodes to put in
+      if [ -n "$available_cluster_hosts" ];then
+        # There is a regular cluster node available, pull out the slave
+        if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check1: Changing any SLAVEREAD nodes in hostgroup $WRITE_HOSTGROUP_ID to hostgroup $SLAVEREAD_HOSTGROUP_ID" >> $ERR_FILE;fi
+        proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, weight=1000 WHERE hostgroup_id='$WRITE_HOSTGROUP_ID' and comment='SLAVEREAD'"
+        check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+        writer_was_slave=1
+      fi
+    fi
+
+    if [ -z $priority_hosts ];then
+      # Order file wasn't found
+      # Do not change the config of a cluster node if the RW_MODE is 'loadbal'
+      if [ -n "$available_cluster_hosts" ] && [ -n "$writer_was_slave" ] && [ "$RW_MODE" != "loadbal" ];then
+        # There is a regular cluster node available, put it back in the writer hostgroup
+        ws_ip=$(echo $available_cluster_hosts | cut -d':' -f1)
+        ws_port=$(echo $available_cluster_hosts | cut -d':' -f2)
+        if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check2: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
+        proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
+        check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+        echo "`date` $ws_ip:$ws_port is ONLINE, switching to write hostgroup" >> $ERR_FILE
+      else
+        # No order file found and a slave is not the current writer, behave as before 
+        CHECK_STATUS=1
+      fi
     else
       # Check here if the highest priority node is the writer
-      # Get the list of all ONLINE nodes in ProxySQL
-      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE'" | sed 's|\t|:|g' | tr '\n' ' '`)
+      # Get the list of all ONLINE nodes in ProxySQL, can't use available_cluster_hosts here
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' AND comment<>'SLAVEREAD'" | sed 's|\t|:|g' | tr '\n' ' '`)
 
       # Find the highest priority host from the online hosts
       for i in "${priority_hosts[@]}"; do
@@ -169,25 +340,44 @@ mode_change_check(){
         current_writer=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='WRITE'" | sed 's|\t|:|g' | tr '\n' ' '`)
         if [ "$current_hosts" != "$current_writer" ];then
           # Switch the writer around
-          # Move the current writer host to reader hostgroup
-          ws_ip=$(echo $current_writer | cut -d':' -f1)
-          ws_port=$(echo $current_writer | cut -d':' -f2)
-          proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
-          check_cmd $? "Cannot update Percona XtraDB Cluster reader node in ProxySQL database, Please check proxysql credentials"
+          if [ -n "$current_writer" ];then
+            # Move the current writer host to reader hostgroup if there is one
+            ws_ip=$(echo $current_writer | cut -d':' -f1)
+            ws_port=$(echo $current_writer | cut -d':' -f2)
+            if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check3: Changing $ws_ip:$ws_port to READ status and hostgroup $READ_HOSTGROUP_ID" >> $ERR_FILE;fi
+            proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
+            check_cmd $? "Cannot update Percona XtraDB Cluster reader node in ProxySQL database, Please check proxysql credentials"
+            echo "`date` $ws_ip:$ws_port is ONLINE but a higher priority node is available, switching to read hostgroup" >> $ERR_FILE
+          fi
           # Move the priority host to the writer hostgroup
           ws_ip=$(echo $current_hosts | cut -d':' -f1)
           ws_port=$(echo $current_hosts | cut -d':' -f2)
-          proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
+          if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check3: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
+          proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
           check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+          echo "`date` $ws_ip:$ws_port is ONLINE and highest priority, switching to write hostgroup" >> $ERR_FILE
         else
           CHECK_STATUS=1
         fi
       else
-        CHECK_STATUS=1
+        if [ -n "$available_cluster_hosts" ] && [ -n "$writer_was_slave" ];then
+          # There is a regular cluster node available, pull out the slave and put the cluster node back in the writer hostgroup
+          ws_ip=$(echo $available_cluster_hosts | cut -d':' -f1)
+          ws_port=$(echo $available_cluster_hosts | cut -d':' -f2)
+          if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check4: Changing $ws_ip:$ws_port to hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
+          proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
+          check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+          echo "`date` $ws_ip:$ws_port is ONLINE, switching to write hostgroup" >> $ERR_FILE
+        else
+          CHECK_STATUS=1
+        fi
       fi
-	fi
+    fi
   fi
+  if [ $debug -eq 1 ];then echo "`date` DEBUG END mode_change_check" >> $ERR_FILE;fi
 }
+
+# Monitoring user needs 'REPLICATION CLIENT' privilege
 
 CLUSTER_USERNAME=$(proxysql_exec "SELECT variable_value FROM global_variables WHERE variable_name='mysql-monitor_username'")
 check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check cluster login credentials"
@@ -195,21 +385,54 @@ check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check 
 CLUSTER_PASSWORD=$(proxysql_exec "SELECT variable_value FROM global_variables WHERE variable_name='mysql-monitor_password'") 
 check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check cluster login credentials"
 
-CLUSTER_HOST_INFO=`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and hostgroup_id in ($WRITE_HOSTGROUP_ID, $READ_HOSTGROUP_ID) limit 1"`
+CLUSTER_HOST_INFO=`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment<>'SLAVEREAD' and hostgroup_id in ($WRITE_HOSTGROUP_ID, $READ_HOSTGROUP_ID) limit 1"`
 check_cmd $? "Could not retrieve cluster node info from ProxySQL. Please check cluster login credentials"
 
 CLUSTER_HOSTNAME=$(echo $CLUSTER_HOST_INFO | awk '{print $1}')
 CLUSTER_PORT=$(echo $CLUSTER_HOST_INFO | awk '{print $2}')
 
 if [[ -z $CLUSTER_HOST_INFO ]]; then
-  echo "`date` Percona XtraDB Cluster nodes are not configured in ProxySQL database. Please pass correct info" >> $ERR_FILE
+  if [ $debug -eq 1 ];then echo "`date` DEBUG Can't get cluster info, checking if a slave is available" >> $ERR_FILE;fi
+  # Set CLUSTER_OFFLINE variable, used my the set_slave_status function and the bottom of this script
+  CLUSTER_OFFLINE=1
+  # No Cluster nodes are available, but is a slave available?
+  SLAVE_HOST_INFO=`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='SLAVEREAD' and hostgroup_id in ($WRITE_HOSTGROUP_ID, $SLAVEREAD_HOSTGROUP_ID) limit 1"`
+  check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check cluster login credentials"
+  SLAVE_HOSTNAME=$(echo $CLUSTER_HOST_INFO | awk '{print $1}')
+  SLAVE_PORT=$(echo $CLUSTER_HOST_INFO | awk '{print $2}')
+  if [[ -z $SLAVE_HOST_INFO ]]; then
+    if [ $debug -eq 1 ];then echo "`date` DEBUG No online slaves were found, will recheck" >> $ERR_FILE;fi
+    # Check for a slave in a status other than 'ONLINE'
+    # This is an emergency measure, just put a random slave online
+    # Would be nice to try to find the most up to date slave if there is more than one, but that would require
+    # a query to all slaves to check their positions, probably not worth the overhead - something to think about
+    slave_host=(`proxysql_exec "SELECT hostname,port FROM mysql_servers where comment='SLAVEREAD' and hostgroup_id in ($WRITE_HOSTGROUP_ID, $SLAVEREAD_HOSTGROUP_ID) ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+    if [ $debug -eq 1 ];then echo "`date` DEBUG Trying to bring slave: $slave_host ONLINE due to cluster being down" >> $ERR_FILE;fi
+    ws_ip=$(echo $slave_host | cut -d':' -f1)
+    ws_port=$(echo $slave_host | cut -d':' -f2)
+    set_slave_status
+  else
+    if [ $debug -eq 1 ];then echo "`date` DEBUG online slaves were found" >> $ERR_FILE;fi
+    # Run function here to move the slave into the write hostgroup
+    mode_change_check
+  fi
+  SLAVE_HOST_INFO=`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='SLAVEREAD' and hostgroup_id='$WRITE_HOSTGROUP_ID' limit 1"`
+  if [[ -z $SLAVE_HOST_INFO ]]; then
+    echo "`date` Percona XtraDB Cluster nodes are offline or not configured, please check status" >> $ERR_FILE
+  else
+    echo "`date` Percona XtraDB Cluster nodes are offline, a slave node is in the writer hostgroup, please check status" >> $ERR_FILE
+  fi
 else
   update_cluster
   mode_change_check
 fi
 
 if [ $CHECK_STATUS -eq 1 ]; then
-  echo "`date` Percona XtraDB Cluster membership looks good." >> $ERR_FILE
+  if [ -z "$CLUSTER_OFFLINE" ];then
+    echo "`date` Percona XtraDB Cluster membership looks good" >> $ERR_FILE
+  else
+    echo "`date` Percona XtraDB Cluster is offline!" >> $ERR_FILE
+  fi
 else
   echo "`date` ###### Loading mysql_servers config into runtime ######" >> $ERR_FILE
   proxysql_exec "LOAD MYSQL SERVERS TO RUNTIME"


### PR DESCRIPTION
Added the --include-slaves option to proxysql-admin. This option allows slave node to be automatically added to ProxySQL and will be monitored for status. The slave nodes will be used as an emergency fallback if all the XtraDB cluster nodes are in a state other than ONLINE.
- A slave node will be considered online as long as slave health is good (slave sql running) and it's behind no more than 3600 seconds according to the 'Seconds_Behind_Master' stat.
- A slave that has fallen behind more than 3600 seconds will be put into an 'OFFLINE_SOFT' state until it catches up.
- When the last available XtraDB Cluster node goes into a non-online state, the first available and 'ONLINE' slave node will be made active in the write hostgroup.
  If no ONLINE slaves are found, any slave will be randomly picked and put online provided it's slave_sql_running is 'Yes'.
- Slave SQL Running = 'No' will trigger an 'OFFLINE_HARD' state.
- Slave IO running != 'Yes' will trigger an 'OFFLINE_SOFT' state.
- As soon as one cluster node comes back into an 'ONLINE' state, any slave in the writer hostgroup will be moved to the reader hostgroup.
- If all the nodes including the slave are down everything will be down (obviously), if the slave is started back up as an emergency measure it will be made ONLINE and put in the writer hostgroup.
Notes:
  Slave nodes need the 'read_only' variable set to 1 (ON)
  The monitoring user needs the 'REPLICATION CLIENT' privilege on the slaves
 
Modified the --write-node option to control a priority order of what host is most desired to be the writer at any given time.
- When used the feature will create the config file which is by default "/var/lib/proxysql/host_priority.conf", this is configurable in proxysql-admin.cnf
- Servers can be specified comma delimited - 10.0.0.51:3306, 10.0.0.52:3306 - The 51 node will always be in the writer hostgroup if it is ONLINE, if it is OFFLINE the 52 node will go into the writer hostgroup, and if it goes down a node from the remaining nodes will be randomly chosen for the writer hostgroup.
- This new config file will be deleted when --disable is used.
- This will ensure a specified writer-node will always be the writer node while it is ONLINE.