### PR TITLE
Fix issue with missed writer in mysql_servers

### DIFF
--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -346,6 +346,8 @@ mode_change_check(){
     checkslave_hid=`proxysql_exec "select hostgroup_id from mysql_servers where hostgroup_id='$WRITE_HOSTGROUP_ID' AND comment='SLAVEREAD'"`
     # Set a variable containing a random available cluster node
     available_cluster_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE status='ONLINE' and comment in ('READ', 'READWRITE') ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+    # If we have any writers at all
+    writers_hid = `proxysql_exec "select hostgroup_id from mysql_servers where hostgroup_id='$WRITE_HOSTGROUP_ID'"`
     if [[ -n "$checkslave_hid" ]]; then
       # The current writer is a slave, check for other ONLINE nodes to put in
       if [ -n "$available_cluster_hosts" ];then
@@ -360,15 +362,18 @@ mode_change_check(){
     if [ -z $priority_hosts ];then
       # Order file wasn't found
       # Do not change the config of a cluster node if the MODE is 'loadbal'
-      if [ -n "$available_cluster_hosts" ] && [ -n "$writer_was_slave" ] && [ "$MODE" != "loadbal" ];then
-        # There is a regular cluster node available, put it back in the writer hostgroup
-        ws_ip=$(echo $available_cluster_hosts | cut -d':' -f1)
-        ws_port=$(echo $available_cluster_hosts | cut -d':' -f2)
-        if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check2: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" ;fi
-        proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
-        check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
-        echoit "$ws_ip:$ws_port is ONLINE, switching to write hostgroup" 
-        CHECK_STATUS=1
+      if [ -n "$available_cluster_hosts" ] && [ "$MODE" != "loadbal" ];then
+        # If we disabled SLAVEREAD which was a writer or have no writers at all
+        if [ -n "$writer_was_slave" ] || [ -n "$writers_hid" ]; then
+          # There is a regular cluster node available, put it back in the writer hostgroup
+          ws_ip=$(echo $available_cluster_hosts | cut -d':' -f1)
+          ws_port=$(echo $available_cluster_hosts | cut -d':' -f2)
+          if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check2: Changing $ws_ip:$ws_port to WRITE status and hostgroup $WRITE_HOSTGROUP_ID" ;fi
+          proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
+          check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
+          echoit "$ws_ip:$ws_port is ONLINE, switching to write hostgroup"
+          CHECK_STATUS=1
+        fi
       fi
     else
       # Check here if the highest priority node is the writer
@@ -410,15 +415,17 @@ mode_change_check(){
           CHECK_STATUS=1
         fi
       else
-        if [ -n "$available_cluster_hosts" ] && [ -n "$writer_was_slave" ];then
-          # There is a regular cluster node available, pull out the slave and put the cluster node back in the writer hostgroup
-          ws_ip=$(echo $available_cluster_hosts | cut -d':' -f1)
-          ws_port=$(echo $available_cluster_hosts | cut -d':' -f2)
-          if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check4: Changing $ws_ip:$ws_port to hostgroup $WRITE_HOSTGROUP_ID" ;fi
-          proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
-          check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
-          echoit "$ws_ip:$ws_port is ONLINE, switching to write hostgroup" 
-          CHECK_STATUS=1
+        if [ -n "$available_cluster_hosts" ] ;then
+          if [ -n "$writer_was_slave" ] || [ -n "$writers_hid" ]; then
+            # There is a regular cluster node available, pull out the slave and put the cluster node back in the writer hostgroup
+            ws_ip=$(echo $available_cluster_hosts | cut -d':' -f1)
+            ws_port=$(echo $available_cluster_hosts | cut -d':' -f2)
+            if [ $debug -eq 1 ];then echoit "DEBUG mode_change_check4: Changing $ws_ip:$ws_port to hostgroup $WRITE_HOSTGROUP_ID" ;fi
+            proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, weight=$WRITE_WEIGHT WHERE hostname='$ws_ip' and port=$ws_port"
+            check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
+            echoit "$ws_ip:$ws_port is ONLINE, switching to write hostgroup"
+            CHECK_STATUS=1
+          fi
         fi
       fi
     fi


### PR DESCRIPTION
Hi guys, 
I configured an xtradb cluster with 2 nodes and 1 arbitrator and configured it in proxysql with proxysql-admin script. During a few weeks of failover test I've found that sometimes both nodes in mysql_servers table become in READ mode and stuck in this mode for hours till next failover happens.
The reason for this that after moving writer to READ host group when it become ONLINE again it doesn't move it to WRITE host group. 
So, I've fixed this by additional check if we have any hosts in WRITE host group at all. 
I hope my fix should do the trick.

Below I've attached some logs which I used during investigation of this problem:
- proxysql_galera_check.log
```
[2018-06-25 21:56:00] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:00] Hostgroup writers 10
[2018-06-25 21:56:00] Hostgroup readers 11
[2018-06-25 21:56:00] Number of writers 1
[2018-06-25 21:56:00] Writers are readers 1
[2018-06-25 21:56:00] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:00] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:00] --> Checking WRITE server 10:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:00] server 10:127.0.0.1:3307 is already ONLINE: 1 of 1 write nodes
[2018-06-25 21:56:00] ###### HANDLE READER NODES ######
[2018-06-25 21:56:00] ###### SUMMARY ######
[2018-06-25 21:56:00] --> Number of writers that are 'ONLINE': 1 : hostgroup: 10
[2018-06-25 21:56:00] --> Number of readers that are 'ONLINE': 0 : hostgroup: 11
[2018-06-25 21:56:00] ###### TRYING TO FIX MISSING READERS ######
[2018-06-25 21:56:00] --> No readers found, Trying to enable last available node of the cluster (in Donor/Desync state) or pick the master
[2018-06-25 21:56:00] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:03] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:03] Hostgroup writers 10
[2018-06-25 21:56:03] Hostgroup readers 11
[2018-06-25 21:56:03] Number of writers 1
[2018-06-25 21:56:03] Writers are readers 1
[2018-06-25 21:56:03] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:03] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:03] --> Checking WRITE server 10:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:03] server 10:127.0.0.1:3307 is already ONLINE: 1 of 1 write nodes
[2018-06-25 21:56:03] ###### HANDLE READER NODES ######
[2018-06-25 21:56:03] ###### SUMMARY ######
[2018-06-25 21:56:03] --> Number of writers that are 'ONLINE': 1 : hostgroup: 10
[2018-06-25 21:56:03] --> Number of readers that are 'ONLINE': 0 : hostgroup: 11
[2018-06-25 21:56:03] ###### TRYING TO FIX MISSING READERS ######
[2018-06-25 21:56:03] --> No readers found, Trying to enable last available node of the cluster (in Donor/Desync state) or pick the master
[2018-06-25 21:56:03] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:07] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:07] Hostgroup writers 10
[2018-06-25 21:56:07] Hostgroup readers 11
[2018-06-25 21:56:07] Number of writers 1
[2018-06-25 21:56:07] Writers are readers 1
[2018-06-25 21:56:07] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:07] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:07] --> Checking WRITE server 10:127.0.0.1:3307, current status ONLINE, wsrep_local_state 2
[2018-06-25 21:56:07] Changing server 10:127.0.0.1:3307 to status OFFLINE_SOFT. Reason: WSREP status is 2 which is not ok
[2018-06-25 21:56:07] ###### HANDLE READER NODES ######
ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1' (111)
ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1' (111)
[2018-06-25 21:56:07] --> Checking READ server 11:127.0.0.1:3306, current status OFFLINE_SOFT, wsrep_local_state
[2018-06-25 21:56:07] server 11:127.0.0.1:3306 is already OFFLINE_SOFT, WSREP status is  which is not ok
[2018-06-25 21:56:07] ###### SUMMARY ######
[2018-06-25 21:56:07] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:07] --> Number of readers that are 'ONLINE': 0 : hostgroup: 11
[2018-06-25 21:56:07] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:07] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:07] Check server 10:127.0.0.1:3307 for only available node in DONOR state, status OFFLINE_SOFT , wsrep_local_state 4
[2018-06-25 21:56:07] Check server 10:127.0.0.1:3307 for only available node in DONOR state, status OFFLINE_SOFT , wsrep_local_state 4
[2018-06-25 21:56:07] Check server 10:127.0.0.1:3307 for only available node in DONOR state, status OFFLINE_SOFT , wsrep_local_state 4
[2018-06-25 21:56:07] Check server 10:127.0.0.1:3307 for only available node in DONOR state, status OFFLINE_SOFT , wsrep_local_state 4
[2018-06-25 21:56:07] Check server 10:127.0.0.1:3307 for only available node in DONOR state, status OFFLINE_SOFT , wsrep_local_state 4
[2018-06-25 21:56:07] ###### TRYING TO FIX MISSING READERS ######
[2018-06-25 21:56:07] --> No readers found, Trying to enable last available node of the cluster (in Donor/Desync state) or pick the master
ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1' (111)
[2018-06-25 21:56:07] Check server 11:127.0.0.1:3306 for only available node in DONOR state, status OFFLINE_SOFT , wsrep_local_state
ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1' (111)
[2018-06-25 21:56:07] Check server 11:127.0.0.1:3306 for only available node in DONOR state, status OFFLINE_SOFT , wsrep_local_state
ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1' (111)
[2018-06-25 21:56:07] Check server 11:127.0.0.1:3306 for only available node in DONOR state, status OFFLINE_SOFT , wsrep_local_state
ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1' (111)
[2018-06-25 21:56:07] Check server 11:127.0.0.1:3306 for only available node in DONOR state, status OFFLINE_SOFT , wsrep_local_state
ERROR 2003 (HY000): Can't connect to MySQL server on '127.0.0.1' (111)
[2018-06-25 21:56:07] Check server 11:127.0.0.1:3306 for only available node in DONOR state, status OFFLINE_SOFT , wsrep_local_state
[2018-06-25 21:56:07] ###### Loading mysql_servers config into runtime ######
[2018-06-25 21:56:10] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:10] Hostgroup writers 10
[2018-06-25 21:56:10] Hostgroup readers 11
[2018-06-25 21:56:10] Number of writers 1
[2018-06-25 21:56:10] Writers are readers 1
[2018-06-25 21:56:10] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:10] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:10] ###### HANDLE READER NODES ######
[2018-06-25 21:56:10] --> Checking READ server 11:127.0.0.1:3306, current status OFFLINE_SOFT, wsrep_local_state 4
[2018-06-25 21:56:10] Changing server 11:127.0.0.1:3306 to status ONLINE. Reason: changed state, making read node ONLINE
[2018-06-25 21:56:10] --> Checking READ server 11:127.0.0.1:3307, current status OFFLINE_SOFT, wsrep_local_state 4
[2018-06-25 21:56:10] Changing server 11:127.0.0.1:3307 to status ONLINE. Reason: changed state, making read node ONLINE
[2018-06-25 21:56:10] ###### SUMMARY ######
[2018-06-25 21:56:10] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:10] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:10] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:10] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:10] ###### Loading mysql_servers config into runtime ######
[2018-06-25 21:56:13] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:13] Hostgroup writers 10
[2018-06-25 21:56:13] Hostgroup readers 11
[2018-06-25 21:56:13] Number of writers 1
[2018-06-25 21:56:13] Writers are readers 1
[2018-06-25 21:56:13] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:13] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:13] ###### HANDLE READER NODES ######
[2018-06-25 21:56:13] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:13] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:14] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:14] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:14] ###### SUMMARY ######
[2018-06-25 21:56:14] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:14] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:14] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:14] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:14] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:17] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:17] Hostgroup writers 10
[2018-06-25 21:56:17] Hostgroup readers 11
[2018-06-25 21:56:17] Number of writers 1
[2018-06-25 21:56:17] Writers are readers 1
[2018-06-25 21:56:17] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:17] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:17] ###### HANDLE READER NODES ######
[2018-06-25 21:56:17] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:17] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:17] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:17] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:17] ###### SUMMARY ######
[2018-06-25 21:56:17] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:17] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:17] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:17] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:17] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:20] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:20] Hostgroup writers 10
[2018-06-25 21:56:20] Hostgroup readers 11
[2018-06-25 21:56:20] Number of writers 1
[2018-06-25 21:56:20] Writers are readers 1
[2018-06-25 21:56:20] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:20] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:20] ###### HANDLE READER NODES ######
[2018-06-25 21:56:20] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:20] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:20] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:20] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:20] ###### SUMMARY ######
[2018-06-25 21:56:20] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:20] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:20] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:20] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:20] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:23] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:23] Hostgroup writers 10
[2018-06-25 21:56:23] Hostgroup readers 11
[2018-06-25 21:56:23] Number of writers 1
[2018-06-25 21:56:23] Writers are readers 1
[2018-06-25 21:56:23] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:23] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:23] ###### HANDLE READER NODES ######
[2018-06-25 21:56:23] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:23] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:23] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:23] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:23] ###### SUMMARY ######
[2018-06-25 21:56:23] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:23] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:23] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:23] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:23] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:27] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:27] Hostgroup writers 10
[2018-06-25 21:56:27] Hostgroup readers 11
[2018-06-25 21:56:27] Number of writers 1
[2018-06-25 21:56:27] Writers are readers 1
[2018-06-25 21:56:27] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:27] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:27] ###### HANDLE READER NODES ######
[2018-06-25 21:56:27] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:27] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:27] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:27] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:27] ###### SUMMARY ######
[2018-06-25 21:56:27] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:27] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:27] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:27] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:27] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:30] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:30] Hostgroup writers 10
[2018-06-25 21:56:30] Hostgroup readers 11
[2018-06-25 21:56:30] Number of writers 1
[2018-06-25 21:56:30] Writers are readers 1
[2018-06-25 21:56:30] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:30] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:30] ###### HANDLE READER NODES ######
[2018-06-25 21:56:30] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:30] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:30] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:30] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:30] ###### SUMMARY ######
[2018-06-25 21:56:30] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:30] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:30] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:30] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:30] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:33] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:33] Hostgroup writers 10
[2018-06-25 21:56:33] Hostgroup readers 11
[2018-06-25 21:56:33] Number of writers 1
[2018-06-25 21:56:33] Writers are readers 1
[2018-06-25 21:56:33] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:33] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:33] ###### HANDLE READER NODES ######
[2018-06-25 21:56:33] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:33] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:33] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:33] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:33] ###### SUMMARY ######
[2018-06-25 21:56:33] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:33] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:33] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:33] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:33] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:37] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:37] Hostgroup writers 10
[2018-06-25 21:56:37] Hostgroup readers 11
[2018-06-25 21:56:37] Number of writers 1
[2018-06-25 21:56:37] Writers are readers 1
[2018-06-25 21:56:37] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:37] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:37] ###### HANDLE READER NODES ######
[2018-06-25 21:56:37] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:37] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:37] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:37] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:37] ###### SUMMARY ######
[2018-06-25 21:56:37] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:37] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:37] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:37] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:37] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:40] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:40] Hostgroup writers 10
[2018-06-25 21:56:40] Hostgroup readers 11
[2018-06-25 21:56:40] Number of writers 1
[2018-06-25 21:56:40] Writers are readers 1
[2018-06-25 21:56:40] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:40] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:40] ###### HANDLE READER NODES ######
[2018-06-25 21:56:40] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:40] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:40] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:40] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:40] ###### SUMMARY ######
[2018-06-25 21:56:40] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:40] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:40] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:40] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:40] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:43] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:43] Hostgroup writers 10
[2018-06-25 21:56:43] Hostgroup readers 11
[2018-06-25 21:56:43] Number of writers 1
[2018-06-25 21:56:43] Writers are readers 1
[2018-06-25 21:56:43] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:43] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:43] ###### HANDLE READER NODES ######
[2018-06-25 21:56:43] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:43] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:43] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:43] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:43] ###### SUMMARY ######
[2018-06-25 21:56:43] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:43] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:43] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:43] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:43] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:47] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:47] Hostgroup writers 10
[2018-06-25 21:56:47] Hostgroup readers 11
[2018-06-25 21:56:47] Number of writers 1
[2018-06-25 21:56:47] Writers are readers 1
[2018-06-25 21:56:47] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:47] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:47] ###### HANDLE READER NODES ######
[2018-06-25 21:56:47] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:47] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:47] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:47] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:47] ###### SUMMARY ######
[2018-06-25 21:56:47] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:47] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:47] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:47] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:47] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:50] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:50] Hostgroup writers 10
[2018-06-25 21:56:50] Hostgroup readers 11
[2018-06-25 21:56:50] Number of writers 1
[2018-06-25 21:56:50] Writers are readers 1
[2018-06-25 21:56:50] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:50] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:50] ###### HANDLE READER NODES ######
[2018-06-25 21:56:50] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:50] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:50] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:50] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:50] ###### SUMMARY ######
[2018-06-25 21:56:50] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:50] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:50] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:50] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:50] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:53] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:53] Hostgroup writers 10
[2018-06-25 21:56:53] Hostgroup readers 11
[2018-06-25 21:56:53] Number of writers 1
[2018-06-25 21:56:53] Writers are readers 1
[2018-06-25 21:56:53] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:53] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:53] ###### HANDLE READER NODES ######
[2018-06-25 21:56:53] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:53] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:53] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:53] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:53] ###### SUMMARY ######
[2018-06-25 21:56:53] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:53] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:53] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:53] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:53] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:56:56] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:56:56] Hostgroup writers 10
[2018-06-25 21:56:56] Hostgroup readers 11
[2018-06-25 21:56:56] Number of writers 1
[2018-06-25 21:56:56] Writers are readers 1
[2018-06-25 21:56:56] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:56:56] ###### HANDLE WRITER NODES ######
[2018-06-25 21:56:56] ###### HANDLE READER NODES ######
[2018-06-25 21:56:56] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:56] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:56:57] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:56:57] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:56:57] ###### SUMMARY ######
[2018-06-25 21:56:57] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:56:57] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:56:57] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:56:57] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:56:57] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:57:00] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:57:00] Hostgroup writers 10
[2018-06-25 21:57:00] Hostgroup readers 11
[2018-06-25 21:57:00] Number of writers 1
[2018-06-25 21:57:00] Writers are readers 1
[2018-06-25 21:57:00] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:57:00] ###### HANDLE WRITER NODES ######
[2018-06-25 21:57:00] ###### HANDLE READER NODES ######
[2018-06-25 21:57:00] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:57:00] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:57:00] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:57:00] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:57:00] ###### SUMMARY ######
[2018-06-25 21:57:00] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:57:00] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
[2018-06-25 21:57:00] ###### TRYING TO FIX MISSING WRITERS ######
[2018-06-25 21:57:00] No writers found, Trying to enable last available node of the cluster (in Donor/Desync state)
[2018-06-25 21:57:00] ###### Not loading mysql_servers, no change needed ######
[2018-06-25 21:57:03] ###### proxysql_galera_checker.sh SUMMARY ######
[2018-06-25 21:57:03] Hostgroup writers 10
[2018-06-25 21:57:03] Hostgroup readers 11
[2018-06-25 21:57:03] Number of writers 1
[2018-06-25 21:57:03] Writers are readers 1
[2018-06-25 21:57:03] log file /var/lib/proxysql/stage_cluster_proxysql_galera_check.log
[2018-06-25 21:57:03] ###### HANDLE WRITER NODES ######
[2018-06-25 21:57:03] ###### HANDLE READER NODES ######
[2018-06-25 21:57:03] --> Checking READ server 11:127.0.0.1:3306, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:57:03] server 11:127.0.0.1:3306 is already ONLINE
[2018-06-25 21:57:03] --> Checking READ server 11:127.0.0.1:3307, current status ONLINE, wsrep_local_state 4
[2018-06-25 21:57:03] server 11:127.0.0.1:3307 is already ONLINE
[2018-06-25 21:57:03] ###### SUMMARY ######
[2018-06-25 21:57:03] --> Number of writers that are 'ONLINE': 0 : hostgroup: 10
[2018-06-25 21:57:03] --> Number of readers that are 'ONLINE': 2 : hostgroup: 11
```
- proxysql_node_monitor.log
```
[2018-06-25 21:56:00] DEBUG MODE: singlewrite
[2018-06-25 21:56:00] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:00] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:00] DEBUG START update_cluster
[2018-06-25 21:56:00] DEBUG Host 127.0.0.1:3306 not found in cluster membership
[2018-06-25 21:56:00] Cluster node (11:127.0.0.1:3306) current status 'OFFLINE_HARD' in ProxySQL database!
[2018-06-25 21:56:00] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:00] Cluster node (10:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:00] DEBUG End update_cluster
[2018-06-25 21:56:00] DEBUG START mode_change_check
[2018-06-25 21:56:00] DEBUG END mode_change_check
[2018-06-25 21:56:00] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:03] DEBUG MODE: singlewrite
[2018-06-25 21:56:03] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:03] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:03] DEBUG START update_cluster
[2018-06-25 21:56:03] DEBUG Host 127.0.0.1:3306 not found in cluster membership
[2018-06-25 21:56:03] Cluster node (11:127.0.0.1:3306) current status 'OFFLINE_HARD' in ProxySQL database!
[2018-06-25 21:56:03] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:03] Cluster node (10:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:03] DEBUG End update_cluster
[2018-06-25 21:56:03] DEBUG START mode_change_check
[2018-06-25 21:56:03] DEBUG END mode_change_check
[2018-06-25 21:56:03] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:06] DEBUG MODE: singlewrite
[2018-06-25 21:56:06] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:06] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:06] DEBUG START update_cluster
[2018-06-25 21:56:07] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:07] Cluster node (10:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:07] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:07] Cluster node (11:127.0.0.1:3306) current status 'OFFLINE_HARD' in ProxySQL database!
[2018-06-25 21:56:07] 11:127.0.0.1:3306 node set to OFFLINE_SOFT status to ProxySQL database.
[2018-06-25 21:56:07] DEBUG End update_cluster
[2018-06-25 21:56:07] DEBUG START mode_change_check
[2018-06-25 21:56:07] DEBUG END mode_change_check
[2018-06-25 21:56:07] ###### Loading mysql_servers config into runtime ######
[2018-06-25 21:56:10] DEBUG MODE: singlewrite
[2018-06-25 21:56:10] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:10] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:10] DEBUG START update_cluster
[2018-06-25 21:56:10] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:10] Cluster node (10:127.0.0.1:3307) current status 'OFFLINE_SOFT' in ProxySQL database!
[2018-06-25 21:56:10] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:10] Cluster node (11:127.0.0.1:3306) current status 'OFFLINE_SOFT' in ProxySQL database!
[2018-06-25 21:56:10] DEBUG End update_cluster
[2018-06-25 21:56:10] DEBUG START mode_change_check
[2018-06-25 21:56:10] DEBUG mode_change_check: Found OFFLINE_SOFT writer, changing to READ status and hostgroup 11
[2018-06-25 21:56:10] DEBUG mode_change_check: No cluster members available, check if any slaves are already in the writer hostgroup
[2018-06-25 21:56:10] DEBUG mode_change_check: No slaves currently in the writer group
[2018-06-25 21:56:10] DEBUG END mode_change_check
[2018-06-25 21:56:10] ###### Loading mysql_servers config into runtime ######
[2018-06-25 21:56:13] DEBUG MODE: singlewrite
[2018-06-25 21:56:13] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:13] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:13] DEBUG START update_cluster
[2018-06-25 21:56:13] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:13] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:13] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:13] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:13] DEBUG End update_cluster
[2018-06-25 21:56:13] DEBUG START mode_change_check
[2018-06-25 21:56:13] DEBUG END mode_change_check
[2018-06-25 21:56:13] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:17] DEBUG MODE: singlewrite
[2018-06-25 21:56:17] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:17] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:17] DEBUG START update_cluster
[2018-06-25 21:56:17] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:17] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:17] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:17] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:17] DEBUG End update_cluster
[2018-06-25 21:56:17] DEBUG START mode_change_check
[2018-06-25 21:56:17] DEBUG END mode_change_check
[2018-06-25 21:56:17] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:20] DEBUG MODE: singlewrite
[2018-06-25 21:56:20] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:20] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:20] DEBUG START update_cluster
[2018-06-25 21:56:20] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:20] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:20] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:20] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:20] DEBUG End update_cluster
[2018-06-25 21:56:20] DEBUG START mode_change_check
[2018-06-25 21:56:20] DEBUG END mode_change_check
[2018-06-25 21:56:20] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:23] DEBUG MODE: singlewrite
[2018-06-25 21:56:23] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:23] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:23] DEBUG START update_cluster
[2018-06-25 21:56:23] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:23] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:23] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:23] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:23] DEBUG End update_cluster
[2018-06-25 21:56:23] DEBUG START mode_change_check
[2018-06-25 21:56:23] DEBUG END mode_change_check
[2018-06-25 21:56:23] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:27] DEBUG MODE: singlewrite
[2018-06-25 21:56:27] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:27] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:27] DEBUG START update_cluster
[2018-06-25 21:56:27] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:27] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:27] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:27] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:27] DEBUG End update_cluster
[2018-06-25 21:56:27] DEBUG START mode_change_check
[2018-06-25 21:56:27] DEBUG END mode_change_check
[2018-06-25 21:56:27] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:30] DEBUG MODE: singlewrite
[2018-06-25 21:56:30] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:30] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:30] DEBUG START update_cluster
[2018-06-25 21:56:30] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:30] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:30] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:30] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:30] DEBUG End update_cluster
[2018-06-25 21:56:30] DEBUG START mode_change_check
[2018-06-25 21:56:30] DEBUG END mode_change_check
[2018-06-25 21:56:30] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:33] DEBUG MODE: singlewrite
[2018-06-25 21:56:33] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:33] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:33] DEBUG START update_cluster
[2018-06-25 21:56:33] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:33] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:33] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:33] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:33] DEBUG End update_cluster
[2018-06-25 21:56:33] DEBUG START mode_change_check
[2018-06-25 21:56:33] DEBUG END mode_change_check
[2018-06-25 21:56:33] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:36] DEBUG MODE: singlewrite
[2018-06-25 21:56:36] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:36] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:37] DEBUG START update_cluster
[2018-06-25 21:56:37] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:37] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:37] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:37] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:37] DEBUG End update_cluster
[2018-06-25 21:56:37] DEBUG START mode_change_check
[2018-06-25 21:56:37] DEBUG END mode_change_check
[2018-06-25 21:56:37] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:40] DEBUG MODE: singlewrite
[2018-06-25 21:56:40] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:40] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:40] DEBUG START update_cluster
[2018-06-25 21:56:40] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:40] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:40] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:40] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:40] DEBUG End update_cluster
[2018-06-25 21:56:40] DEBUG START mode_change_check
[2018-06-25 21:56:40] DEBUG END mode_change_check
[2018-06-25 21:56:40] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:43] DEBUG MODE: singlewrite
[2018-06-25 21:56:43] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:43] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:43] DEBUG START update_cluster
[2018-06-25 21:56:43] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:43] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:43] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:43] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:43] DEBUG End update_cluster
[2018-06-25 21:56:43] DEBUG START mode_change_check
[2018-06-25 21:56:43] DEBUG END mode_change_check
[2018-06-25 21:56:43] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:46] DEBUG MODE: singlewrite
[2018-06-25 21:56:46] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:46] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:46] DEBUG START update_cluster
[2018-06-25 21:56:46] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:46] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:46] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:46] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:46] DEBUG End update_cluster
[2018-06-25 21:56:46] DEBUG START mode_change_check
[2018-06-25 21:56:47] DEBUG END mode_change_check
[2018-06-25 21:56:47] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:50] DEBUG MODE: singlewrite
[2018-06-25 21:56:50] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:50] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:50] DEBUG START update_cluster
[2018-06-25 21:56:50] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:50] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:50] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:50] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:50] DEBUG End update_cluster
[2018-06-25 21:56:50] DEBUG START mode_change_check
[2018-06-25 21:56:50] DEBUG END mode_change_check
[2018-06-25 21:56:50] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:53] DEBUG MODE: singlewrite
[2018-06-25 21:56:53] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:53] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:53] DEBUG START update_cluster
[2018-06-25 21:56:53] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:53] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:53] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:53] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:53] DEBUG End update_cluster
[2018-06-25 21:56:53] DEBUG START mode_change_check
[2018-06-25 21:56:53] DEBUG END mode_change_check
[2018-06-25 21:56:53] Percona XtraDB Cluster membership looks good
[2018-06-25 21:56:56] DEBUG MODE: singlewrite
[2018-06-25 21:56:56] DEBUG check mode name from proxysql data directory
[2018-06-25 21:56:56] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:56:56] DEBUG START update_cluster
[2018-06-25 21:56:56] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:56:56] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:56] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:56:56] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:56:56] DEBUG End update_cluster
[2018-06-25 21:56:56] DEBUG START mode_change_check
[2018-06-25 21:56:56] DEBUG END mode_change_check
[2018-06-25 21:56:56] Percona XtraDB Cluster membership looks good
[2018-06-25 21:57:00] DEBUG MODE: singlewrite
[2018-06-25 21:57:00] DEBUG check mode name from proxysql data directory
[2018-06-25 21:57:00] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:57:00] DEBUG START update_cluster
[2018-06-25 21:57:00] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:57:00] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:57:00] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:57:00] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:57:00] DEBUG End update_cluster
[2018-06-25 21:57:00] DEBUG START mode_change_check
[2018-06-25 21:57:00] DEBUG END mode_change_check
[2018-06-25 21:57:00] Percona XtraDB Cluster membership looks good
[2018-06-25 21:57:03] DEBUG MODE: singlewrite
[2018-06-25 21:57:03] DEBUG check mode name from proxysql data directory
[2018-06-25 21:57:03] ###### Percona XtraDB Cluster status ######
[2018-06-25 21:57:03] DEBUG START update_cluster
[2018-06-25 21:57:03] DEBUG Host 127.0.0.1:3307 was found in cluster membership
[2018-06-25 21:57:03] Cluster node (11:127.0.0.1:3307) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:57:03] DEBUG Host 127.0.0.1:3306 was found in cluster membership
[2018-06-25 21:57:03] Cluster node (11:127.0.0.1:3306) current status 'ONLINE' in ProxySQL database!
[2018-06-25 21:57:03] DEBUG End update_cluster
[2018-06-25 21:57:03] DEBUG START mode_change_check
[2018-06-25 21:57:03] DEBUG END mode_change_check
[2018-06-25 21:57:03] Percona XtraDB Cluster membership looks good
```