### PR TITLE
Propertly quote MONITOR_USERNAME in admin script query

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -573,7 +573,7 @@ enable_proxysql(){
 
   check_user=$(mysql_exec "SELECT user,host FROM mysql.user where user='$MONITOR_USERNAME' and host='$USER_HOST_RANGE';")
   if [[ -z "$check_user" ]]; then
-    mysql_exec "CREATE USER $MONITOR_USERNAME@'$USER_HOST_RANGE' IDENTIFIED BY '$MONITOR_PASSWORD';"
+    mysql_exec "CREATE USER '$MONITOR_USERNAME'@'$USER_HOST_RANGE' IDENTIFIED BY '$MONITOR_PASSWORD';"
     check_cmd $?  "Failed to create the ProxySQL monitoring user. Please check '$CLUSTER_USERNAME'@'$CLUSTER_HOSTNAME' has proper permission to create montioring user"
     proxysql_exec "update global_variables set variable_value='$MONITOR_USERNAME' where variable_name='mysql-monitor_username'; update global_variables set variable_value='$MONITOR_PASSWORD' where variable_name='mysql-monitor_password'; "
     check_cmd $?  "Failed to set the mysql-monitor variables in ProxySQL. Please check username, password and other options for connecting to ProxySQL database"
@@ -640,7 +640,7 @@ enable_proxysql(){
     done
     # GRANT REPLICATION CLIENT permissions to the monitoring user account
     echo -e "\nGranting 'REPLICATION CLIENT' privilege to $MONITOR_USERNAME@$USER_HOST_RANGE"
-    mysql_exec "GRANT REPLICATION CLIENT ON *.* TO $MONITOR_USERNAME@'$USER_HOST_RANGE';"
+    mysql_exec "GRANT REPLICATION CLIENT ON *.* TO '$MONITOR_USERNAME'@'$USER_HOST_RANGE';"
     check_cmd $? "$CLUSTER_USERNAME@'$CLUSTER_HOSTNAME' does not have the GRANT privilege required to assign the requested permissions"
   fi
 


### PR DESCRIPTION
This commit puts quotes around the MONITOR_USERNAME environment variable
to be consistent with the others. We ran into a bug where a dash in the
hostname was causing the monitoring user to have a dash in it, and mysql
complained that:

> mysql> create user monitor_ubuntu-xenial-yul-314584@'%' IDENTIFIED BY 'abc';
> ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-xenial-yul-314584@'%' IDENTIFIED BY 'abc'' at line 1