### PR TITLE
Updated proxysql-admin script to configure multiple clusters in proxysql

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -249,7 +249,7 @@ do
     ENABLE=1
     ;;
     -v | --version )
-      echo "proxysql-admin version 1.4.5"
+      echo "proxysql-admin version 1.4.6"
       exit 0
     ;;
     --help )
@@ -456,6 +456,10 @@ check_proxysql(){
   fi
 }
 
+CLUSTER_NAME=$(mysql_exec "select @@wsrep_cluster_name;")
+rm -rf ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode
+echo "$MODE" > ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode
+
 user_input_check(){
   USER_CATEGORY=$1
   USER_DESCRIPTION=$2
@@ -488,19 +492,26 @@ user_input_check(){
   if [ "$USER_CATEGORY" != "MONITOR" ]; then
     check_user=$(mysql_exec "SELECT user,host FROM mysql.user where user='$USERNAME' and host='$USER_HOST_RANGE';")
     if [[ -z "$check_user" ]]; then
-      mysql_exec "CREATE USER $USERNAME@'$USER_HOST_RANGE' IDENTIFIED BY '$PASSWORD';"
-      check_cmd $? "Failed to add Percona XtraDB Cluster application user: '$USERNAME'. Please check '$CLUSTER_USERNAME'@'$CLUSTER_HOSTNAME' has proper permission to create montioring user"
-      if [ ! -z "$QUICK_DEMO" ]; then
-        mysql_exec "GRANT ALL ON *.* to $USERNAME@'$USER_HOST_RANGE'"
-        check_cmd $? "$CLUSTER_USERNAME@'$CLUSTER_HOSTNAME' does not have the GRANT privilege required to assign the requested permissions"
-      fi
+      precheck_user=$(proxysql_exec "SELECT username FROM mysql_users where username='$USERNAME'")
+	  if [[ -z "$precheck_user" ]]; then  
+        mysql_exec "CREATE USER $USERNAME@'$USER_HOST_RANGE' IDENTIFIED BY '$PASSWORD';"
+        check_cmd $? "Failed to add Percona XtraDB Cluster application user: '$USERNAME'. Please check '$CLUSTER_USERNAME'@'$CLUSTER_HOSTNAME' has proper permission to create montioring user"
+        if [ ! -z "$QUICK_DEMO" ]; then
+          mysql_exec "GRANT ALL ON *.* to $USERNAME@'$USER_HOST_RANGE'"
+          check_cmd $? "$CLUSTER_USERNAME@'$CLUSTER_HOSTNAME' does not have the GRANT privilege required to assign the requested permissions"
+        fi
 
-      proxysql_exec "INSERT INTO mysql_users (username,password,active,default_hostgroup) values ('$USERNAME','$PASSWORD',1,$HOSTGROUP_ID);LOAD MYSQL USERS TO RUNTIME;SAVE MYSQL USERS FROM RUNTIME;SAVE MYSQL USERS TO DISK;"
-      check_cmd $? "Failed to add Percona XtraDB Cluster application user: '$USERNAME' in ProxySQL database. Please check username, password and other options for connecting to ProxySQL database"
-      if [ -z "$QUICK_DEMO" ]; then
-        echo -e "\nPercona XtraDB Cluster application user '${BD}$USERNAME'@'$USER_HOST_RANGE${NBD}' has been added with the USAGE privilege, please make sure to the grant appropriate privileges"
+        proxysql_exec "INSERT INTO mysql_users (username,password,active,default_hostgroup) values ('$USERNAME','$PASSWORD',1,$HOSTGROUP_ID);LOAD MYSQL USERS TO RUNTIME;SAVE MYSQL USERS FROM RUNTIME;SAVE MYSQL USERS TO DISK;"
+        check_cmd $? "Failed to add Percona XtraDB Cluster application user: '$USERNAME' in ProxySQL database. Please check username, password and other options for connecting to ProxySQL database"
+        if [ -z "$QUICK_DEMO" ]; then
+          echo -e "\nPercona XtraDB Cluster application user '${BD}$USERNAME'@'$USER_HOST_RANGE${NBD}' has been added with the USAGE privilege, please make sure to the grant appropriate privileges"
+        else
+          echo -e "\nPercona XtraDB Cluster application user '${BD}$USERNAME'@'$USER_HOST_RANGE${NBD}' has been added with ${BD}ALL${NBD} privileges, ${BD}this user is created for testing purposes${NBD}"
+        fi
       else
-        echo -e "\nPercona XtraDB Cluster application user '${BD}$USERNAME'@'$USER_HOST_RANGE${NBD}' has been added with ${BD}ALL${NBD} privileges, ${BD}this user is created for testing purposes${NBD}"
+        echo -e "\nERROR: The application user ${BD}$USERNAME${NBD} is already present in ProxySQL database. Terminating!"
+        echo -e " Note: ProxySQL do not allow duplicate username."
+        exit 1
       fi
     else
       check_user=$(proxysql_exec "SELECT username FROM mysql_users where username='$USERNAME'")
@@ -509,7 +520,9 @@ user_input_check(){
         proxysql_exec "INSERT INTO mysql_users (username,password,active,default_hostgroup) values ('$USERNAME','$PASSWORD',1,$HOSTGROUP_ID);LOAD MYSQL USERS TO RUNTIME;SAVE MYSQL USERS FROM RUNTIME;SAVE MYSQL USERS TO DISK;"
         check_cmd $? "Failed to add Percona XtraDB Cluster application user: '$USERNAME' in ProxySQL database. Please check username, password and other options for connecting to ProxySQL database"
       else
-        echo -e "\nThe application user '${BD}${USERNAME}'@'$USER_HOST_RANGE${NBD}' is already present in Percona XtraDB Cluster and ProxySQL database."
+        echo -e "\nERROR: The application user ${BD}$USERNAME${NBD} is already present in ProxySQL database. Terminating!"
+        echo -e " Note: ProxySQL do not allow duplicate username."
+        exit 1
       fi
     fi
   fi
@@ -566,6 +579,11 @@ enable_proxysql(){
 
   cluster_connection_check
 
+  check_hgs=$(proxysql_exec "SELECT hostgroup_id FROM mysql_servers where hostgroup_id in ($READ_HOSTGROUP_ID,$WRITE_HOSTGROUP_ID)")
+  if [[ ! -z "$check_hgs" ]]; then
+    echo -e "\nERROR: READ/WRITE hostgroups($READ_HOSTGROUP_ID,$WRITE_HOSTGROUP_ID) are already present in ProxySQL database. Terminating!"
+    exit 1
+  fi
   CLUSTER_NETWORK=$(mysql_exec "show status like 'wsrep_incoming_addresses'" | awk '{print $2}' | cut -d'.' -f1)
   if [[ "$CLUSTER_NETWORK" =~ ^[0-9]+$ ]]; then 
     USER_HOST_RANGE="$CLUSTER_NETWORK.%"
@@ -742,22 +760,16 @@ enable_proxysql(){
 
   # Adding Percona XtraDB Cluster monitoring scripts
   # Adding proxysql galera check scheduler
-  proxysql_exec "DELETE FROM SCHEDULER WHERE ID=10;"
+  proxysql_exec "DELETE FROM SCHEDULER WHERE COMMENT='$CLUSTER_NAME';"
   check_cmd $? "Failed to delete the Percona XtraDB Cluster nodes from ProxySQL. Please check username, password and other options for connecting to ProxySQL database"
   if [ $MODE == "singlewrite" ]; then
     NUMBER_WRITERS=1
   else
     NUMBER_WRITERS=0
   fi
-  proxysql_exec "INSERT  INTO SCHEDULER (id,active,interval_ms,filename,arg1,arg2,arg3,arg4,arg5) VALUES (10,1,$NODE_CHECK_INTERVAL,'$PROXYSQL_GALERA_CHECK',$WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID,$NUMBER_WRITERS,1,'$PROXYSQL_DATADIR/proxysql_galera_check.log');"
+  proxysql_exec "INSERT  INTO SCHEDULER (active,interval_ms,filename,arg1,arg2,arg3,arg4,arg5,comment) VALUES (1,$NODE_CHECK_INTERVAL,'$PROXYSQL_GALERA_CHECK',$WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID,$NUMBER_WRITERS,1,'$PROXYSQL_DATADIR/${CLUSTER_NAME}_proxysql_galera_check.log','$CLUSTER_NAME');"
   check_cmd $? "Failed to add the Percona XtraDB Cluster monitoring scheduler in ProxySQL. Please check username, password and other options for connecting to ProxySQL database"
-
-  # Adding Percona XtraDB Cluster membership checking scheduler
-  #proxysql_exec "DELETE FROM SCHEDULER WHERE ID=11;"
-  #check_cmd $?
-  #proxysql_exec "INSERT  INTO SCHEDULER (id,active,interval_ms,filename,arg1,arg2,arg3) VALUES (11,1,5000,'$PROXYSQL_NODE_MONITOR',$WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID,'$PROXYSQL_DATADIR/proxysql_node_monitor.log');"
-  #check_cmd $? "Failed to add the Percona XtraDB Cluster membership checking scheduler in ProxySQL"
-
+  
   proxysql_exec "LOAD SCHEDULER TO RUNTIME;SAVE SCHEDULER TO DISK;"
 }
 
@@ -771,7 +783,7 @@ disable_proxysql(){
   proxysql_exec "DELETE FROM mysql_servers WHERE hostgroup_id in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID);"
   check_cmd $? "Failed to delete the Percona XtraDB Cluster nodes from ProxySQL. Please check username, password and other options for connecting to ProxySQL database"
   echo "Removing scheduler script from ProxySQL database."
-  proxysql_exec "DELETE FROM SCHEDULER WHERE ID IN (10);"
+  proxysql_exec "DELETE FROM SCHEDULER WHERE COMMENT='$CLUSTER_NAME';"
   check_cmd $? "Failed to delete the Galera checker from ProxySQL. Please check username, password and other options for connecting to ProxySQL database"
   echo "Removing query rules from ProxySQL database if any."
   proxysql_exec "DELETE FROM mysql_query_rules WHERE destination_hostgroup in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID)"

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -1,6 +1,8 @@
 #!/bin/bash
 ## inspired by Percona clustercheck.sh
 
+ERR_FILE="${5:-/dev/null}"
+
 if [ -f /etc/proxysql-admin.cnf ]; then
   source /etc/proxysql-admin.cnf
 else
@@ -51,7 +53,6 @@ HOSTGROUP_WRITER_ID="${1}"
 HOSTGROUP_READER_ID="${2:--1}"
 NUMBER_WRITERS="${3:-0}"
 WRITER_IS_READER="${4:-1}"
-ERR_FILE="${5:-/dev/null}"
 RELOAD_CHECK_FILE="${PROXYSQL_DATADIR}/reload"
 
 echo "0" > ${RELOAD_CHECK_FILE}

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -66,7 +66,7 @@ proxysql_exec() {
 }
 
 CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$HOSTGROUP_WRITER_ID")
-RELOAD_CHECK_FILE="${PROXYSQL_DATADIR}/$CLUSTER_NAME_reload"
+RELOAD_CHECK_FILE="${PROXYSQL_DATADIR}/${CLUSTER_NAME}_reload"
 
 echo "0" > ${RELOAD_CHECK_FILE}
 #Timeout exists for instances where mysqld may be hung

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -36,8 +36,8 @@ Notes about the mysql_servers in ProxySQL:
                      will be changed to either ONLINE or OFFLINE_SOFT.
 
 
-When no nodes were found to be in wsrep_local_state=4 (SYNCED) for either 
-read or write nodes, then the script will try 5 times for each node to try 
+When no nodes were found to be in wsrep_local_state=4 (SYNCED) for either
+read or write nodes, then the script will try 5 times for each node to try
 to find nodes wsrep_local_state=4 (SYNCED) or wsrep_local_state=2 (DONOR/DESYNC)
 
 This is to avoid $0 to mark all nodes as OFFLINE_SOFT
@@ -56,15 +56,6 @@ RELOAD_CHECK_FILE="${PROXYSQL_DATADIR}/reload"
 
 echo "0" > ${RELOAD_CHECK_FILE}
 
-#Running proxysql_node_monitor script.
-if [ ! -f /usr/bin/proxysql_node_monitor ] ;then
-  echo "`date` ERROR! Could not run /usr/bin/proxysql_node_monitor. Monitoring script does not exists in default location. Terminating" >> ${ERR_FILE}
-  exit 1  
-else
-  /usr/bin/proxysql_node_monitor $HOSTGROUP_WRITER_ID $HOSTGROUP_READER_ID ${PROXYSQL_DATADIR}/proxysql_node_monitor.log
-fi
-
-
 proxysql_exec() {
   local query="$1"
   printf "%s\n" \
@@ -76,6 +67,7 @@ proxysql_exec() {
       | mysql --defaults-file=/dev/stdin --protocol=tcp -Nse "${query}"
 }
 
+CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$HOSTGROUP_WRITER_ID")
 #Timeout exists for instances where mysqld may be hung
 TIMEOUT=10
 
@@ -89,6 +81,14 @@ mysql_exec() {
       "port=${port}"  \
       | timeout $TIMEOUT mysql --defaults-file=/dev/stdin --protocol=tcp -nNE -e "${query}"
 }
+
+#Running proxysql_node_monitor script.
+if [ ! -f /usr/bin/proxysql_node_monitor ] ;then
+  echo "`date` ERROR! Could not run /usr/bin/proxysql_node_monitor. Monitoring script does not exists in default location. Terminating" >> ${ERR_FILE}
+  exit 1
+else
+  /usr/bin/proxysql_node_monitor $HOSTGROUP_WRITER_ID $HOSTGROUP_READER_ID ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_proxysql_node_monitor.log
+fi
 
 if [ "$1" = '-h' -o "$1" = '--help'  -o -z "$1" ]
 then
@@ -130,7 +130,7 @@ if [ $WRITER_IS_READER -ne 0 -a $WRITER_IS_READER -ne 1 ]; then
 fi
 
 
-# print information prior to a run if ${ERR_FILE} is defined 
+# print information prior to a run if ${ERR_FILE} is defined
 echo "`date` ###### proxysql_galera_checker.sh SUMMARY ######" >> ${ERR_FILE}
 echo "`date` Hostgroup writers $HOSTGROUP_WRITER_ID" >> ${ERR_FILE}
 echo "`date` Hostgroup readers $HOSTGROUP_READER_ID" >> ${ERR_FILE}
@@ -280,13 +280,13 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
          reader.status,
          writer.status
   FROM mysql_servers as reader
-  LEFT JOIN mysql_servers as writer 
-    ON writer.hostgroup_id = $HOSTGROUP_WRITER_ID 
-    AND writer.hostname = reader.hostname 
+  LEFT JOIN mysql_servers as writer
+    ON writer.hostgroup_id = $HOSTGROUP_WRITER_ID
+    AND writer.hostname = reader.hostname
     AND writer.port = reader.port
   WHERE reader.hostgroup_id = $HOSTGROUP_READER_ID
     AND reader.status <> 'OFFLINE_HARD'
-	AND reader.comment <> 'SLAVEREAD'
+        AND reader.comment <> 'SLAVEREAD'
   ORDER BY writer.status ASC,
            reader.weight DESC,
            reader.hostname,
@@ -354,7 +354,7 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
           echo "`date` server $hostgroup:$server:$port is already ONLINE" >> ${ERR_FILE}
           OFFLINE_READERS_FOUND=$(( $OFFLINE_READERS_FOUND + 1 ))
         fi
-      
+
         # WSREP status OK, but node is not marked ONLINE
         if [ "${WSREP_STATUS}" = "4" -a "$stat" != "ONLINE" ] ; then
           change_server_status $HOSTGROUP_READER_ID "$server" $port "ONLINE" "changed state, making read node ONLINE"
@@ -369,7 +369,7 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
           echo "`date` server $hostgroup:$server:$port is $stat" >> ${ERR_FILE}
           OFFLINE_READERS_FOUND=$(( $OFFLINE_READERS_FOUND + 1 ))
         fi
-      
+
         # WSREP status OK, but node is not marked ONLINE
         if [ "${WSREP_STATUS}" = "4" -a "$stat" != "ONLINE" -a "${PXC_MAIN_MODE}" == "DISABLED" ] ; then
           change_server_status $HOSTGROUP_READER_ID "$server" $port "ONLINE" "changed state, making read node ONLINE"
@@ -488,7 +488,7 @@ if [  ${HOSTGROUP_READER_ID} -ne -1 -a ${NUMBER_READERS_ONLINE} -eq 0 ]; then
         proxysql_exec "LOAD MYSQL QUERY RULES TO RUNTIME;" 2>> ${ERR_FILE}
         echo "`date` Slave host is online, disabling read transaction from writer node" >> ${ERR_FILE}
       fi
-    fi   
+    fi
   fi
 fi
 

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -53,9 +53,6 @@ HOSTGROUP_WRITER_ID="${1}"
 HOSTGROUP_READER_ID="${2:--1}"
 NUMBER_WRITERS="${3:-0}"
 WRITER_IS_READER="${4:-1}"
-RELOAD_CHECK_FILE="${PROXYSQL_DATADIR}/reload"
-
-echo "0" > ${RELOAD_CHECK_FILE}
 
 proxysql_exec() {
   local query="$1"
@@ -69,6 +66,9 @@ proxysql_exec() {
 }
 
 CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$HOSTGROUP_WRITER_ID")
+RELOAD_CHECK_FILE="${PROXYSQL_DATADIR}/$CLUSTER_NAME_reload"
+
+echo "0" > ${RELOAD_CHECK_FILE}
 #Timeout exists for instances where mysqld may be hung
 TIMEOUT=10
 

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -372,7 +372,7 @@ mode_change_check(){
       # Only initiate changing hosts if a more priority host was found
       if [ -n $found_host ];then
         # Check to see if the host in 'current_host' is the writer
-        current_writer=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='WRITE'" | sed 's|\t|:|g' | tr '\n' ' '`)
+        current_writer=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='WRITE' and hostgroup_id=$WRITE_HOSTGROUP_ID" | sed 's|\t|:|g' | tr '\n' ' '`)
         if [ "$current_hosts" != "$current_writer" ];then
           # Switch the writer around
           if [ -n "$current_writer" ];then

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -4,6 +4,7 @@
 
 debug=0
 
+ERR_FILE="${3:-/dev/null}"
 if [ -f /etc/proxysql-admin.cnf ]; then
   source /etc/proxysql-admin.cnf
 else
@@ -21,7 +22,7 @@ SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
 if [ $SLAVEREAD_HOSTGROUP_ID -eq $WRITE_HOSTGROUP_ID ];then
   let SLAVEREAD_HOSTGROUP_ID+=1
 fi
-ERR_FILE="${3:-/dev/null}"
+
 CHECK_STATUS=0
 SLAVE_SECONDS_BEHIND=3600 #How far behind can a slave be before its put into OFFLINE_SOFT state
 CLUSTER_TIMEOUT=3 # Maximum time to wait for cluster status

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -26,7 +26,19 @@ CHECK_STATUS=0
 SLAVE_SECONDS_BEHIND=3600 #How far behind can a slave be before its put into OFFLINE_SOFT state
 CLUSTER_TIMEOUT=3 # Maximum time to wait for cluster status
 
+proxysql_exec() {
+  query=$1
+    printf "[client]\nuser=${PROXYSQL_USERNAME}\npassword=${PROXYSQL_PASSWORD}\nhost=${PROXYSQL_HOSTNAME}\nport=${PROXYSQL_PORT}\n" | \
+      mysql --defaults-file=/dev/stdin --protocol=tcp -Bse "${query}" 2>/dev/null
+}
+
 if [ $debug -eq 1 ];then echo "`date` DEBUG MODE: $MODE" >> $ERR_FILE;fi
+
+if [ $debug -eq 1 ];then echo "`date` DEBUG check mode name from proxysql data directory " >> $ERR_FILE;fi
+CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$WRITE_HOSTGROUP_ID")
+if [ -f ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode ] ; then
+  MODE=$(cat ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode)
+fi
 
 if [ "$MODE" == "loadbal" ]; then
   MODE_COMMENT="READWRITE"
@@ -46,12 +58,6 @@ check_cmd(){
       echo "`date` $ERROR_INFO." >> $ERR_FILE
     fi
   fi
-}
-
-proxysql_exec() {
-  query=$1
-    printf "[client]\nuser=${PROXYSQL_USERNAME}\npassword=${PROXYSQL_PASSWORD}\nhost=${PROXYSQL_HOSTNAME}\nport=${PROXYSQL_PORT}\n" | \
-      mysql --defaults-file=/dev/stdin --protocol=tcp -Bse "${query}" 2>/dev/null
 }
 
 #Timeout exists for instances where mysqld may be hung
@@ -148,7 +154,6 @@ update_cluster(){
   if [ $debug -eq 1 ];then echo "`date` DEBUG START update_cluster" >> $ERR_FILE;fi
   current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers where hostgroup_id in ( $WRITE_HOSTGROUP_ID, $READ_HOSTGROUP_ID, $SLAVEREAD_HOSTGROUP_ID )" | sed 's|\t|:|g' | tr '\n' ' '`)
   wsrep_address=(`mysql_exec "SHOW STATUS LIKE 'wsrep_incoming_addresses'" | awk '{print $2}' | sed 's|,| |g'`)
-
   if [ ${#wsrep_address[@]} -eq 0 ]; then
     # Cluster might be down, but is there a slave to fall back to?
     slave_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers where hostgroup_id in ( $WRITE_HOSTGROUP_ID, $SLAVEREAD_HOSTGROUP_ID ) and comment = 'SLAVEREAD'" | sed 's|\t|:|g' | tr '\n' ' '`)
@@ -190,17 +195,17 @@ update_cluster(){
         set_slave_status
       else
         if [ "$ws_status" == "OFFLINE_SOFT" ]; then
-          echo "`date` Cluster node ${ws_hg_id}:${i} does not exists in cluster membership! Chaning status from OFFLINE_SOFT to OFFLINE_HARD" >> $ERR_FILE
-          proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_HARD', hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
+          echo "`date` Cluster node ${ws_hg_id}:${i} does not exists in cluster membership! Changing status from OFFLINE_SOFT to OFFLINE_HARD" >> $ERR_FILE
+          proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_HARD', hostgroup_id = $READ_HOSTGROUP_ID, comment='$MODE_COMMENT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
           check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
           CHECK_STATUS=1
         fi
         node_status=$(echo `proxysql_exec "SELECT status from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port"`)
         echo "`date` Cluster node (${ws_hg_id}:${i}) current status '$node_status' in ProxySQL database!" >> $ERR_FILE
         if [ "$MODE" == "singlewrite" ]; then
-          checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment='WRITE' and status='ONLINE'"`
+          checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment='WRITE' and status='ONLINE' and hostgroup_id in ($WRITE_HOSTGROUP_ID)"`
           if [[ -z "$checkwriter_hid" ]]; then
-            current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ'  ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+            current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ' and hostgroup_id='$READ_HOSTGROUP_ID' ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
             ws_ip=$(echo $current_hosts | cut -d':' -f1)
             ws_port=$(echo $current_hosts | cut -d':' -f2)
             echo "`date` No writer found, promoting $ws_ip:$ws_port as writer node!" >> $ERR_FILE
@@ -250,12 +255,12 @@ mode_change_check(){
   #
 
   # Check if the current writer is in an OFFLINE_SOFT state
-  checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment in ('WRITE', 'READWRITE') and status='OFFLINE_SOFT'"`
+  checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment in ('WRITE', 'READWRITE') and status='OFFLINE_SOFT' and hostgroup_id in ($WRITE_HOSTGROUP_ID)"`
   if [[ -n "$checkwriter_hid" ]]; then
     # Found a writer node that was in 'OFFLINE_SOFT' state, move it to the READ hostgroup unless the MODE is 'loadbal'
     if [ "$MODE" != "loadbal" ];then
       if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check: Found OFFLINE_SOFT writer, changing to READ status and hostgroup $READ_HOSTGROUP_ID" >> $ERR_FILE;fi
-      proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE comment='WRITE' and status='OFFLINE_SOFT'"
+      proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE comment='WRITE' and status='OFFLINE_SOFT' and hostgroup_id='$WRITE_HOSTGROUP_ID'"
       check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
       CHECK_STATUS=1
     fi
@@ -264,10 +269,10 @@ mode_change_check(){
     unset current_hosts
     if [ -z $priority_hosts ];then
       # Order file wasn't found, behave as before
-      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment in ('READ', 'READWRITE') ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment in ('READ', 'READWRITE') and hostgroup_id='$READ_HOSTGROUP_ID' ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
     else
       # Get the list of all ONLINE reader nodes in ProxySQL
-      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='READ'" | sed 's|\t|:|g' | tr '\n' ' '`)
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='READ' and hostgroup_id='$READ_HOSTGROUP_ID' " | sed 's|\t|:|g' | tr '\n' ' '`)
 
       # Find the highest priority host from the online reader hosts
       for i in "${priority_hosts[@]}"; do
@@ -352,7 +357,7 @@ mode_change_check(){
     else
       # Check here if the highest priority node is the writer
       # Get the list of all ONLINE nodes in ProxySQL, can't use available_cluster_hosts here
-      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' AND comment<>'SLAVEREAD'" | sed 's|\t|:|g' | tr '\n' ' '`)
+      current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and hostgroup_id in($READ_HOSTGROUP_ID,$WRITE_HOSTGROUP_ID) AND comment<>'SLAVEREAD'" | sed 's|\t|:|g' | tr '\n' ' '`)
 
       # Find the highest priority host from the online hosts
       for i in "${priority_hosts[@]}"; do


### PR DESCRIPTION
Now, proxysql-admin can configure multiple clusters in proxysql.
Pre-requisites to configure multiple clusters in proxysql.
- Cluster name (wsrep_cluster_name) should be unique.
- proxysql-admin.cnf configuration differences
  - ProxySQL READ/WRITE hostgroup should be different for each cluster.
  - Application user should be different for each cluster.

PS : Host priority feature support only one cluster at a time.
