### PR TITLE
V1.4.7 dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ This script will accept two different options to configure Cluster nodes
  ___scheduler___ script info :
   * __proxysql_galera_checker__ : will check desynced nodes, and temporarily deactivate them. This will also call __proxysql_node_monitor__ script to check cluster node membership, and re-configure ProxySQL if cluster membership changes occur
 
+```
+Note:
+         As proxysql_galera_check runs in regular intervals, there is the possibility of a race 
+      condition in certain circumstances, for example starting this script twice or more at the 
+      same time. To avoid such situations from occuring, a Galera process identifier check file
+      was added, which will prevent duplicate  script execution in most cases. Still, it may be 
+      possible in some rare cases to circumvent this check if you execute more then one copy of 
+      proxysql_galera_check  simultaneously.  Please  note that  running  more then one copy of 
+      proxysql_galera_check in the same runtime environment at the same  time is not supported,
+      and may lead to undefined behavior.
+```
   It will also add two new users into the Percona XtraDB Cluster with the USAGE privilege; one is for monitoring cluster nodes through ProxySQL, and another is for connecting to Cluster node via the ProxySQL console. 
   
   Note: Please make sure to use super user credentials from Percona XtraDB Cluster to setup the default users.

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -249,7 +249,7 @@ do
     ENABLE=1
     ;;
     -v | --version )
-      echo "proxysql-admin version 1.4.6"
+      echo "proxysql-admin version 1.4.7"
       exit 0
     ;;
     --help )

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -76,6 +76,38 @@ proxysql_exec() {
 CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$HOSTGROUP_WRITER_ID")
 RELOAD_CHECK_FILE="${PROXYSQL_DATADIR}/${CLUSTER_NAME}_reload"
 
+# WIth thanks, http://bencane.com/2015/09/22/preventing-duplicate-cron-job-executions/
+CHECKER_PIDFILE=${PROXYSQL_DATADIR}/${CLUSTER_NAME}_galera_checker.pid
+if [ -f $CHECKER_PIDFILE ] ; then
+  GPID=$(cat $CHECKER_PIDFILE)
+  if ps -f $GPID | grep -o proxysql_galera_check > /dev/null 2>&1 ; then
+    ps -p $GPID > /dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      echoit "ProxySQL galera checker process already running."
+      exit 1
+    else
+      echo $$ > $CHECKER_PIDFILE
+      if [ $? -ne 0 ] ; then
+        echoit "Could not create galera checker PID file"
+        exit 1
+      fi
+    fi
+  else
+    echoit "Warning! Existing PID($GPID) belongs to some other process. Creating new PID file."
+    echo $$ > $CHECKER_PIDFILE
+    if [ $? -ne 0 ] ; then
+      echoit "Could not create galera checker PID file"
+      exit 1
+    fi
+  fi
+else
+  echo $$ > $CHECKER_PIDFILE
+  if [ $? -ne 0 ]; then
+    echoit "Could not create galera checker PID file"
+    exit 1
+  fi
+fi
+
 echo "0" > ${RELOAD_CHECK_FILE}
 
 mysql_exec() {
@@ -520,4 +552,5 @@ else
     echoit "###### Not loading mysql_servers, no change needed ######"
 fi
 
+rm $CHECKER_PIDFILE
 exit 0

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -66,6 +66,9 @@ proxysql_exec() {
       "host=${PROXYSQL_HOSTNAME}" \
       "port=${PROXYSQL_PORT}"  \
       | timeout $TIMEOUT mysql --defaults-file=/dev/stdin --protocol=tcp -Nse "${query}"
+  if [ "$?" == "124" ]; then
+    echo "`date` TIMEOUT ERROR: Connection terminated due to timeout." >> $ERR_FILE
+  fi
 }
 
 CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$HOSTGROUP_WRITER_ID")
@@ -82,6 +85,9 @@ mysql_exec() {
       "host=${server}" \
       "port=${port}"  \
       | timeout $TIMEOUT mysql --defaults-file=/dev/stdin --protocol=tcp -nNE -e "${query}"
+  if [ "$?" == "124" ]; then
+    echo "`date` TIMEOUT ERROR: Connection terminated due to timeout." >> $ERR_FILE
+  fi
 }
 
 #Running proxysql_node_monitor script.

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -15,6 +15,9 @@ if [[ -z "$PROXYSQL_DATADIR" ]]; then
   PROXYSQL_DATADIR='/var/lib/proxysql'
 fi
 
+#Timeout exists for instances where mysqld/proxysql may be hung
+TIMEOUT=5
+
 function usage()
 {
   cat << EOF
@@ -62,15 +65,13 @@ proxysql_exec() {
       "password=${PROXYSQL_PASSWORD}" \
       "host=${PROXYSQL_HOSTNAME}" \
       "port=${PROXYSQL_PORT}"  \
-      | mysql --defaults-file=/dev/stdin --protocol=tcp -Nse "${query}"
+      | timeout $TIMEOUT mysql --defaults-file=/dev/stdin --protocol=tcp -Nse "${query}"
 }
 
 CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$HOSTGROUP_WRITER_ID")
 RELOAD_CHECK_FILE="${PROXYSQL_DATADIR}/${CLUSTER_NAME}_reload"
 
 echo "0" > ${RELOAD_CHECK_FILE}
-#Timeout exists for instances where mysqld may be hung
-TIMEOUT=10
 
 mysql_exec() {
   local query="$1"

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -76,11 +76,11 @@ proxysql_exec() {
 CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$HOSTGROUP_WRITER_ID")
 RELOAD_CHECK_FILE="${PROXYSQL_DATADIR}/${CLUSTER_NAME}_reload"
 
-# WIth thanks, http://bencane.com/2015/09/22/preventing-duplicate-cron-job-executions/
+# With thanks, http://bencane.com/2015/09/22/preventing-duplicate-cron-job-executions/
 CHECKER_PIDFILE=${PROXYSQL_DATADIR}/${CLUSTER_NAME}_galera_checker.pid
 if [ -f $CHECKER_PIDFILE ] ; then
   GPID=$(cat $CHECKER_PIDFILE)
-  if ps -f $GPID | grep -o proxysql_galera_check > /dev/null 2>&1 ; then
+  if ps -p $GPID -o args=ARGS | grep $ERR_FILE | grep -o proxysql_galera_check > /dev/null 2>&1 ; then
     ps -p $GPID > /dev/null 2>&1
     if [ $? -eq 0 ]; then
       echoit "ProxySQL galera checker process already running."

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -2,11 +2,13 @@
 ## inspired by Percona clustercheck.sh
 
 ERR_FILE="${5:-/dev/null}"
-
+echoit(){
+  echo "[$(date +%Y-%m-%d\ %H:%M:%S)] $1" >> $ERR_FILE
+}
 if [ -f /etc/proxysql-admin.cnf ]; then
   source /etc/proxysql-admin.cnf
 else
-  echo "Assert! proxysql-admin configuration file :/etc/proxysql-admin.cnf does not exists, Terminating!" >> $ERR_FILE
+  echo "Assert! proxysql-admin configuration file :/etc/proxysql-admin.cnf does not exists, Terminating!"
   exit 1
 fi
 #
@@ -67,7 +69,7 @@ proxysql_exec() {
       "port=${PROXYSQL_PORT}"  \
       | timeout $TIMEOUT mysql --defaults-file=/dev/stdin --protocol=tcp -Nse "${query}"
   if [ "$?" == "124" ]; then
-    echo "`date` TIMEOUT ERROR: Connection terminated due to timeout." >> $ERR_FILE
+    echoit "TIMEOUT ERROR: Connection terminated due to timeout."
   fi
 }
 
@@ -86,13 +88,13 @@ mysql_exec() {
       "port=${port}"  \
       | timeout $TIMEOUT mysql --defaults-file=/dev/stdin --protocol=tcp -nNE -e "${query}"
   if [ "$?" == "124" ]; then
-    echo "`date` TIMEOUT ERROR: Connection terminated due to timeout." >> $ERR_FILE
+    echoit "TIMEOUT ERROR: Connection terminated due to timeout."
   fi
 }
 
 #Running proxysql_node_monitor script.
 if [ ! -f /usr/bin/proxysql_node_monitor ] ;then
-  echo "`date` ERROR! Could not run /usr/bin/proxysql_node_monitor. Monitoring script does not exists in default location. Terminating" >> ${ERR_FILE}
+  echoit "ERROR! Could not run /usr/bin/proxysql_node_monitor. Monitoring script does not exists in default location. Terminating"
   exit 1
 else
   /usr/bin/proxysql_node_monitor $HOSTGROUP_WRITER_ID $HOSTGROUP_READER_ID ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_proxysql_node_monitor.log
@@ -139,12 +141,12 @@ fi
 
 
 # print information prior to a run if ${ERR_FILE} is defined
-echo "`date` ###### proxysql_galera_checker.sh SUMMARY ######" >> ${ERR_FILE}
-echo "`date` Hostgroup writers $HOSTGROUP_WRITER_ID" >> ${ERR_FILE}
-echo "`date` Hostgroup readers $HOSTGROUP_READER_ID" >> ${ERR_FILE}
-echo "`date` Number of writers $NUMBER_WRITERS" >> ${ERR_FILE}
-echo "`date` Writers are readers $WRITER_IS_READER" >> ${ERR_FILE}
-echo "`date` log file $ERR_FILE" >> ${ERR_FILE}
+echoit "###### proxysql_galera_checker.sh SUMMARY ######"
+echoit "Hostgroup writers $HOSTGROUP_WRITER_ID"
+echoit "Hostgroup readers $HOSTGROUP_READER_ID"
+echoit "Number of writers $NUMBER_WRITERS"
+echoit "Writers are readers $WRITER_IS_READER"
+echoit "log file $ERR_FILE"
 
 #Timeout exists for instances where mysqld may be hung
 TIMEOUT=10
@@ -157,26 +159,26 @@ MYSQL_PASSWORD=$(echo $MYSQL_CREDENTIALS | awk '{print $2}')
 
 
 function change_server_status() {
-  echo "`date` Changing server $1:$2:$3 to status $4. Reason: $5" >> ${ERR_FILE}
+  echoit "Changing server $1:$2:$3 to status $4. Reason: $5"
   proxysql_exec "UPDATE mysql_servers set status = '$4' WHERE hostgroup_id = $1 AND hostname = '$2' AND port = $3;" 2>> ${ERR_FILE}
 }
 
 
-echo "`date` ###### HANDLE WRITER NODES ######" >> ${ERR_FILE}
+echoit "###### HANDLE WRITER NODES ######"
 NUMBER_WRITERS_ONLINE=0
 proxysql_exec "SELECT hostgroup_id, hostname, port, status FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_WRITER_ID) AND status <> 'OFFLINE_HARD' AND comment <> 'SLAVEREAD' ORDER BY hostgroup_id, weight DESC, hostname, port" | while read hostgroup server port stat
 do
   WSREP_STATUS=$(mysql_exec "SHOW STATUS LIKE 'wsrep_local_state'" 2>>${ERR_FILE}| tail -1 2>>${ERR_FILE})
   PXC_MAIN_MODE=$(mysql_exec "SHOW VARIABLES LIKE 'pxc_maint_mode'" 2>>${ERR_FILE} | tail -1 2>>${ERR_FILE})
 
-  echo "`date` --> Checking WRITE server $hostgroup:$server:$port, current status $stat, wsrep_local_state $WSREP_STATUS" >> ${ERR_FILE}
+  echoit "--> Checking WRITE server $hostgroup:$server:$port, current status $stat, wsrep_local_state $WSREP_STATUS"
 
   # we have to limit amount of writers, WSREP status OK, AND node is not marked ONLINE
   if [ -z "$PXC_MAIN_MODE" ]; then
     if [ $NUMBER_WRITERS -gt 0 -a "${WSREP_STATUS}" = "4" -a "$stat" == "ONLINE" ] ; then
         if [ $NUMBER_WRITERS_ONLINE -lt $NUMBER_WRITERS ]; then
           NUMBER_WRITERS_ONLINE=$(( $NUMBER_WRITERS_ONLINE + 1 ))
-          echo "`date` server $hostgroup:$server:$port is already ONLINE: ${NUMBER_WRITERS_ONLINE} of ${NUMBER_WRITERS} write nodes" >> ${ERR_FILE}
+          echoit "server $hostgroup:$server:$port is already ONLINE: ${NUMBER_WRITERS_ONLINE} of ${NUMBER_WRITERS} write nodes"
         else
           NUMBER_WRITERS_ONLINE=$(( $NUMBER_WRITERS_ONLINE + 1 ))
           change_server_status $HOSTGROUP_WRITER_ID "$server" $port "OFFLINE_SOFT" "max write nodes reached (${NUMBER_WRITERS})"
@@ -187,7 +189,7 @@ do
     if [ $NUMBER_WRITERS -gt 0 -a "${WSREP_STATUS}" = "4" -a "$stat" == "ONLINE" ] ; then
         if [ $NUMBER_WRITERS_ONLINE -lt $NUMBER_WRITERS ]; then
           NUMBER_WRITERS_ONLINE=$(( $NUMBER_WRITERS_ONLINE + 1 ))
-          echo "`date` server $hostgroup:$server:$port is already ONLINE: ${NUMBER_WRITERS_ONLINE} of ${NUMBER_WRITERS} write nodes" >> ${ERR_FILE}
+          echoit "server $hostgroup:$server:$port is already ONLINE: ${NUMBER_WRITERS_ONLINE} of ${NUMBER_WRITERS} write nodes"
         else
           NUMBER_WRITERS_ONLINE=$(( $NUMBER_WRITERS_ONLINE + 1 ))
           change_server_status $HOSTGROUP_WRITER_ID "$server" $port "OFFLINE_SOFT" "max write nodes reached (${NUMBER_WRITERS})"
@@ -195,7 +197,7 @@ do
         fi
     elif [ $NUMBER_WRITERS -gt 0 -a "${WSREP_STATUS}" = "4" -a "$stat" != "ONLINE"  -a "${PXC_MAIN_MODE}" != "DISABLED" ] ; then
       NUMBER_WRITERS_ONLINE=$(( $NUMBER_WRITERS_ONLINE + 1 ))
-      echo "`date` server $hostgroup:$server:$port is $stat : ${NUMBER_WRITERS_ONLINE} of ${NUMBER_WRITERS} write nodes" >> ${ERR_FILE}
+      echoit "server $hostgroup:$server:$port is $stat : ${NUMBER_WRITERS_ONLINE} of ${NUMBER_WRITERS} write nodes"
     fi
   fi
 
@@ -214,7 +216,7 @@ do
             change_server_status $HOSTGROUP_WRITER_ID "$server" $port "OFFLINE_SOFT" "max write nodes reached (${NUMBER_WRITERS})"
             echo "1" > ${RELOAD_CHECK_FILE}
           else
-             echo "`date` server $hostgroup:$server:$port is already OFFLINE_SOFT, max write nodes reached (${NUMBER_WRITERS})" >> ${ERR_FILE}
+             echoit "server $hostgroup:$server:$port is already OFFLINE_SOFT, max write nodes reached (${NUMBER_WRITERS})"
           fi
         fi
       # we do not have to limit
@@ -237,7 +239,7 @@ do
             change_server_status $HOSTGROUP_WRITER_ID "$server" $port "OFFLINE_SOFT" "max write nodes reached (${NUMBER_WRITERS})"
             echo "1" > ${RELOAD_CHECK_FILE}
           else
-             echo "`date` server $hostgroup:$server:$port is already OFFLINE_SOFT, max write nodes reached (${NUMBER_WRITERS})" >> ${ERR_FILE}
+             echoit "server $hostgroup:$server:$port is already OFFLINE_SOFT, max write nodes reached (${NUMBER_WRITERS})"
           fi
         fi
       # we do not have to limit
@@ -253,18 +255,18 @@ do
       change_server_status $HOSTGROUP_WRITER_ID "$server" $port "OFFLINE_SOFT" "WSREP status is ${WSREP_STATUS} which is not ok"
       echo "1" > ${RELOAD_CHECK_FILE}
     elif [ "${WSREP_STATUS}" != "4" -a "$stat" = "OFFLINE_SOFT" ]; then
-      echo "`date` server $hostgroup:$server:$port is already OFFLINE_SOFT, WSREP status is ${WSREP_STATUS} which is not ok" >> ${ERR_FILE}
+      echoit "server $hostgroup:$server:$port is already OFFLINE_SOFT, WSREP status is ${WSREP_STATUS} which is not ok"
     fi
   else
     if [ "${WSREP_STATUS}" != "4" -a "$stat" = "ONLINE" ]; then
       change_server_status $HOSTGROUP_WRITER_ID "$server" $port "OFFLINE_SOFT" "WSREP status is ${WSREP_STATUS} which is not ok"
       echo "1" > ${RELOAD_CHECK_FILE}
     elif [ "${PXC_MAIN_MODE}" != "DISABLED" -a "$stat" = "ONLINE" ];then
-      echo "`date` Changing server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE" >> ${ERR_FILE}
+      echoit "Changing server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE"
       change_server_status  $HOSTGROUP_WRITER_ID "$server" $port "OFFLINE_SOFT" "Changed  server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE" 2>> ${ERR_FILE}
       echo "1" > ${RELOAD_CHECK_FILE}
     elif [ "${WSREP_STATUS}" != "4" -a "$stat" = "OFFLINE_SOFT" ]; then
-      echo "`date` server $hostgroup:$server:$port is already OFFLINE_SOFT, WSREP status is ${WSREP_STATUS} which is not ok" >> ${ERR_FILE}
+      echoit "server $hostgroup:$server:$port is already OFFLINE_SOFT, WSREP status is ${WSREP_STATUS} which is not ok"
     fi
 
   fi
@@ -277,7 +279,7 @@ NUMBER_WRITERS_ONLINE=$(proxysql_exec "SELECT count(*) FROM mysql_servers WHERE 
 NUMBER_READERS_ONLINE=0
 if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
 
-  echo "`date` ###### HANDLE READER NODES ######" >> ${ERR_FILE}
+  echoit "###### HANDLE READER NODES ######"
   if [ $WRITER_IS_READER -eq 1 ]; then
     READER_PROXYSQL_QUERY="SELECT hostgroup_id, hostname, port, status, 'NULL' FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_READER_ID) AND status <> 'OFFLINE_HARD' AND comment <> 'SLAVEREAD' ORDER BY weight DESC, hostname, port"
   elif [ $WRITER_IS_READER -eq 0 ]; then
@@ -307,14 +309,14 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
     PXC_MAIN_MODE=$(mysql_exec "SHOW VARIABLES LIKE 'pxc_maint_mode'" 2>>${ERR_FILE} | tail -1 2>>${ERR_FILE})
     WSREP_STATUS=$(mysql_exec "SHOW STATUS LIKE 'wsrep_local_state'" 2>>${ERR_FILE}| tail -1 2>>${ERR_FILE})
 
-    echo "`date` --> Checking READ server $hostgroup:$server:$port, current status $stat, wsrep_local_state $WSREP_STATUS" >> ${ERR_FILE}
+    echoit "--> Checking READ server $hostgroup:$server:$port, current status $stat, wsrep_local_state $WSREP_STATUS"
 
     if [ $WRITER_IS_READER -eq 0 -a "$writer_stat" == "ONLINE" ] ; then
 
       if [ $OFFLINE_READERS_FOUND -eq 0 ] ; then
         if [ -z "$PXC_MAIN_MODE" ]; then
           if [ "${WSREP_STATUS}" = "4" -a "$stat" == "ONLINE" ] ; then
-            echo "`date` server $hostgroup:$server:$port is already ONLINE, is also write node in ONLINE state, not enough non-ONLINE readers found" >> ${ERR_FILE}
+            echoit "server $hostgroup:$server:$port is already ONLINE, is also write node in ONLINE state, not enough non-ONLINE readers found"
           fi
           if [ "${WSREP_STATUS}" = "4" -a "$stat" != "ONLINE" ] ; then
             change_server_status $HOSTGROUP_READER_ID "$server" $port "ONLINE" "marking ONLINE write node as read ONLINE state, not enough non-ONLINE readers found"
@@ -322,13 +324,13 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
           fi
         else
           if [ "${WSREP_STATUS}" = "4" -a "$stat" == "ONLINE" -a "${PXC_MAIN_MODE}" == "DISABLED" ] ; then
-            echo "`date` server $hostgroup:$server:$port is already ONLINE, is also write node in ONLINE state, not enough non-ONLINE readers found" >> ${ERR_FILE}
+            echoit "server $hostgroup:$server:$port is already ONLINE, is also write node in ONLINE state, not enough non-ONLINE readers found"
           fi
           if [ "${WSREP_STATUS}" = "4" -a "$stat" != "ONLINE"  -a "${PXC_MAIN_MODE}" == "DISABLED" ] ; then
             change_server_status $HOSTGROUP_READER_ID "$server" $port "ONLINE" "marking ONLINE write node as read ONLINE state, not enough non-ONLINE readers found"
             echo "1" > ${RELOAD_CHECK_FILE}
           elif [ "${PXC_MAIN_MODE}" != "DISABLED" -a "$stat" = "ONLINE" ];then
-            echo "`date` Changing server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE" >> ${ERR_FILE}
+            echoit "Changing server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE"
             change_server_status  $hostgroup "$server" $port "OFFLINE_SOFT" "Changed  server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE" 2>> ${ERR_FILE}
             echo "1" > ${RELOAD_CHECK_FILE}
           fi
@@ -340,7 +342,7 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
             echo "1" > ${RELOAD_CHECK_FILE}
           fi
           if [ "${WSREP_STATUS}" = "4" -a "$stat" != "ONLINE" ] ; then
-            echo "`date` server $hostgroup:$server:$port is $stat, keeping node in $stat is a writer ONLINE and it's preferred not to have writers as readers" >> ${ERR_FILE}
+            echoit "server $hostgroup:$server:$port is $stat, keeping node in $stat is a writer ONLINE and it's preferred not to have writers as readers"
           fi
         else
           if [ "${WSREP_STATUS}" = "4" -a "$stat" == "ONLINE" -a "${PXC_MAIN_MODE}" == "DISABLED" ] ; then
@@ -348,9 +350,9 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
             echo "1" > ${RELOAD_CHECK_FILE}
           fi
           if [ "${WSREP_STATUS}" = "4" -a "$stat" != "ONLINE" -a "${PXC_MAIN_MODE}" == "DISABLED" ] ; then
-            echo "`date` server $hostgroup:$server:$port is $stat, keeping node in $stat is a writer ONLINE and it's preferred not to have writers as readers" >> ${ERR_FILE}
+            echoit "server $hostgroup:$server:$port is $stat, keeping node in $stat is a writer ONLINE and it's preferred not to have writers as readers"
           elif [ "${PXC_MAIN_MODE}" != "DISABLED" -a "$stat" = "ONLINE" ];then
-            echo "`date` Changing server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE" >> ${ERR_FILE}
+            echoit "Changing server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE"
             change_server_status  $hostgroup "$server" $port "OFFLINE_SOFT" "Changed  server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE" 2>> ${ERR_FILE}
             echo "1" > ${RELOAD_CHECK_FILE}
           fi
@@ -359,7 +361,7 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
     else
       if [ -z "$PXC_MAIN_MODE" ]; then
         if [ "${WSREP_STATUS}" = "4" -a "$stat" == "ONLINE" ] ; then
-          echo "`date` server $hostgroup:$server:$port is already ONLINE" >> ${ERR_FILE}
+          echoit "server $hostgroup:$server:$port is already ONLINE"
           OFFLINE_READERS_FOUND=$(( $OFFLINE_READERS_FOUND + 1 ))
         fi
 
@@ -371,10 +373,10 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
         fi
       else
         if [ "${WSREP_STATUS}" = "4" -a "$stat" == "ONLINE" -a "${PXC_MAIN_MODE}" == "DISABLED" ] ; then
-          echo "`date` server $hostgroup:$server:$port is already ONLINE" >> ${ERR_FILE}
+          echoit "server $hostgroup:$server:$port is already ONLINE"
           OFFLINE_READERS_FOUND=$(( $OFFLINE_READERS_FOUND + 1 ))
         elif [ "${WSREP_STATUS}" = "4" -a "$stat" != "ONLINE" -a "${PXC_MAIN_MODE}" != "DISABLED" ] ; then
-          echo "`date` server $hostgroup:$server:$port is $stat" >> ${ERR_FILE}
+          echoit "server $hostgroup:$server:$port is $stat"
           OFFLINE_READERS_FOUND=$(( $OFFLINE_READERS_FOUND + 1 ))
         fi
 
@@ -384,7 +386,7 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
           echo "1" > ${RELOAD_CHECK_FILE}
           OFFLINE_READERS_FOUND=$(( $OFFLINE_READERS_FOUND + 1 ))
         elif [ "${PXC_MAIN_MODE}" != "DISABLED" -a "$stat" = "ONLINE" ];then
-          echo "`date` Changing server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE" >> ${ERR_FILE}
+          echoit "Changing server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE"
           change_server_status  $hostgroup "$server" $port "OFFLINE_SOFT" "Changed  server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE" 2>> ${ERR_FILE}
           echo "1" > ${RELOAD_CHECK_FILE}
         fi
@@ -396,18 +398,18 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
         change_server_status $HOSTGROUP_READER_ID "$server" $port "OFFLINE_SOFT" "WSREP status is ${WSREP_STATUS} which is not ok"
         echo "1" > ${RELOAD_CHECK_FILE}
       elif [ "${WSREP_STATUS}" != "4" -a "$stat" = "OFFLINE_SOFT" ]; then
-        echo "`date` server $hostgroup:$server:$port is already OFFLINE_SOFT, WSREP status is ${WSREP_STATUS} which is not ok" >> ${ERR_FILE}
+        echoit "server $hostgroup:$server:$port is already OFFLINE_SOFT, WSREP status is ${WSREP_STATUS} which is not ok"
       fi
     else
       if [ "${WSREP_STATUS}" != "4" -a "$stat" = "ONLINE" ]; then
         change_server_status $HOSTGROUP_READER_ID "$server" $port "OFFLINE_SOFT" "WSREP status is ${WSREP_STATUS} which is not ok"
         echo "1" > ${RELOAD_CHECK_FILE}
       elif [ "${PXC_MAIN_MODE}" != "DISABLED" -a "$stat" = "ONLINE" ];then
-        echo "`date` Changing server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE" >> ${ERR_FILE}
+        echoit "Changing server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE"
         change_server_status  $HOSTGROUP_WRITER_ID "$server" $port "OFFLINE_SOFT" "Changed  server $hostgroup:$server:$port to status OFFLINE_SOFT due to $PXC_MAIN_MODE" 2>> ${ERR_FILE}
         echo "1" > ${RELOAD_CHECK_FILE}
       elif [ "${WSREP_STATUS}" != "4" -a "$stat" = "OFFLINE_SOFT" ]; then
-        echo "`date` server $hostgroup:$server:$port is already OFFLINE_SOFT, WSREP status is ${WSREP_STATUS} which is not ok" >> ${ERR_FILE}
+        echoit "server $hostgroup:$server:$port is already OFFLINE_SOFT, WSREP status is ${WSREP_STATUS} which is not ok"
       fi
     fi
   done
@@ -415,24 +417,24 @@ if [ ${HOSTGROUP_READER_ID} -ne -1 ]; then
   NUMBER_READERS_ONLINE=$(proxysql_exec "SELECT count(*) FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_READER_ID) AND status = 'ONLINE' AND comment <> 'SLAVEREAD'" 2>>${ERR_FILE}| tail -1 2>>${ERR_FILE})
 fi
 
-echo "`date` ###### SUMMARY ######" >> ${ERR_FILE}
-echo "`date` --> Number of writers that are 'ONLINE': ${NUMBER_WRITERS_ONLINE} : hostgroup: ${HOSTGROUP_WRITER_ID}" >> ${ERR_FILE}
-[ ${HOSTGROUP_READER_ID} -ne -1 ] && echo "`date` --> Number of readers that are 'ONLINE': ${NUMBER_READERS_ONLINE} : hostgroup: ${HOSTGROUP_READER_ID}" >> ${ERR_FILE}
+echoit "###### SUMMARY ######"
+echoit "--> Number of writers that are 'ONLINE': ${NUMBER_WRITERS_ONLINE} : hostgroup: ${HOSTGROUP_WRITER_ID}"
+[ ${HOSTGROUP_READER_ID} -ne -1 ] && echoit "--> Number of readers that are 'ONLINE': ${NUMBER_READERS_ONLINE} : hostgroup: ${HOSTGROUP_READER_ID}"
 
 
 cnt=0
 # We don't have any writers... alert, try to bring some online!
 # This includes bringing a DONOR online
 if [ ${NUMBER_WRITERS_ONLINE} -eq 0 ]; then
-  echo "`date` ###### TRYING TO FIX MISSING WRITERS ######"
-  echo "`date` No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)" >> ${ERR_FILE}
+  echoit "###### TRYING TO FIX MISSING WRITERS ######"
+  echoit "No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)"
   proxysql_exec "SELECT hostgroup_id, hostname, port, status FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_WRITER_ID) AND status <> 'OFFLINE_HARD' AND comment <> 'SLAVEREAD'" | while read hostgroup server port stat
   do
     safety_cnt=0
       while [ ${cnt} -le $NUMBER_WRITERS -a ${safety_cnt} -lt 5 ]
       do
         WSREP_STATUS=$(mysql_exec "SHOW STATUS LIKE 'wsrep_local_state'" 2>>${ERR_FILE} | tail -1 2>>${ERR_FILE})
-        echo "`date` Check server $hostgroup:$server:$port for only available node in DONOR state, status $stat , wsrep_local_state $WSREP_STATUS" >> ${ERR_FILE}
+        echoit "Check server $hostgroup:$server:$port for only available node in DONOR state, status $stat , wsrep_local_state $WSREP_STATUS"
         if [ "${WSREP_STATUS}" = "2" -a "$stat" != "ONLINE" ] # if we are on Donor/Desync an not online in mysql_servers -> proceed
         then
           PROXY_RUNTIME_STATUS=$(proxysql_exec "SELECT status FROM runtime_mysql_servers WHERE hostname='${server}' AND port='${port}' AND hostgroup_id='${hostgroup}'")
@@ -456,15 +458,15 @@ fi
 cnt=0
 # We don't have any readers... alert, try to bring some online!
 if [  ${HOSTGROUP_READER_ID} -ne -1 -a ${NUMBER_READERS_ONLINE} -eq 0 ]; then
-  echo "`date` ###### TRYING TO FIX MISSING READERS ######"
-  echo "`date` --> No readers found, Trying to enable last available node of the cluster (in Donor/Desync state) or pick the master" >> ${ERR_FILE}
+  echoit "###### TRYING TO FIX MISSING READERS ######"
+  echoit "--> No readers found, Trying to enable last available node of the cluster (in Donor/Desync state) or pick the master"
   proxysql_exec "SELECT hostgroup_id, hostname, port, status FROM mysql_servers WHERE hostgroup_id IN ($HOSTGROUP_READER_ID) AND status <> 'OFFLINE_HARD' AND comment <> 'SLAVEREAD'" | while read hostgroup server port stat
   do
     safety_cnt=0
       while [ ${cnt} -eq 0 -a ${safety_cnt} -lt 5 ]
       do
         WSREP_STATUS=$(mysql_exec "SHOW STATUS LIKE 'wsrep_local_state'" 2>>${ERR_FILE} | tail -1 2>>${ERR_FILE})
-        echo "`date` Check server $hostgroup:$server:$port for only available node in DONOR state, status $stat , wsrep_local_state $WSREP_STATUS" >> ${ERR_FILE}
+        echoit "Check server $hostgroup:$server:$port for only available node in DONOR state, status $stat , wsrep_local_state $WSREP_STATUS"
         if [ "${WSREP_STATUS}" = "2" -a "$stat" != "ONLINE" ];then # if we are on Donor/Desync an not online in mysql_servers -> proceed
           PROXY_RUNTIME_STATUS=$(proxysql_exec "SELECT status FROM runtime_mysql_servers WHERE hostname='${server}' AND port='${port}' AND hostgroup_id='${hostgroup}'")
           if [ "${PROXY_RUNTIME_STATUS}" != "ONLINE" ] # if we are not online in runtime_mysql_servers, proceed to change the server status and reload mysql_servers
@@ -488,13 +490,13 @@ if [  ${HOSTGROUP_READER_ID} -ne -1 -a ${NUMBER_READERS_ONLINE} -eq 0 ]; then
       if [[ ${IS_QUERY_RULE_ACTIVE} -eq 1 ]]; then
         proxysql_exec "UPDATE mysql_query_rules SET active=0 WHERE destination_hostgroup=$HOSTGROUP_READER_ID;" 2>> ${ERR_FILE}
         proxysql_exec "LOAD MYSQL QUERY RULES TO RUNTIME;" 2>> ${ERR_FILE}
-        echo "`date` No readers found, marking single writer node as read/write mode" >> ${ERR_FILE}
+        echoit "No readers found, marking single writer node as read/write mode"
       fi
     else
       if [[ ${IS_QUERY_RULE_ACTIVE} -eq 0 ]]; then
         proxysql_exec "UPDATE mysql_query_rules SET active=1 WHERE destination_hostgroup=$HOSTGROUP_READER_ID;" 2>> ${ERR_FILE}
         proxysql_exec "LOAD MYSQL QUERY RULES TO RUNTIME;" 2>> ${ERR_FILE}
-        echo "`date` Slave host is online, disabling read transaction from writer node" >> ${ERR_FILE}
+        echoit "Slave host is online, disabling read transaction from writer node"
       fi
     fi
   fi
@@ -506,16 +508,16 @@ if [ "$MODE" == "singlewrite" ]; then
     if [[ ${IS_QUERY_RULE_ACTIVE} -eq 0 ]]; then
       proxysql_exec "UPDATE mysql_query_rules SET active=1 WHERE destination_hostgroup=$HOSTGROUP_READER_ID;" 2>> ${ERR_FILE}
       proxysql_exec "LOAD MYSQL QUERY RULES TO RUNTIME;" 2>> ${ERR_FILE}
-      echo "`date` Found reader, disabling read transaction from writer node" >> ${ERR_FILE}
+      echoit "Found reader, disabling read transaction from writer node"
     fi
   fi
 fi
 
 if [ $(cat ${RELOAD_CHECK_FILE})  -ne 0 ] ; then
-    echo "`date` ###### Loading mysql_servers config into runtime ######" >> ${ERR_FILE}
+    echoit "###### Loading mysql_servers config into runtime ######"
     proxysql_exec "LOAD MYSQL SERVERS TO RUNTIME;" 2>> ${ERR_FILE}
 else
-    echo "`date` ###### Not loading mysql_servers, no change needed ######" >> ${ERR_FILE}
+    echoit "###### Not loading mysql_servers, no change needed ######"
 fi
 
 exit 0

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -43,6 +43,7 @@ if [ $debug -eq 1 ];then echoit "DEBUG MODE: $MODE" ;fi
 
 if [ $debug -eq 1 ];then echoit "DEBUG check mode name from proxysql data directory " ;fi
 CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$WRITE_HOSTGROUP_ID")
+
 if [ -f ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode ] ; then
   MODE=$(cat ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode)
 fi

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -56,6 +56,9 @@ check_cmd(){
   MPID=$1
   ERROR_MSG=$2
   ERROR_INFO=$3
+  if [ "$MPID" == "124" ]; then
+    echo "`date` TIMEOUT ERROR: Connection terminated due to timeout." >> $ERR_FILE
+  fi
   if [ ${MPID} -ne 0 ]; then 
     echo "`date` WARNING: $ERROR_MSG." >> $ERR_FILE
     if [[ ! -z  $ERROR_INFO ]]; then

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -16,6 +16,9 @@ if [[ -z "$PROXYSQL_DATADIR" ]]; then
   PROXYSQL_DATADIR='/var/lib/proxysql'
 fi
 
+#Timeout exists for instances where mysqld/proxysql may be hung
+TIMEOUT=5
+
 WRITE_HOSTGROUP_ID="${1:-0}"
 READ_HOSTGROUP_ID="${2:-0}"
 SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
@@ -30,7 +33,7 @@ CLUSTER_TIMEOUT=3 # Maximum time to wait for cluster status
 proxysql_exec() {
   query=$1
     printf "[client]\nuser=${PROXYSQL_USERNAME}\npassword=${PROXYSQL_PASSWORD}\nhost=${PROXYSQL_HOSTNAME}\nport=${PROXYSQL_PORT}\n" | \
-      mysql --defaults-file=/dev/stdin --protocol=tcp -Bse "${query}" 2>/dev/null
+     timeout $TIMEOUT mysql --defaults-file=/dev/stdin --protocol=tcp -Bse "${query}" 2>/dev/null
 }
 
 if [ $debug -eq 1 ];then echo "`date` DEBUG MODE: $MODE" >> $ERR_FILE;fi
@@ -60,9 +63,6 @@ check_cmd(){
     fi
   fi
 }
-
-#Timeout exists for instances where mysqld may be hung
-TIMEOUT=10
 
 mysql_exec() {
   query=$1

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -5,10 +5,13 @@
 debug=0
 
 ERR_FILE="${3:-/dev/null}"
+echoit(){
+  echo "[$(date +%Y-%m-%d\ %H:%M:%S)] $1" >> $ERR_FILE
+}
 if [ -f /etc/proxysql-admin.cnf ]; then
   source /etc/proxysql-admin.cnf
 else
-  echo "`date` Assert! proxysql-admin configuration file :/etc/proxysql-admin.cnf does not exists, Terminating!" >> $ERR_FILE
+  echoit "Assert! proxysql-admin configuration file :/etc/proxysql-admin.cnf does not exists, Terminating!" 
   exit 1
 fi
 
@@ -36,9 +39,9 @@ proxysql_exec() {
      timeout $TIMEOUT mysql --defaults-file=/dev/stdin --protocol=tcp -Bse "${query}" 2>/dev/null
 }
 
-if [ $debug -eq 1 ];then echo "`date` DEBUG MODE: $MODE" >> $ERR_FILE;fi
+if [ $debug -eq 1 ];then echoit "DEBUG MODE: $MODE" ;fi
 
-if [ $debug -eq 1 ];then echo "`date` DEBUG check mode name from proxysql data directory " >> $ERR_FILE;fi
+if [ $debug -eq 1 ];then echoit "DEBUG check mode name from proxysql data directory " ;fi
 CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$WRITE_HOSTGROUP_ID")
 if [ -f ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode ] ; then
   MODE=$(cat ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode)
@@ -57,12 +60,12 @@ check_cmd(){
   ERROR_MSG=$2
   ERROR_INFO=$3
   if [ "$MPID" == "124" ]; then
-    echo "`date` TIMEOUT ERROR: Connection terminated due to timeout." >> $ERR_FILE
+    echoit "TIMEOUT ERROR: Connection terminated due to timeout." 
   fi
   if [ ${MPID} -ne 0 ]; then 
-    echo "`date` WARNING: $ERROR_MSG." >> $ERR_FILE
+    echoit "WARNING: $ERROR_MSG." 
     if [[ ! -z  $ERROR_INFO ]]; then
-      echo "`date` $ERROR_INFO." >> $ERR_FILE
+      echoit "$ERROR_INFO." 
     fi
   fi
 }
@@ -76,7 +79,7 @@ mysql_exec() {
 set_slave_status() {
   # This function checks the status of slave machines and sets their status field
   # The ws_ip and ws_port variables are used and must be set before calling this function
-  if [ $debug -eq 1 ];then echo "`date` DEBUG START set_slave_status" >> $ERR_FILE;fi
+  if [ $debug -eq 1 ];then echoit "DEBUG START set_slave_status" ;fi
   # This function will get and return a status of a slave node, 4=GOOD, 2=BEHIND, 0=OTHER
   SLAVE_STATUS=$(printf "[client]\nuser=${CLUSTER_USERNAME}\npassword=${CLUSTER_PASSWORD}\nhost=${ws_ip}\nport=${ws_port}\n" | timeout $TIMEOUT mysql --defaults-file=/dev/stdin --protocol=tcp -Bse 'SHOW SLAVE STATUS\G' 2>${PROXYSQL_DATADIR}/proxysql_admin_error_info)
   check_cmd $? "Cannot get status from the slave $ws_ip:$ws_port, Please check cluster login credentials" "`cat ${PROXYSQL_DATADIR}/proxysql_admin_error_info`"
@@ -84,11 +87,11 @@ set_slave_status() {
   echo "$SLAVE_STATUS" | grep "^Master_Host:" >/dev/null
   if [ $? -ne 0 ];then
     # No status was found, this is not replicating
-    if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: No slave status found, setting to OFFLINE_HARD, status was: $ws_status" >> $ERR_FILE;fi
+    if [ $debug -eq 1 ];then echoit "DEBUG set_slave_status: No slave status found, setting to OFFLINE_HARD, status was: $ws_status" ;fi
     # Only changing the status here as another node might be in the writer hostgroup
     proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_HARD', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
     check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql admin credentials" 
-    echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_HARD status to ProxySQL database." >> $ERR_FILE
+    echoit "${ws_hg_id}:${i} Slave node set to OFFLINE_HARD status to ProxySQL database." 
   else
     slave_master_host=$(echo "$SLAVE_STATUS" | grep "^Master_Host:" | cut -d: -f2)
     slave_io_running=$(echo "$SLAVE_STATUS" | grep "^Slave_IO_Running:" | cut -d: -f2)
@@ -101,91 +104,91 @@ set_slave_status() {
     if [ "$slave_io_running" != "Yes" ] && [ "$slave_sql_running" == "Yes" ];then
       # Cannot connect to the master
       if [ "$ws_status" == "ONLINE" ];then
-        echo "`date` Slave node (${ws_hg_id}:${i}) This slave cannot connect to it's master: $slave_master_host" >> $ERR_FILE
+        echoit "Slave node (${ws_hg_id}:${i}) This slave cannot connect to it's master: $slave_master_host" 
         if [ -z "$CLUSTER_OFFLINE" ];then
           # The cluster is up so this slave should go to OFFLINE_SOFT state
           proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, status = 'OFFLINE_SOFT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
           check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
-          echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_SOFT status to ProxySQL database." >> $ERR_FILE
+          echoit "${ws_hg_id}:${i} Slave node set to OFFLINE_SOFT status to ProxySQL database." 
         fi
       else
         if [ -n "$CLUSTER_OFFLINE" ];then
           # The slave is not currently online and cannot connect to its master, but we are here because all cluster nodes are down so put the slave ONLINE
-          if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Forcing slave $ws_ip:$ws_port ONLINE because cluster is offline" >> $ERR_FILE;fi
+          if [ $debug -eq 1 ];then echoit "DEBUG set_slave_status: Forcing slave $ws_ip:$ws_port ONLINE because cluster is offline" ;fi
           proxysql_exec "UPDATE mysql_servers set status = 'ONLINE', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
           check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
-          echo "`date` ${SLAVEREAD_HOSTGROUP_ID}:$ws_ip:$ws_port Slave node set to ONLINE status to ProxySQL database." >> $ERR_FILE
+          echoit "${SLAVEREAD_HOSTGROUP_ID}:$ws_ip:$ws_port Slave node set to ONLINE status to ProxySQL database." 
         else
-          echo "`date` Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE
+          echoit "Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" 
         fi
       fi
     elif [ "$slave_sql_running" != "Yes" ];then
       # Slave is not replicating
       if [ "$ws_status" != "OFFLINE_HARD" ];then
-        if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Setting to OFFLINE_HARD, status was: $ws_status" >> $ERR_FILE;fi
+        if [ $debug -eq 1 ];then echoit "DEBUG set_slave_status: Setting to OFFLINE_HARD, status was: $ws_status" ;fi
         proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, status = 'OFFLINE_HARD', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
         check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
-        echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_HARD status to ProxySQL database." >> $ERR_FILE
+        echoit "${ws_hg_id}:${i} Slave node set to OFFLINE_HARD status to ProxySQL database." 
       else
-        echo "`date` Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE
+        echoit "Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" 
       fi
     elif [ $seconds_behind -gt $SLAVE_SECONDS_BEHIND ];then
       # Slave is more than the set number of seconds behind, return status 2
       if [ "$ws_status" != "OFFLINE_SOFT" ];then
-        if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Setting to OFFLINE_SOFT, status was: $ws_status" >> $ERR_FILE;fi
+        if [ $debug -eq 1 ];then echoit "DEBUG set_slave_status: Setting to OFFLINE_SOFT, status was: $ws_status" ;fi
         proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, status = 'OFFLINE_SOFT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
         check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
-        echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_SOFT status to ProxySQL database." >> $ERR_FILE
+        echoit "${ws_hg_id}:${i} Slave node set to OFFLINE_SOFT status to ProxySQL database." 
       else
-        echo "`date` Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE
+        echoit "Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" 
       fi
     else
       if [ "$ws_status" != "ONLINE" ];then
-        if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Setting to ONLINE, status was: $ws_status" >> $ERR_FILE;fi
+        if [ $debug -eq 1 ];then echoit "DEBUG set_slave_status: Setting to ONLINE, status was: $ws_status" ;fi
         proxysql_exec "UPDATE mysql_servers set status = 'ONLINE', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
         check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
-        echo "`date` ${ws_hg_id}:${i} Slave node set to ONLINE status to ProxySQL database." >> $ERR_FILE
+        echoit "${ws_hg_id}:${i} Slave node set to ONLINE status to ProxySQL database." 
       else
-        echo "`date` Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE
+        echoit "Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" 
       fi
     fi
   fi
-  if [ $debug -eq 1 ];then echo "`date` DEBUG END set_slave_status" >> $ERR_FILE;fi
+  if [ $debug -eq 1 ];then echoit "DEBUG END set_slave_status" ;fi
 }
 
 # Update Percona XtraDB Cluster nodes in ProxySQL database
 update_cluster(){
-  if [ $debug -eq 1 ];then echo "`date` DEBUG START update_cluster" >> $ERR_FILE;fi
+  if [ $debug -eq 1 ];then echoit "DEBUG START update_cluster" ;fi
   current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers where hostgroup_id in ( $WRITE_HOSTGROUP_ID, $READ_HOSTGROUP_ID, $SLAVEREAD_HOSTGROUP_ID )" | sed 's|\t|:|g' | tr '\n' ' '`)
   wsrep_address=(`mysql_exec "SHOW STATUS LIKE 'wsrep_incoming_addresses'" | awk '{print $2}' | sed 's|,| |g'`)
   if [ ${#wsrep_address[@]} -eq 0 ]; then
     # Cluster might be down, but is there a slave to fall back to?
     slave_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers where hostgroup_id in ( $WRITE_HOSTGROUP_ID, $SLAVEREAD_HOSTGROUP_ID ) and comment = 'SLAVEREAD'" | sed 's|\t|:|g' | tr '\n' ' '`)
     if [ ${#slave_hosts[@]} -eq 0 ]; then
-      echo "`date` Alert! wsrep_incoming_addresses is empty. Terminating!" >> $ERR_FILE
+      echoit "Alert! wsrep_incoming_addresses is empty. Terminating!" 
       exit 1
     fi
   fi
 
   for i in "${wsrep_address[@]}"; do
     if [[ ! " ${current_hosts[@]} " =~ " ${i} " ]]; then
-      if [ $debug -eq 1 ];then echo "`date` DEBUG Host $i in cluster membership was not found in ProxySQL, adding it" >> $ERR_FILE;fi
+      if [ $debug -eq 1 ];then echoit "DEBUG Host $i in cluster membership was not found in ProxySQL, adding it" ;fi
       ws_ip=$(echo $i | cut -d':' -f1)
       ws_port=$(echo $i | cut -d':' -f2)
       ws_hg_status=$(echo `proxysql_exec "SELECT hostgroup_id,status from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port"`)
       ws_hg_id=$(echo $ws_hg_status | cut -d' ' -f1)
       ws_status=$(echo $ws_hg_status | cut -d' ' -f2)
-      echo "`date` Cluster node (${ws_hg_id}:${i}) does not exists in ProxySQL database!" >> $ERR_FILE
+      echoit "Cluster node (${ws_hg_id}:${i}) does not exists in ProxySQL database!" 
       proxysql_exec "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$READ_HOSTGROUP_ID,$ws_port,1000,'$MODE_COMMENT');"
       check_cmd $? "Cannot add Percona XtraDB Cluster node $ws_ip:$ws_port (hostgroup $READ_HOSTGROUP_ID) to ProxySQL database, Please check proxysql login credentials"
-      echo "`date` Added ${ws_hg_id}:${i} node into ProxySQL database." >> $ERR_FILE
+      echoit "Added ${ws_hg_id}:${i} node into ProxySQL database." 
       CHECK_STATUS=1
     fi
   done
 
   for i in "${current_hosts[@]}"; do
     if [[ ! " ${wsrep_address[@]} " =~ " ${i} " ]]; then
-      if [ $debug -eq 1 ];then echo "`date` DEBUG Host $i not found in cluster membership" >> $ERR_FILE;fi
+      if [ $debug -eq 1 ];then echoit "DEBUG Host $i not found in cluster membership" ;fi
       # The current host in current_hosts was not found in cluster membership, set it OFFLINE_HARD unless its a slave node
       ws_ip=$(echo $i | cut -d':' -f1)
       ws_port=$(echo $i | cut -d':' -f2)
@@ -194,25 +197,25 @@ update_cluster(){
       ws_status=$(echo $ws_hg_status | cut -d' ' -f2)
       comment=$(echo $ws_hg_status | cut -d' ' -f3)
       if [ "$comment" == "SLAVEREAD" ];then
-        if [ $debug -eq 1 ];then echo "`date` DEBUG Host $i is a slave, checking its health" >> $ERR_FILE;fi
+        if [ $debug -eq 1 ];then echoit "DEBUG Host $i is a slave, checking its health" ;fi
         #This is a slave, check health differently
         set_slave_status
       else
         if [ "$ws_status" == "OFFLINE_SOFT" ]; then
-          echo "`date` Cluster node ${ws_hg_id}:${i} does not exists in cluster membership! Changing status from OFFLINE_SOFT to OFFLINE_HARD" >> $ERR_FILE
+          echoit "Cluster node ${ws_hg_id}:${i} does not exists in cluster membership! Changing status from OFFLINE_SOFT to OFFLINE_HARD" 
           proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_HARD', hostgroup_id = $READ_HOSTGROUP_ID, comment='$MODE_COMMENT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
           check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
           CHECK_STATUS=1
         fi
         node_status=$(echo `proxysql_exec "SELECT status from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port"`)
-        echo "`date` Cluster node (${ws_hg_id}:${i}) current status '$node_status' in ProxySQL database!" >> $ERR_FILE
+        echoit "Cluster node (${ws_hg_id}:${i}) current status '$node_status' in ProxySQL database!" 
         if [ "$MODE" == "singlewrite" ]; then
           checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment='WRITE' and status='ONLINE' and hostgroup_id in ($WRITE_HOSTGROUP_ID)"`
           if [[ -z "$checkwriter_hid" ]]; then
             current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ' and hostgroup_id='$READ_HOSTGROUP_ID' ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
             ws_ip=$(echo $current_hosts | cut -d':' -f1)
             ws_port=$(echo $current_hosts | cut -d':' -f2)
-            echo "`date` No writer found, promoting $ws_ip:$ws_port as writer node!" >> $ERR_FILE
+            echoit "No writer found, promoting $ws_ip:$ws_port as writer node!" 
             proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
             check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
             CHECK_STATUS=1
@@ -225,28 +228,28 @@ update_cluster(){
 
   for i in "${wsrep_address[@]}"; do
     if [[ ! " ${current_hosts[@]} " == " ${i} " ]]; then
-      if [ $debug -eq 1 ];then echo "`date` DEBUG Host $i was found in cluster membership" >> $ERR_FILE;fi
+      if [ $debug -eq 1 ];then echoit "DEBUG Host $i was found in cluster membership" ;fi
       # current_hosts contains the node in wsrep_addresses
       ws_ip=$(echo $i | cut -d':' -f1)
       ws_port=$(echo $i | cut -d':' -f2)
       ws_hg_status=$(echo `proxysql_exec "SELECT hostgroup_id,status from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port"`)
       ws_hg_id=$(echo $ws_hg_status | cut -d' ' -f1)
       ws_status=$(echo $ws_hg_status | cut -d' ' -f2)
-      echo "`date` Cluster node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE 
+      echoit "Cluster node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!"  
       if [ "$ws_status" == "OFFLINE_HARD" ]; then
         # The node was OFFLINE_HARD, but its now in the cluster list so lets make it OFFLINE_SOFT
         proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_SOFT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
         check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
-        echo "`date` ${ws_hg_id}:${i} node set to OFFLINE_SOFT status to ProxySQL database." >> $ERR_FILE
+        echoit "${ws_hg_id}:${i} node set to OFFLINE_SOFT status to ProxySQL database." 
         CHECK_STATUS=1
       fi
     fi
   done
-  if [ $debug -eq 1 ];then echo "`date` DEBUG End update_cluster" >> $ERR_FILE;fi
+  if [ $debug -eq 1 ];then echoit "DEBUG End update_cluster" ;fi
 }
 
 mode_change_check(){
-  if [ $debug -eq 1 ];then echo "`date` DEBUG START mode_change_check" >> $ERR_FILE;fi
+  if [ $debug -eq 1 ];then echoit "DEBUG START mode_change_check" ;fi
 
   if [ -f $HOST_PRIORITY_FILE ];then
     # Get the list of hosts from the host_priority file ignoring blanks and any lines that start with '#'
@@ -263,7 +266,7 @@ mode_change_check(){
   if [[ -n "$checkwriter_hid" ]]; then
     # Found a writer node that was in 'OFFLINE_SOFT' state, move it to the READ hostgroup unless the MODE is 'loadbal'
     if [ "$MODE" != "loadbal" ];then
-      if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check: Found OFFLINE_SOFT writer, changing to READ status and hostgroup $READ_HOSTGROUP_ID" >> $ERR_FILE;fi
+      if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check: Found OFFLINE_SOFT writer, changing to READ status and hostgroup $READ_HOSTGROUP_ID" ;fi
       proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE comment='WRITE' and status='OFFLINE_SOFT' and hostgroup_id='$WRITE_HOSTGROUP_ID'"
       check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
       CHECK_STATUS=1
@@ -297,15 +300,15 @@ mode_change_check(){
     # If the $current_hosts variabe is empty here then it's time to put the SLAVEREAD node in if there is one
     if [ -z "$current_hosts" ];then
       # Verify a slave is not already in the write hostgroup
-      if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check: No cluster members available, check if any slaves are already in the writer hostgroup" >> $ERR_FILE;fi
+      if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check: No cluster members available, check if any slaves are already in the writer hostgroup" ;fi
       slave_check=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='SLAVEREAD' and hostgroup_id=$WRITE_HOSTGROUP_ID ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
       if [ -z "$slave_check" ];then
         # no slaves were currently in the writer group
-        if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check: No slaves currently in the writer group" >> $ERR_FILE;fi
+        if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check: No slaves currently in the writer group" ;fi
         current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='SLAVEREAD' ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
         slave_write="1"
       else
-        if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check: A slave is already in the writer hostgroup" >> $ERR_FILE;fi
+        if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check: A slave is already in the writer hostgroup" ;fi
       fi
     fi
 
@@ -314,17 +317,17 @@ mode_change_check(){
 
     # If the cluster is failed and a slave was already in as writer, the current_hosts variable will be empty
     if [ "$slave_write" == "1" ] && [ -n "$current_hosts" ];then
-      if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check1: Changing $ws_ip:$ws_port to hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
+      if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check1: Changing $ws_ip:$ws_port to hostgroup $WRITE_HOSTGROUP_ID" ;fi
       proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
       check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
-      echo "`date` $ws_ip:$ws_port (slave) is ONLINE, switching to write hostgroup" >> $ERR_FILE
+      echoit "$ws_ip:$ws_port (slave) is ONLINE, switching to write hostgroup" 
       CHECK_STATUS=1
     elif [ "$MODE" != "loadbal" ] && [ -n "$current_hosts" ];then
       # Only do this if the MODE is not 'loadbal'
-      if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check1: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
+      if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check1: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" ;fi
       proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
       check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
-      echo "`date` $ws_ip:$ws_port is ONLINE, switching to write hostgroup" >> $ERR_FILE
+      echoit "$ws_ip:$ws_port is ONLINE, switching to write hostgroup" 
       CHECK_STATUS=1
     fi
   else
@@ -338,7 +341,7 @@ mode_change_check(){
       # The current writer is a slave, check for other ONLINE nodes to put in
       if [ -n "$available_cluster_hosts" ];then
         # There is a regular cluster node available, pull out the slave
-        if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check1: Changing any SLAVEREAD nodes in hostgroup $WRITE_HOSTGROUP_ID to hostgroup $SLAVEREAD_HOSTGROUP_ID" >> $ERR_FILE;fi
+        if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check1: Changing any SLAVEREAD nodes in hostgroup $WRITE_HOSTGROUP_ID to hostgroup $SLAVEREAD_HOSTGROUP_ID" ;fi
         proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, weight=1000 WHERE hostgroup_id='$WRITE_HOSTGROUP_ID' and comment='SLAVEREAD'"
         check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
         writer_was_slave=1
@@ -352,10 +355,10 @@ mode_change_check(){
         # There is a regular cluster node available, put it back in the writer hostgroup
         ws_ip=$(echo $available_cluster_hosts | cut -d':' -f1)
         ws_port=$(echo $available_cluster_hosts | cut -d':' -f2)
-        if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check2: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
+        if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check2: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" ;fi
         proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
         check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
-        echo "`date` $ws_ip:$ws_port is ONLINE, switching to write hostgroup" >> $ERR_FILE
+        echoit "$ws_ip:$ws_port is ONLINE, switching to write hostgroup" 
         CHECK_STATUS=1
       fi
     else
@@ -383,18 +386,18 @@ mode_change_check(){
             # Move the current writer host to reader hostgroup if there is one
             ws_ip=$(echo $current_writer | cut -d':' -f1)
             ws_port=$(echo $current_writer | cut -d':' -f2)
-            if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check3: Changing $ws_ip:$ws_port to READ status and hostgroup $READ_HOSTGROUP_ID" >> $ERR_FILE;fi
+            if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check3: Changing $ws_ip:$ws_port to READ status and hostgroup $READ_HOSTGROUP_ID" ;fi
             proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
             check_cmd $? "Cannot update Percona XtraDB Cluster reader node in ProxySQL database, Please check proxysql login credentials"
-            echo "`date` $ws_ip:$ws_port is ONLINE but a higher priority node is available, switching to read hostgroup" >> $ERR_FILE
+            echoit "$ws_ip:$ws_port is ONLINE but a higher priority node is available, switching to read hostgroup" 
           fi
           # Move the priority host to the writer hostgroup
           ws_ip=$(echo $current_hosts | cut -d':' -f1)
           ws_port=$(echo $current_hosts | cut -d':' -f2)
-          if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check3: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
+          if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check3: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" ;fi
           proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
           check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
-          echo "`date` $ws_ip:$ws_port is ONLINE and highest priority, switching to write hostgroup" >> $ERR_FILE
+          echoit "$ws_ip:$ws_port is ONLINE and highest priority, switching to write hostgroup" 
           CHECK_STATUS=1
         fi
       else
@@ -402,20 +405,20 @@ mode_change_check(){
           # There is a regular cluster node available, pull out the slave and put the cluster node back in the writer hostgroup
           ws_ip=$(echo $available_cluster_hosts | cut -d':' -f1)
           ws_port=$(echo $available_cluster_hosts | cut -d':' -f2)
-          if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check4: Changing $ws_ip:$ws_port to hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
+          if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check4: Changing $ws_ip:$ws_port to hostgroup $WRITE_HOSTGROUP_ID" ;fi
           proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
           check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
-          echo "`date` $ws_ip:$ws_port is ONLINE, switching to write hostgroup" >> $ERR_FILE
+          echoit "$ws_ip:$ws_port is ONLINE, switching to write hostgroup" 
           CHECK_STATUS=1
         fi
       fi
     fi
   fi
-  if [ $debug -eq 1 ];then echo "`date` DEBUG END mode_change_check" >> $ERR_FILE;fi
+  if [ $debug -eq 1 ];then echoit "DEBUG END mode_change_check" ;fi
 }
 
 # Monitoring user needs 'REPLICATION CLIENT' privilege
-echo "`date` ###### Percona XtraDB Cluster status ######" >> $ERR_FILE
+echoit "###### Percona XtraDB Cluster status ######" 
 CLUSTER_USERNAME=$(proxysql_exec "SELECT variable_value FROM global_variables WHERE variable_name='mysql-monitor_username'")
 check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check proxysql login credentials"
 
@@ -441,7 +444,7 @@ for i in "${CLUSTER_HOSTS[@]}"; do
 done
 
 if [[ -z $CLUSTER_HOST_INFO ]]; then
-  if [ $debug -eq 1 ];then echo "`date` DEBUG Can't get cluster info, checking if a slave is available" >> $ERR_FILE;fi
+  if [ $debug -eq 1 ];then echoit "DEBUG Can't get cluster info, checking if a slave is available" ;fi
   # Set CLUSTER_OFFLINE variable, used my the set_slave_status function and the bottom of this script
   CLUSTER_OFFLINE=1
   # No Cluster nodes are available, but is a slave available?
@@ -450,18 +453,18 @@ if [[ -z $CLUSTER_HOST_INFO ]]; then
     SLAVE_HOST_INFO=`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='SLAVEREAD' and hostgroup_id in ($WRITE_HOSTGROUP_ID, $SLAVEREAD_HOSTGROUP_ID) limit 1"`
     check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check proxysql login credentials"
     if [[ -z $SLAVE_HOST_INFO ]]; then
-      if [ $debug -eq 1 ];then echo "`date` DEBUG No online slaves were found, will recheck" >> $ERR_FILE;fi
+      if [ $debug -eq 1 ];then echoit "DEBUG No online slaves were found, will recheck" ;fi
       # Check for a slave in a status other than 'ONLINE'
       # This is an emergency measure, just put a random slave online
       # Would be nice to try to find the most up to date slave if there is more than one, but that would require
       # a query to all slaves to check their positions, probably not worth the overhead - something to think about
       slave_host=(`proxysql_exec "SELECT hostname,port FROM mysql_servers where comment='SLAVEREAD' and hostgroup_id in ($WRITE_HOSTGROUP_ID, $SLAVEREAD_HOSTGROUP_ID) ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
-      if [ $debug -eq 1 ];then echo "`date` DEBUG Trying to bring slave: $slave_host ONLINE due to cluster being down" >> $ERR_FILE;fi
+      if [ $debug -eq 1 ];then echoit "DEBUG Trying to bring slave: $slave_host ONLINE due to cluster being down" ;fi
       ws_ip=$(echo $slave_host | cut -d':' -f1)
       ws_port=$(echo $slave_host | cut -d':' -f2)
       set_slave_status
     else
-      if [ $debug -eq 1 ];then echo "`date` DEBUG online slaves were found" >> $ERR_FILE;fi
+      if [ $debug -eq 1 ];then echoit "DEBUG online slaves were found" ;fi
       # Run function here to move the slave into the write hostgroup
       mode_change_check
     fi
@@ -472,10 +475,10 @@ if [[ -z $CLUSTER_HOST_INFO ]]; then
     for i in "${offline_hosts[@]}"; do
       offline_host=(`echo ${i} | awk -F: '{print $1 ":" $2 ":" $3}'`)
       offline_host_status=(`echo ${i} | cut -d':' -f4`)
-      echo "`date` Cluster node ($offline_host) current status '$offline_host_status' in ProxySQL database!" >> $ERR_FILE
+      echoit "Cluster node ($offline_host) current status '$offline_host_status' in ProxySQL database!" 
     done
   else
-    echo "`date` Percona XtraDB Cluster nodes are offline, a slave node is in the writer hostgroup, please check status" >> $ERR_FILE
+    echoit "Percona XtraDB Cluster nodes are offline, a slave node is in the writer hostgroup, please check status" 
   fi
 else
   update_cluster
@@ -484,12 +487,12 @@ fi
 
 if [ $CHECK_STATUS -eq 0 ]; then
   if [ -z "$CLUSTER_OFFLINE" ];then
-    echo "`date` Percona XtraDB Cluster membership looks good" >> $ERR_FILE
+    echoit "Percona XtraDB Cluster membership looks good" 
   else
-    echo "`date` Percona XtraDB Cluster is offline!" >> $ERR_FILE
+    echoit "Percona XtraDB Cluster is offline!" 
   fi
 else
-  echo "`date` ###### Loading mysql_servers config into runtime ######" >> $ERR_FILE
+  echoit "###### Loading mysql_servers config into runtime ######" 
   proxysql_exec "LOAD MYSQL SERVERS TO RUNTIME"
 fi
 exit 0

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -84,7 +84,7 @@ set_slave_status() {
     if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: No slave status found, setting to OFFLINE_HARD, status was: $ws_status" >> $ERR_FILE;fi
     # Only changing the status here as another node might be in the writer hostgroup
     proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_HARD', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
-    check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+    check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql admin credentials" 
     echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_HARD status to ProxySQL database." >> $ERR_FILE
   else
     slave_master_host=$(echo "$SLAVE_STATUS" | grep "^Master_Host:" | cut -d: -f2)
@@ -102,7 +102,7 @@ set_slave_status() {
         if [ -z "$CLUSTER_OFFLINE" ];then
           # The cluster is up so this slave should go to OFFLINE_SOFT state
           proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, status = 'OFFLINE_SOFT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
-          check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+          check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
           echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_SOFT status to ProxySQL database." >> $ERR_FILE
         fi
       else
@@ -110,7 +110,7 @@ set_slave_status() {
           # The slave is not currently online and cannot connect to its master, but we are here because all cluster nodes are down so put the slave ONLINE
           if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Forcing slave $ws_ip:$ws_port ONLINE because cluster is offline" >> $ERR_FILE;fi
           proxysql_exec "UPDATE mysql_servers set status = 'ONLINE', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
-          check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+          check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
           echo "`date` ${SLAVEREAD_HOSTGROUP_ID}:$ws_ip:$ws_port Slave node set to ONLINE status to ProxySQL database." >> $ERR_FILE
         else
           echo "`date` Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE
@@ -121,7 +121,7 @@ set_slave_status() {
       if [ "$ws_status" != "OFFLINE_HARD" ];then
         if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Setting to OFFLINE_HARD, status was: $ws_status" >> $ERR_FILE;fi
         proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, status = 'OFFLINE_HARD', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
-        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
         echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_HARD status to ProxySQL database." >> $ERR_FILE
       else
         echo "`date` Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE
@@ -131,7 +131,7 @@ set_slave_status() {
       if [ "$ws_status" != "OFFLINE_SOFT" ];then
         if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Setting to OFFLINE_SOFT, status was: $ws_status" >> $ERR_FILE;fi
         proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, status = 'OFFLINE_SOFT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
-        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
         echo "`date` ${ws_hg_id}:${i} Slave node set to OFFLINE_SOFT status to ProxySQL database." >> $ERR_FILE
       else
         echo "`date` Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE
@@ -140,7 +140,7 @@ set_slave_status() {
       if [ "$ws_status" != "ONLINE" ];then
         if [ $debug -eq 1 ];then echo "`date` DEBUG set_slave_status: Setting to ONLINE, status was: $ws_status" >> $ERR_FILE;fi
         proxysql_exec "UPDATE mysql_servers set status = 'ONLINE', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
-        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
         echo "`date` ${ws_hg_id}:${i} Slave node set to ONLINE status to ProxySQL database." >> $ERR_FILE
       else
         echo "`date` Slave node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL database!" >> $ERR_FILE
@@ -174,7 +174,7 @@ update_cluster(){
       ws_status=$(echo $ws_hg_status | cut -d' ' -f2)
       echo "`date` Cluster node (${ws_hg_id}:${i}) does not exists in ProxySQL database!" >> $ERR_FILE
       proxysql_exec "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$READ_HOSTGROUP_ID,$ws_port,1000,'$MODE_COMMENT');"
-      check_cmd $? "Cannot add Percona XtraDB Cluster node $ws_ip:$ws_port (hostgroup $READ_HOSTGROUP_ID) to ProxySQL database, Please check proxysql credentials"
+      check_cmd $? "Cannot add Percona XtraDB Cluster node $ws_ip:$ws_port (hostgroup $READ_HOSTGROUP_ID) to ProxySQL database, Please check proxysql login credentials"
       echo "`date` Added ${ws_hg_id}:${i} node into ProxySQL database." >> $ERR_FILE
       CHECK_STATUS=1
     fi
@@ -198,7 +198,7 @@ update_cluster(){
         if [ "$ws_status" == "OFFLINE_SOFT" ]; then
           echo "`date` Cluster node ${ws_hg_id}:${i} does not exists in cluster membership! Changing status from OFFLINE_SOFT to OFFLINE_HARD" >> $ERR_FILE
           proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_HARD', hostgroup_id = $READ_HOSTGROUP_ID, comment='$MODE_COMMENT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
-          check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+          check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
           CHECK_STATUS=1
         fi
         node_status=$(echo `proxysql_exec "SELECT status from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port"`)
@@ -211,7 +211,7 @@ update_cluster(){
             ws_port=$(echo $current_hosts | cut -d':' -f2)
             echo "`date` No writer found, promoting $ws_ip:$ws_port as writer node!" >> $ERR_FILE
             proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
-            check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+            check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
             CHECK_STATUS=1
           fi
         fi
@@ -233,7 +233,7 @@ update_cluster(){
       if [ "$ws_status" == "OFFLINE_HARD" ]; then
         # The node was OFFLINE_HARD, but its now in the cluster list so lets make it OFFLINE_SOFT
         proxysql_exec "UPDATE mysql_servers set status = 'OFFLINE_SOFT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
-        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql credentials" 
+        check_cmd $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check proxysql login credentials" 
         echo "`date` ${ws_hg_id}:${i} node set to OFFLINE_SOFT status to ProxySQL database." >> $ERR_FILE
         CHECK_STATUS=1
       fi
@@ -262,7 +262,7 @@ mode_change_check(){
     if [ "$MODE" != "loadbal" ];then
       if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check: Found OFFLINE_SOFT writer, changing to READ status and hostgroup $READ_HOSTGROUP_ID" >> $ERR_FILE;fi
       proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE comment='WRITE' and status='OFFLINE_SOFT' and hostgroup_id='$WRITE_HOSTGROUP_ID'"
-      check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+      check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
       CHECK_STATUS=1
     fi
 
@@ -313,14 +313,14 @@ mode_change_check(){
     if [ "$slave_write" == "1" ] && [ -n "$current_hosts" ];then
       if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check1: Changing $ws_ip:$ws_port to hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
       proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
-      check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+      check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
       echo "`date` $ws_ip:$ws_port (slave) is ONLINE, switching to write hostgroup" >> $ERR_FILE
       CHECK_STATUS=1
     elif [ "$MODE" != "loadbal" ] && [ -n "$current_hosts" ];then
       # Only do this if the MODE is not 'loadbal'
       if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check1: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
       proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
-      check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+      check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
       echo "`date` $ws_ip:$ws_port is ONLINE, switching to write hostgroup" >> $ERR_FILE
       CHECK_STATUS=1
     fi
@@ -337,7 +337,7 @@ mode_change_check(){
         # There is a regular cluster node available, pull out the slave
         if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check1: Changing any SLAVEREAD nodes in hostgroup $WRITE_HOSTGROUP_ID to hostgroup $SLAVEREAD_HOSTGROUP_ID" >> $ERR_FILE;fi
         proxysql_exec "UPDATE mysql_servers set hostgroup_id = $SLAVEREAD_HOSTGROUP_ID, weight=1000 WHERE hostgroup_id='$WRITE_HOSTGROUP_ID' and comment='SLAVEREAD'"
-        check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+        check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
         writer_was_slave=1
       fi
     fi
@@ -351,7 +351,7 @@ mode_change_check(){
         ws_port=$(echo $available_cluster_hosts | cut -d':' -f2)
         if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check2: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
         proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
-        check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+        check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
         echo "`date` $ws_ip:$ws_port is ONLINE, switching to write hostgroup" >> $ERR_FILE
         CHECK_STATUS=1
       fi
@@ -382,7 +382,7 @@ mode_change_check(){
             ws_port=$(echo $current_writer | cut -d':' -f2)
             if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check3: Changing $ws_ip:$ws_port to READ status and hostgroup $READ_HOSTGROUP_ID" >> $ERR_FILE;fi
             proxysql_exec "UPDATE mysql_servers set hostgroup_id = $READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port"
-            check_cmd $? "Cannot update Percona XtraDB Cluster reader node in ProxySQL database, Please check proxysql credentials"
+            check_cmd $? "Cannot update Percona XtraDB Cluster reader node in ProxySQL database, Please check proxysql login credentials"
             echo "`date` $ws_ip:$ws_port is ONLINE but a higher priority node is available, switching to read hostgroup" >> $ERR_FILE
           fi
           # Move the priority host to the writer hostgroup
@@ -390,7 +390,7 @@ mode_change_check(){
           ws_port=$(echo $current_hosts | cut -d':' -f2)
           if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check3: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
           proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
-          check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+          check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
           echo "`date` $ws_ip:$ws_port is ONLINE and highest priority, switching to write hostgroup" >> $ERR_FILE
           CHECK_STATUS=1
         fi
@@ -401,7 +401,7 @@ mode_change_check(){
           ws_port=$(echo $available_cluster_hosts | cut -d':' -f2)
           if [ $debug -eq 1 ];then echo "`date` DEBUG mode_change_check4: Changing $ws_ip:$ws_port to hostgroup $WRITE_HOSTGROUP_ID" >> $ERR_FILE;fi
           proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
-          check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql credentials"
+          check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
           echo "`date` $ws_ip:$ws_port is ONLINE, switching to write hostgroup" >> $ERR_FILE
           CHECK_STATUS=1
         fi
@@ -414,13 +414,13 @@ mode_change_check(){
 # Monitoring user needs 'REPLICATION CLIENT' privilege
 echo "`date` ###### Percona XtraDB Cluster status ######" >> $ERR_FILE
 CLUSTER_USERNAME=$(proxysql_exec "SELECT variable_value FROM global_variables WHERE variable_name='mysql-monitor_username'")
-check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check cluster login credentials"
+check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check proxysql login credentials"
 
 CLUSTER_PASSWORD=$(proxysql_exec "SELECT variable_value FROM global_variables WHERE variable_name='mysql-monitor_password'") 
-check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check cluster login credentials"
+check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check proxysql login credentials"
 
 CLUSTER_HOST_INFO=`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment<>'SLAVEREAD' and hostgroup_id in ($WRITE_HOSTGROUP_ID, $READ_HOSTGROUP_ID) limit 1"`
-check_cmd $? "Could not retrieve cluster node info from ProxySQL. Please check cluster login credentials"
+check_cmd $? "Could not retrieve cluster node info from ProxySQL. Please check proxysql login credentials"
 
 CLUSTER_HOSTS=($(proxysql_exec "SELECT hostname || '-' || port FROM mysql_servers WHERE status='ONLINE' and comment<>'SLAVEREAD' and hostgroup_id in ($WRITE_HOSTGROUP_ID, $READ_HOSTGROUP_ID)"))
 CLUSTER_TIMEOUT=($(proxysql_exec "SELECT MAX(interval_ms / 1000 - 1, 1) FROM scheduler"))
@@ -445,7 +445,7 @@ if [[ -z $CLUSTER_HOST_INFO ]]; then
   SLAVE_CHECK=`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE comment='SLAVEREAD' limit 1"`
   if [[ ! -z $SLAVE_CHECK ]]; then
     SLAVE_HOST_INFO=`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment='SLAVEREAD' and hostgroup_id in ($WRITE_HOSTGROUP_ID, $SLAVEREAD_HOSTGROUP_ID) limit 1"`
-    check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check cluster login credentials"
+    check_cmd $? "Could not retrieve cluster login info from ProxySQL. Please check proxysql login credentials"
     if [[ -z $SLAVE_HOST_INFO ]]; then
       if [ $debug -eq 1 ];then echo "`date` DEBUG No online slaves were found, will recheck" >> $ERR_FILE;fi
       # Check for a slave in a status other than 'ONLINE'


### PR DESCRIPTION
Fixed PSQLADM-2 : proxysql_galera_checker doesn't check if another instance of itself is already running
Fixed PSQLADM-39 : proxysql_node_monitor login error message is misleading.
Fixed PSQLADM-40 : ProxySQL scheduler generates many proxysql_(galera_checker|node_monitor) processes with wrong proxysql credentials
Fixed PSQLADM-41: Improve timeout error handing
Fixed PSQLADM-42 : Inconsistent date format in ProxySQL and scripts.
