### PR TITLE
PQA-156 - Add test for updating runtime_mysql_servers table

### DIFF
--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -43,6 +43,53 @@ echo "$output"
   [ "$cluster_user_count" -eq "$proxysql_user_count" ]
 }
 
+@test "run the check for updating runtime_mysql_servers table" {
+  # check initial writer info
+  first_writer_port=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select port from mysql_servers where hostgroup_id='10';" 2>/dev/null)
+  first_writer_status=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select status from mysql_servers where hostgroup_id='10';" 2>/dev/null)
+  first_writer_weight=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select weight from mysql_servers where hostgroup_id='10';" 2>/dev/null)
+  first_writer_comment=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select comment from mysql_servers where hostgroup_id='10';" 2>/dev/null)
+  first_writer_start_cmd=$(ps aux|grep "mysqld"|grep "port=$first_writer_port"|sed 's:^.* /:/:')
+  first_writer_start_user=$(ps aux|grep "mysqld"|grep "port=$first_writer_port"|awk -F' ' '{print $1}')
+  [ "$first_writer_status" = "ONLINE" ]
+  [ "$first_writer_weight" = "1000000" ]
+  [ "$first_writer_comment" = "WRITE" ]
+
+  # check that the tables are equal at start
+  mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from mysql_servers order by port;" 2>/dev/null)
+  runtime_mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from mysql_servers order by port;" 2>/dev/null)
+  [ "$(echo \"$mysql_servers\"|md5sum)" = "$(echo \"$runtime_mysql_servers\"|md5sum)" ]
+
+  # shutdown writer
+  pxc_bindir=$(ps aux|grep "mysqld"|grep "port=$first_writer_port"|sed 's:^.* /:/:'|grep -o "^.*bin/")
+  pxc_socket=$(ps aux|grep "mysqld"|grep "port=$first_writer_port"|sed 's:^.* /:/:'|grep -o "\-\-socket=.* ")
+  $pxc_bindir/mysqladmin $pxc_socket -u root shutdown
+  sleep 3
+  nr_nodes=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select count(*) from mysql_servers where status='ONLINE';" 2>/dev/null)
+  [ "$nr_nodes" = "2" ]
+
+  # check new writer info
+  second_writer_status=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select status from mysql_servers where hostgroup_id='10';" 2>/dev/null)
+  second_writer_weight=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select weight from mysql_servers where hostgroup_id='10';" 2>/dev/null)
+  second_writer_comment=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select comment from mysql_servers where hostgroup_id='10';" 2>/dev/null)
+  [ "$second_writer_status" = "ONLINE" ]
+  [ "$second_writer_weight" = "1000000" ]
+  [ "$second_writer_comment" = "WRITE" ]
+
+  # bring the node up
+  first_writer_start_cmd=$(echo $first_writer_start_cmd|sed 's:--wsrep_cluster_address.*--wsrep_provider_options:--wsrep_provider_options:')
+  cluster_address=$(ps aux|grep mysqld|grep -o "\-\-wsrep_cluster_address=gcomm.* --wsrep_provider_options"|sort|head -n1|grep -o ",gcomm.*,"|sed 's/^,//'|sed 's/,$//')
+  first_writer_start_cmd="$first_writer_start_cmd --wsrep_cluster_address=$cluster_address"
+  nohup $first_writer_start_cmd --user=$first_writer_start_user 3>- &
+  sleep 3
+  nr_nodes=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select count(*) from mysql_servers where status='ONLINE';" 2>/dev/null)
+  [ "$nr_nodes" = "3" ]
+
+  # check that the tables are equal at end
+  mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from mysql_servers order by port;" 2>/dev/null)
+  runtime_mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from mysql_servers order by port;" 2>/dev/null)
+  [ "$(echo \"$mysql_servers\"|md5sum)" = "$(echo \"$runtime_mysql_servers\"|md5sum)" ]
+}
 
 @test "run the check for --test-run" {
   run sudo proxysql-admin  --enable --quick-demo <<< n


### PR DESCRIPTION
This is doing following:
- checking that mysql_servers and runtime_mysql_servers tables are equal
- stopping initial writer node
- checking that tables are updated
- starting the stopped node again
- checking that tables are updated

Test run:
```
ubuntu@ubuntu-test:~$ ./proxysql-admin-tool/tests/proxysql-admin-testsuite.sh /home/ubuntu/workdir
Started PXC node1. Socket : /home/ubuntu/workdir//Percona-XtraDB-Cluster-5.7.20-rel18-29.24.1.Linux.x86_64.ssl100/node1/socket.sock
Started PXC node2. Socket : /home/ubuntu/workdir//Percona-XtraDB-Cluster-5.7.20-rel18-29.24.1.Linux.x86_64.ssl100/node2/socket.sock
Started PXC node3. Socket : /home/ubuntu/workdir//Percona-XtraDB-Cluster-5.7.20-rel18-29.24.1.Linux.x86_64.ssl100/node3/socket.sock
proxysql-admin generic bats test log
 ✓ run proxysql-admin under root privileges
 ✓ run proxysql-admin without any arguments
 ✓ run proxysql-admin --help
 ✓ run proxysql-admin with wrong option
 ✓ run proxysql-admin --config-file without parameters
 ✓ run proxysql-admin check default configuration file
 ✓ run proxysql-admin --proxysql-username without parameters
 ✓ run proxysql-admin --proxysql-port without parameters
 ✓ run proxysql-admin --proxysql-hostname without parameters
 ✓ run proxysql-admin --cluster-username without parameters
 ✓ run proxysql-admin --cluster-port without parameters
 ✓ run proxysql-admin --cluster-hostname without parameters
 ✓ run proxysql-admin --cluster-app-username without parameters
 ✓ run proxysql-admin --monitor-username without parameters
 ✓ run proxysql-admin --mode without parameters
 ✓ run proxysql-admin --write-node without parameters

16 tests, 0 failures
proxysql-admin testsuite bats test log
 ✓ run proxysql-admin -d
 ✓ run proxysql-admin -e
 ✓ run the check for cluster size
 ✓ run the check for --node-check-interval
 ✓ run the check for --adduser
 ✓ run proxysql-admin --syncusers
 ✓ run the check for --syncusers
 ✓ run the check for updating runtime_mysql_servers table
 ✓ run the check for --test-run

9 tests, 0 failures
```