### PR TITLE
Dump host_priority / proxysql-admin.cnf  and changed output format

### DIFF
--- a/proxysql-status
+++ b/proxysql-status
@@ -10,7 +10,7 @@ TABLES=`mysql -u $USER -p$PASSWORD -h $HOST -P $PORT --protocol=tcp -BNe "SHOW T
 for table in $TABLES
 do
 	echo "***** DUMPING $table *****"
-	mysql -u $USER -p$PASSWORD -h $HOST -P $PORT --protocol=tcp -Be "SELECT * FROM $table" 2> /dev/null
+	mysql -u $USER -p$PASSWORD -h $HOST -P $PORT --protocol=tcp -te "SELECT * FROM $table" 2> /dev/null
 	echo "***** END OF DUMPING $table *****"
 done
 echo "............ END OF DUMPING MAIN DATABASE ............"
@@ -21,7 +21,7 @@ TABLES=`mysql -u $USER -p$PASSWORD -h $HOST -P $PORT --protocol=tcp -BNe "SHOW T
 for table in $TABLES
 do
 	echo "***** DUMPING stats.$table *****"
-	mysql -u $USER -p$PASSWORD -h $HOST -P $PORT --protocol=tcp -e "SELECT * FROM $table" stats 2> /dev/null
+	mysql -u $USER -p$PASSWORD -h $HOST -P $PORT --protocol=tcp -te "SELECT * FROM $table" stats 2> /dev/null
 	echo "***** END OF DUMPING stats.$table *****"
 done
 echo "............ END OF DUMPING STATS DATABASE ............"
@@ -32,7 +32,7 @@ TABLES=`mysql -u $USER -p$PASSWORD -h $HOST -P $PORT --protocol=tcp -BNe "SHOW T
 for table in $TABLES
 do
 	echo "***** DUMPING monitor.$table *****"
-	mysql -u $USER -p$PASSWORD -h $HOST -P $PORT --protocol=tcp -e "SELECT * FROM $table" monitor 2> /dev/null
+	mysql -u $USER -p$PASSWORD -h $HOST -P $PORT --protocol=tcp -te "SELECT * FROM $table" monitor 2> /dev/null
 	echo "***** END OF DUMPING monitor.$table *****"
 done
 echo "............ END OF DUMPING MONITOR DATABASE ............"

--- a/proxysql-status
+++ b/proxysql-status
@@ -36,3 +36,11 @@ do
 	echo "***** END OF DUMPING monitor.$table *****"
 done
 echo "............ END OF DUMPING MONITOR DATABASE ............"
+
+echo "............ DUMPING HOST PRIORITY FILE ............"
+cat /var/lib/proxysql/host_priority.conf
+echo "............ END OF DUMPING HOST PRIORITY FILE ............"
+
+echo "............ DUMPING PROXYSQL ADMIN CNF FILE ............"
+cat /etc/proxysql-admin.conf
+echo "............ END OF DUMPING PROXYSQL ADMIN CNF FILE ............"

--- a/proxysql-status
+++ b/proxysql-status
@@ -42,5 +42,5 @@ cat /var/lib/proxysql/host_priority.conf
 echo "............ END OF DUMPING HOST PRIORITY FILE ............"
 
 echo "............ DUMPING PROXYSQL ADMIN CNF FILE ............"
-cat /etc/proxysql-admin.conf
+cat /etc/proxysql-admin.cnf
 echo "............ END OF DUMPING PROXYSQL ADMIN CNF FILE ............"


### PR DESCRIPTION
This change includes the dump of /var/lib/proxysql/host_priority.conf and /etc/proxysql-admin.cnf
Output was changed, now it forces tabular format.