### PR TITLE
PQA-234 : Add more testcases in proxysql-admin test-suite

### DIFF
--- a/tests/generic-test.bats
+++ b/tests/generic-test.bats
@@ -97,8 +97,21 @@ echo "$output"
         [ "$status" -eq 1 ]
 }
 
+@test "run proxysql-admin --mode check wrong option" {
+run sudo proxysql-admin --mode=foo
+echo "$output"
+        [ "$status" -eq 1 ]
+		[ "${lines[0]}" == "ERROR: Invalid --mode passed:" ]
+}
+
 @test "run proxysql-admin --write-node without parameters" {
 run sudo proxysql-admin --write-node
 echo "$output"
         [ "$status" -eq 1 ]
+}
+
+@test "run proxysql-admin --version check" {
+  admin_version=$(sudo proxysql-admin -v | grep -oe "1\.[0-9]\.[0-9]")
+  proxysql_version=$(sudo proxysql --help | grep -oe '1\.[0-9]\.[0-9]')
+ [ "${proxysql_version}" = "${admin_version}" ]
 }

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -1,5 +1,29 @@
 ## proxysql-admin setup tests
 source /etc/proxysql-admin.cnf
+CLUSTER_ONE_PORT=$(${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/cluster_one1.sock -Bse"select @@port")
+CLUSTER_TWO_PORT=$(${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/cluster_two1.sock -Bse"select @@port")
+
+sed -i "0,/^[ \t]*export CLUSTER_PORT[ \t]*=.*$/s|^[ \t]*export CLUSTER_PORT[ \t]*=.*$|export CLUSTER_PORT=\"$CLUSTER_ONE_PORT\"|" /etc/proxysql-admin.cnf
+sed -i "0,/^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$/s|^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$|export CLUSTER_APP_USERNAME=\"cluster_one\"|" /etc/proxysql-admin.cnf
+sed -i "0,/^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$|export WRITE_HOSTGROUP_ID=\"10\"|" /etc/proxysql-admin.cnf
+sed -i "0,/^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$|export READ_HOSTGROUP_ID=\"11\"|" /etc/proxysql-admin.cnf
+
+@test "run proxysql-admin -d" {
+run sudo proxysql-admin -d
+echo "$output"
+    [ "$status" -eq  0 ]
+}
+
+@test "run proxysql-admin -e" {
+run sudo proxysql-admin -e <<< 'n'
+echo "$output"
+    [ "$status" -eq  0 ]
+}
+
+sed -i "0,/^[ \t]*export CLUSTER_PORT[ \t]*=.*$/s|^[ \t]*export CLUSTER_PORT[ \t]*=.*$|export CLUSTER_PORT=\"$CLUSTER_TWO_PORT\"|" /etc/proxysql-admin.cnf
+sed -i "0,/^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$/s|^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$|export CLUSTER_APP_USERNAME=\"cluster_two\"|" /etc/proxysql-admin.cnf
+sed -i "0,/^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$|export WRITE_HOSTGROUP_ID=\"20\"|" /etc/proxysql-admin.cnf
+sed -i "0,/^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$|export READ_HOSTGROUP_ID=\"21\"|" /etc/proxysql-admin.cnf
 
 @test "run proxysql-admin -d" {
 run sudo proxysql-admin -d

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -1,89 +1,51 @@
 ## proxysql-admin setup tests
-CLUSTER_ONE_PORT=$(${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/cluster_one1.sock -Bse"select @@port")
-CLUSTER_TWO_PORT=$(${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/cluster_two1.sock -Bse"select @@port")
-
-sed -i "0,/^[ \t]*export CLUSTER_PORT[ \t]*=.*$/s|^[ \t]*export CLUSTER_PORT[ \t]*=.*$|export CLUSTER_PORT=\"$CLUSTER_ONE_PORT\"|" /etc/proxysql-admin.cnf
-sed -i "0,/^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$/s|^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$|export CLUSTER_APP_USERNAME=\"cluster_one\"|" /etc/proxysql-admin.cnf
-sed -i "0,/^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$|export WRITE_HOSTGROUP_ID=\"10\"|" /etc/proxysql-admin.cnf
-sed -i "0,/^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$|export READ_HOSTGROUP_ID=\"11\"|" /etc/proxysql-admin.cnf
 source /etc/proxysql-admin.cnf
+wsrep_cluster_name=$(mysql --user=$CLUSTER_USERNAME --password=$CLUSTER_PASSWORD  --host=$CLUSTER_HOSTNAME --port=$CLUSTER_PORT --protocol=tcp -Bse"select @@wsrep_cluster_name" 2> /dev/null)
 
-@test "run proxysql-admin -d" {
+@test "run proxysql-admin -d (cluster name : $wsrep_cluster_name)" {
 run sudo proxysql-admin -d
 echo "$output"
     [ "$status" -eq  0 ]
 }
 
-@test "run proxysql-admin -e for cluster one" {
+@test "run proxysql-admin -e (cluster name : $wsrep_cluster_name)" {
 run sudo proxysql-admin -e <<< 'n'
 echo "$output"
     [ "$status" -eq  0 ]
 }
 
-@test "run the check for cluster size (cluster one)" {
+@test "run the check for cluster size (cluster name : $wsrep_cluster_name)" {
   #get values from PXC and ProxySQL side
   wsrep_cluster_count=$(mysql --user=$CLUSTER_APP_USERNAME --password=$CLUSTER_APP_PASSWORD  --host=$CLUSTER_HOSTNAME --port=6033 --protocol=tcp -Bse"show status like 'wsrep_cluster_size'" | awk '{print $2}')
   proxysql_cluster_count=$(mysql --user=$PROXYSQL_USERNAME --password=$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select count(*) from mysql_servers where hostgroup_id in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID) " | awk '{print $0}')
   [ "$wsrep_cluster_count" -eq "$proxysql_cluster_count" ]
 }
 
-@test "run the check for --node-check-interval (cluster one)" {
+@test "run the check for --node-check-interval (cluster name : $wsrep_cluster_name)" {
   wsrep_cluster_name=$(mysql --user=$CLUSTER_APP_USERNAME --password=$CLUSTER_APP_PASSWORD  --host=$CLUSTER_HOSTNAME --port=6033 --protocol=tcp -Bse"select @@wsrep_cluster_name")
   report_interval=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD  --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse"select interval_ms from scheduler where comment='$wsrep_cluster_name'" | awk '{print $0}')
   [ "$report_interval" -eq 3000 ]
 }
 
-sed -i "0,/^[ \t]*export CLUSTER_PORT[ \t]*=.*$/s|^[ \t]*export CLUSTER_PORT[ \t]*=.*$|export CLUSTER_PORT=\"$CLUSTER_TWO_PORT\"|" /etc/proxysql-admin.cnf
-sed -i "0,/^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$/s|^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$|export CLUSTER_APP_USERNAME=\"cluster_two\"|" /etc/proxysql-admin.cnf
-sed -i "0,/^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$|export WRITE_HOSTGROUP_ID=\"20\"|" /etc/proxysql-admin.cnf
-sed -i "0,/^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$|export READ_HOSTGROUP_ID=\"21\"|" /etc/proxysql-admin.cnf
-
-source /etc/proxysql-admin.cnf
-
-@test "run proxysql-admin -d" {
-run sudo proxysql-admin -d
-echo "$output"
-    [ "$status" -eq  0 ]
-}
-
-@test "run proxysql-admin -e for cluster two" {
-run sudo proxysql-admin -e <<< 'n'
-echo "$output"
-    [ "$status" -eq  0 ]
-}
-
-@test "run the check for cluster size (cluster two)" {
-  #get values from PXC and ProxySQL side
-  wsrep_cluster_count=$(mysql --user=$CLUSTER_APP_USERNAME --password=$CLUSTER_APP_PASSWORD  --host=$CLUSTER_HOSTNAME --port=6033 --protocol=tcp -Bse"show status like 'wsrep_cluster_size'" | awk '{print $2}')
-  proxysql_cluster_count=$(mysql --user=$PROXYSQL_USERNAME --password=$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select count(*) from mysql_servers where hostgroup_id in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID)" | awk '{print $0}')
-  [ "$wsrep_cluster_count" -eq "$proxysql_cluster_count" ]
-}
-
-@test "run the check for --node-check-interval (cluster two)" {
-  wsrep_cluster_name=$(mysql --user=$CLUSTER_APP_USERNAME --password=$CLUSTER_APP_PASSWORD  --host=$CLUSTER_HOSTNAME --port=6033 --protocol=tcp -Bse"select @@wsrep_cluster_name")
-  report_interval=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD  --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse"select interval_ms from scheduler where comment='$wsrep_cluster_name'" | awk '{print $0}')
-  [ "$report_interval" -eq 3000 ]
-}
-
-@test "run the check for --adduser" {
+@test "run the check for --adduser (cluster name : $wsrep_cluster_name)" {
   run_add_command=$(printf "proxysql_test_user1\ntest_user\ny" | sudo proxysql-admin --adduser)
   run_check_user_command=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD  --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select 1 from mysql_users where username='proxysql_test_user1'" | awk '{print $0}')
   [ "$run_check_user_command" -eq 1 ]
 }
 
-@test "run proxysql-admin --syncusers" {
+@test "run proxysql-admin --syncusers (cluster name : $wsrep_cluster_name)" {
 run sudo proxysql-admin --syncusers
 echo "$output"
     [ "$status" -eq  0 ]
 }
 
-@test "run the check for --syncusers" {
+@test "run the check for --syncusers (cluster name : $wsrep_cluster_name)" {
   cluster_user_count=$(mysql --user=$CLUSTER_USERNAME --password=$CLUSTER_PASSWORD  --host=$CLUSTER_HOSTNAME --port=$CLUSTER_PORT --protocol=tcp -Bse"select count(*) from mysql.user where authentication_string!='' and user not in ('admin','mysql.sys')" | awk '{print $1}')
   proxysql_user_count=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD  --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select count(*) from mysql_users" | awk '{print $0}')
   [ "$cluster_user_count" -eq "$proxysql_user_count" ]
 }
 
-@test "run the check for updating runtime_mysql_servers table" {
+@test "run the check for updating runtime_mysql_servers table (cluster name : $wsrep_cluster_name)" {
   # check initial writer info
   first_writer_port=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select port from mysql_servers where hostgroup_id='$WRITE_HOSTGROUP_ID';" 2>/dev/null)
   first_writer_status=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select status from mysql_servers where hostgroup_id='$WRITE_HOSTGROUP_ID';" 2>/dev/null)
@@ -96,8 +58,8 @@ echo "$output"
   [ "$first_writer_comment" = "WRITE" ]
 
   # check that the tables are equal at start
-  mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from mysql_servers order by port;" 2>/dev/null)
-  runtime_mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from runtime_mysql_servers order by port;" 2>/dev/null)
+  mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from mysql_servers where hostgroup_id in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID) order by port;" 2>/dev/null)
+  runtime_mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from runtime_mysql_servers where hostgroup_id in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID) order by port;" 2>/dev/null)
   [ "$(echo \"$mysql_servers\"|md5sum)" = "$(echo \"$runtime_mysql_servers\"|md5sum)" ]
 
   # shutdown writer
@@ -105,7 +67,7 @@ echo "$output"
   pxc_socket=$(ps aux|grep "mysqld"|grep "port=$first_writer_port"|sed 's:^.* /:/:'|grep -o "\-\-socket=.* ")
   $pxc_bindir/mysqladmin $pxc_socket -u root shutdown
   sleep 3
-  nr_nodes=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select count(*) from mysql_servers where status='ONLINE';" 2>/dev/null)
+  nr_nodes=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select count(*) from mysql_servers where status='ONLINE' and hostgroup_id in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID);" 2>/dev/null)
   [ "$nr_nodes" = "2" ]
 
   # check new writer info
@@ -118,20 +80,20 @@ echo "$output"
 
   # bring the node up
   first_writer_start_cmd=$(echo $first_writer_start_cmd|sed 's:--wsrep_cluster_address.*--wsrep_provider_options:--wsrep_provider_options:')
-  cluster_address=$(ps aux|grep mysqld|grep -o "\-\-wsrep_cluster_address=gcomm.* --wsrep_provider_options"|sort|head -n1|grep -o ",gcomm.*,"|sed 's/^,//'|sed 's/,$//')
+  cluster_address=$(ps aux|grep mysqld | grep $wsrep_cluster_name | grep -o "\-\-wsrep_cluster_address=gcomm.* --wsrep_provider_options"|sort|head -n1|grep -o ",gcomm.*,"|sed 's/^,//'|sed 's/,$//')
   first_writer_start_cmd="$first_writer_start_cmd --wsrep_cluster_address=$cluster_address"
   nohup $first_writer_start_cmd --user=$first_writer_start_user 3>- &
-  sleep 10
-  nr_nodes=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select count(*) from mysql_servers where status='ONLINE';" 2>/dev/null)
+  sleep 15
+  nr_nodes=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select count(*) from mysql_servers where status='ONLINE' and hostgroup_id in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID);" 2>/dev/null)
   [ "$nr_nodes" = "3" ]
 
   # check that the tables are equal at end
-  mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from mysql_servers order by port;" 2>/dev/null)
-  runtime_mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from runtime_mysql_servers order by port;" 2>/dev/null)
+  mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from mysql_servers where hostgroup_id in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID) order by port;" 2>/dev/null)
+  runtime_mysql_servers=$(mysql --user=$PROXYSQL_USERNAME -p$PROXYSQL_PASSWORD --host=$PROXYSQL_HOSTNAME --port=$PROXYSQL_PORT --protocol=tcp -Bse "select * from runtime_mysql_servers where hostgroup_id in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID) order by port;" 2>/dev/null)
   [ "$(echo \"$mysql_servers\"|md5sum)" = "$(echo \"$runtime_mysql_servers\"|md5sum)" ]
 }
 
-@test "run the check for --test-run" {
+@test "run the check for --test-run (cluster name : $wsrep_cluster_name)" {
   run sudo proxysql-admin  --enable --quick-demo <<< n
   echo "$output"
     [ "$status" -eq 1 ]

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -20,6 +20,7 @@ RBASE="$(( RPORT*1000 ))"
 ADDR="127.0.0.1"
 SUSER=root
 SPASS=
+OS_USER=$(whoami)
 
 if [ -z $WORKDIR ];then
   WORKDIR="${PWD}"
@@ -132,6 +133,7 @@ ${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/node1.sock -e"GRANT ALL ON *.* TO admin@'
 sed -i "s/3306/${BASEPORT}/" $PROXYSQL_BASE/etc/proxysql-admin.cnf
 sed -i "s|\/var\/lib\/proxysql|$PROXYSQL_BASE|" $PROXYSQL_BASE/etc/proxysql-admin.cnf
 sudo cp $PROXYSQL_BASE/etc/proxysql-admin.cnf /etc/proxysql-admin.cnf
+sudo chown $OS_USER:$OS_USER /etc/proxysql-admin.cnf
 sudo cp $PROXYSQL_BASE/usr/bin/* /usr/bin/
  
 if [[ ! -e $(which bats 2> /dev/null) ]] ;then

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -75,6 +75,7 @@ start_pxc_node(){
   RPORT=$(( RANDOM%21 + 10 ))
   RBASE="$(( RPORT*1000 ))"
   ADDR="127.0.0.1"
+  WSREP_CLUSTER_NAME="--wsrep_cluster_name=$CLUSTER_NAME"
   # Creating default my.cnf file
   cd $PXC_BASEDIR
   echo "[mysqld]" > my.cnf
@@ -114,7 +115,7 @@ start_pxc_node(){
     fi
 
     ${PXC_BASEDIR}/bin/mysqld --defaults-file=${PXC_BASEDIR}/my.cnf \
-      --datadir=$node $WSREP_CLUSTER_ADD \
+      --datadir=$node $WSREP_CLUSTER_ADD $WSREP_CLUSTER_NAME \
       --wsrep_provider_options=gmcast.listen_addr=tcp://$LADDR1 \
       --log-error=$WORKDIR/logs/${CLUSTER_NAME}${i}.err \
       --socket=/tmp/${CLUSTER_NAME}${i}.sock --port=$RBASE1 > $WORKDIR/logs/${CLUSTER_NAME}${i}.err 2>&1 &
@@ -129,6 +130,8 @@ start_pxc_node(){
 }
 
 start_pxc_node cluster_one
+WSREP_CLUSTER=""
+NODES=0
 start_pxc_node cluster_two
 
 ${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/cluster_one1.sock -e"GRANT ALL ON *.* TO admin@'%' identified by 'admin';flush privileges;"
@@ -149,11 +152,12 @@ fi
 echo "proxysql-admin generic bats test log"
 sudo TERM=xterm bats $SCRIPT_PWD/generic-test.bats 
 echo "proxysql-admin testsuite bats test log"
-sudo TERM=xterm bats $SCRIPT_PWD/proxysql-admin-testsuite.bats 
-
+#sudo TERM=xterm bats $SCRIPT_PWD/proxysql-admin-testsuite.bats 
+'
 ${PXC_BASEDIR}/bin/mysqladmin  --socket=/tmp/cluster_one1.sock  -u root shutdown
 ${PXC_BASEDIR}/bin/mysqladmin  --socket=/tmp/cluster_one2.sock  -u root shutdown
 ${PXC_BASEDIR}/bin/mysqladmin  --socket=/tmp/cluster_one3.sock  -u root shutdown
 ${PXC_BASEDIR}/bin/mysqladmin  --socket=/tmp/cluster_two1.sock  -u root shutdown
 ${PXC_BASEDIR}/bin/mysqladmin  --socket=/tmp/cluster_two2.sock  -u root shutdown
 ${PXC_BASEDIR}/bin/mysqladmin  --socket=/tmp/cluster_two3.sock  -u root shutdown
+'


### PR DESCRIPTION
```
proxysql-admin generic bats test log
 ✓ run proxysql-admin under root privileges
 ✓ run proxysql-admin without any arguments
 ✓ run proxysql-admin --help
 ✓ run proxysql-admin with wrong option
 ✓ run proxysql-admin --config-file without parameters
 ✓ run proxysql-admin check default configuration file
 ✓ run proxysql-admin --proxysql-username without parameters
 ✓ run proxysql-admin --proxysql-port without parameters
 ✓ run proxysql-admin --proxysql-hostname without parameters
 ✓ run proxysql-admin --cluster-username without parameters
 ✓ run proxysql-admin --cluster-port without parameters
 ✓ run proxysql-admin --cluster-hostname without parameters
 ✓ run proxysql-admin --cluster-app-username without parameters
 ✓ run proxysql-admin --monitor-username without parameters
 ✓ run proxysql-admin --mode without parameters
 ✓ run proxysql-admin --mode check wrong option
 ✓ run proxysql-admin --write-node without parameters
 ✓ run proxysql-admin --version check

18 tests, 0 failures
proxysql-admin testsuite bats test log for custer_one
 ✓ run proxysql-admin -d (cluster name : cluster_one)
 ✓ run proxysql-admin -e (cluster name : cluster_one)
 ✓ run the check for cluster size (cluster name : cluster_one)
 ✓ run the check for --node-check-interval (cluster name : cluster_one)
 ✓ run the check for --adduser (cluster name : cluster_one)
 ✓ run proxysql-admin --syncusers (cluster name : cluster_one)
 ✓ run the check for --syncusers (cluster name : cluster_one)
 ✓ run the check for updating runtime_mysql_servers table (cluster name : cluster_one)
 ✓ run the check for --test-run (cluster name : cluster_one)

9 tests, 0 failures
proxysql-admin testsuite bats test log for custer_two
 ✓ run proxysql-admin -d (cluster name : cluster_two)
 ✓ run proxysql-admin -e (cluster name : cluster_two)
 ✓ run the check for cluster size (cluster name : cluster_two)
 ✓ run the check for --node-check-interval (cluster name : cluster_two)
 ✓ run the check for --adduser (cluster name : cluster_two)
 ✓ run proxysql-admin --syncusers (cluster name : cluster_two)
 ✓ run the check for --syncusers (cluster name : cluster_two)
 ✓ run the check for updating runtime_mysql_servers table (cluster name : cluster_two)
 ✓ run the check for --test-run (cluster name : cluster_two)

9 tests, 0 failures
```
