### PR TITLE
added option --without-check-monitor-user

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -55,6 +55,7 @@ usage () {
   echo "  --without-cluster-app-user         Configure Percona XtraDB Cluster without application user"
   echo "  --monitor-username=user_name       Username for monitoring Percona XtraDB Cluster nodes through ProxySQL"
   echo "  --monitor-password[=password]      Password for monitoring Percona XtraDB Cluster nodes through ProxySQL"
+  echo "  --without-check-monitor-user       Configure ProxySQL without checking/attempting to create monitor user"
   echo "  --enable, -e                       Auto-configure Percona XtraDB Cluster nodes into ProxySQL"
   echo "  --disable, -d                      Remove any Percona XtraDB Cluster configurations from ProxySQL"
   echo "  --node-check-interval=3000         Interval for monitoring node checker script (in milliseconds)"
@@ -73,7 +74,7 @@ usage () {
 # Check if we have a functional getopt(1)
 if ! getopt --test
   then
-  go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-datadir:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,include-slaves:,without-cluster-app-user,enable,disable,adduser,syncusers,version,help \
+  go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-datadir:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,include-slaves:,without-check-monitor-user,without-cluster-app-user,enable,disable,adduser,syncusers,version,help \
   --name="$(basename "$0")" -- "$@")"
   test $? -eq 0 || exit 1
   eval set -- "$go_out"
@@ -187,6 +188,10 @@ do
     --monitor-password )
     MONITOR_PASSWORD="$2"
     shift 2
+    ;;
+    --without-check-monitor-user )
+    WITHOUT_CHECK_MONITOR_USER=1
+    shift
     ;;
     --cluster-app-username )
     CLUSTER_APP_USERNAME="$2"
@@ -602,8 +607,13 @@ enable_proxysql(){
     proxysql_exec "LOAD MYSQL VARIABLES TO RUNTIME;SAVE MYSQL VARIABLES TO DISK;"
     echo -e "\nUser '${BD}$MONITOR_USERNAME'@'$USER_HOST_RANGE${NBD}' has been added with USAGE privilege"
   else
-    echo ""
-    read -p "The monitoring user is already present in Percona XtraDB Cluster. Would you like to proceed with the existing username and password [y/n] ? " check_param
+    if [[  "$WITHOUT_CHECK_MONITOR_USER" == 1 ]]
+    then
+        check_param="n"
+    else
+        echo ""
+        read -p "The monitoring user is already present in Percona XtraDB Cluster. Would you like to proceed with the existing username and password [y/n] ? " check_param
+    fi
     case $check_param in
       y|Y)
         if [ -z "$QUICK_DEMO" ]; then


### PR DESCRIPTION
This will avoid human interaction when deploying multiple proxysql's on the same cluster