### PR TITLE
Add delaycompress in proxysql-logrotate

### DIFF
--- a/proxysql-logrotate
+++ b/proxysql-logrotate
@@ -4,6 +4,7 @@
         daily
         notifempty
         compress
+	delaycompress
         create 0600 proxysql proxysql
         rotate 15
 	postrotate


### PR DESCRIPTION
I got this today : 
/etc/cron.daily/logrotate:
error: Compressing program wrote following message to stderr when compressing log /var/lib/proxysql/proxysql.log.1:
gzip: stdin: file size changed while zipping

Adding delaycompress should prevent this error.

I'm using : ProxySQL 1.4.3-1.1.stretch on Debian stretch
downloaded from repo.percona.com