### PR TITLE
PSQLADM-63

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,6 @@ Pre-requisites
 
   # ProxySQL read/write configuration mode.
   export MODE="singlewrite"
-
-  # ProxySQL Cluster Node Priority File
-  export HOST_PRIORITY_FILE=$PROXYSQL_DATADIR/host_priority.conf
 ```
 
 It is recommend you use _--config-file_ to run this proxysql-admin script.
@@ -166,7 +163,7 @@ __i) --mode__
 This option allows you to setup read/write mode for cluster nodes in ProxySQL database based on the hostgroup. For now, the only supported modes are _loadbal_ and _singlewrite_. _singlewrite_ is the default mode, and it will configure Percona Cluster to only accept writes on one single node only. All other remaining nodes will be read-only and accept only read statements. 
 
 With --write-node option we can control a priority order of what host is most desired to be the writer at any given time.
-When used the feature will create the config file which is by default "/var/lib/proxysql/host_priority.conf", this is configurable in proxysql-admin.cnf. Servers can be specified comma delimited - 10.0.0.51:3306, 10.0.0.52:3306 - The 51 node will always be in the writer hostgroup if it is ONLINE, if it is OFFLINE the 52 node will go into the writer hostgroup, and if it goes down a node from the remaining nodes will be randomly chosen for the writer hostgroup.
+When used the feature will create the config file which is by default stored as `${CLUSTER_NAME}_host_priority` under your `$PROXYSQL_DATADIR` folder. Servers can be specified comma delimited - 10.0.0.51:3306, 10.0.0.52:3306 - The 51 node will always be in the writer hostgroup if it is ONLINE, if it is OFFLINE the 52 node will go into the writer hostgroup, and if it goes down a node from the remaining nodes will be randomly chosen for the writer hostgroup.
 This new config file will be deleted when --disable is used. This will ensure a specified writer-node will always be the writer node while it is ONLINE.
 
 The mode _loadbal_ on the other hand is a load balanced set of evenly weighted read/write nodes.

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -460,6 +460,13 @@ CLUSTER_NAME=$(mysql_exec "select @@wsrep_cluster_name;")
 rm -rf ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode
 echo "$MODE" > ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode
 
+# Create the host priority file if multiple write nodes were specified
+if [ -n $enable_priority ];then
+    if [[ -z $CLUSTER_NAME ]]; then
+        HOST_PRIORITY_FILE="${HOST_PRIORITY_FILE}_${CLUSTER_NAME}"
+    fi
+fi
+
 user_input_check(){
   USER_CATEGORY=$1
   USER_DESCRIPTION=$2

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -459,13 +459,7 @@ check_proxysql(){
 CLUSTER_NAME=$(mysql_exec "select @@wsrep_cluster_name;")
 rm -rf ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode
 echo "$MODE" > ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode
-
-# Create the host priority file if multiple write nodes were specified
-if [ -n $enable_priority ];then
-    if [[ -z $CLUSTER_NAME ]]; then
-        HOST_PRIORITY_FILE="${HOST_PRIORITY_FILE}_${CLUSTER_NAME}"
-    fi
-fi
+HOST_PRIORITY_FILE=${PROXYSQL_DATADIR}/${CLUSTER_NAME}_host_priority
 
 user_input_check(){
   USER_CATEGORY=$1

--- a/proxysql-admin.cnf
+++ b/proxysql-admin.cnf
@@ -25,6 +25,3 @@ export READ_HOSTGROUP_ID='11'
 
 # ProxySQL read/write configuration mode.
 export MODE="singlewrite"
-
-# ProxySQL Cluster Node Priority File
-export HOST_PRIORITY_FILE=$PROXYSQL_DATADIR/host_priority.conf

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -258,9 +258,7 @@ update_cluster(){
 
 mode_change_check(){
   if [ $debug -eq 1 ];then echoit "DEBUG START mode_change_check" ;fi
-  if [[ -z $CLUSTER_NAME ]]; then
-      HOST_PRIORITY_FILE="${HOST_PRIORITY_FILE}_${CLUSTER_NAME}"
-  fi
+  HOST_PRIORITY_FILE=${PROXYSQL_DATADIR}/${CLUSTER_NAME}_host_priority
 
   if [ -f $HOST_PRIORITY_FILE ];then
     # Get the list of hosts from the host_priority file ignoring blanks and any lines that start with '#'

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -43,7 +43,6 @@ if [ $debug -eq 1 ];then echoit "DEBUG MODE: $MODE" ;fi
 
 if [ $debug -eq 1 ];then echoit "DEBUG check mode name from proxysql data directory " ;fi
 CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$WRITE_HOSTGROUP_ID")
-
 if [[ -z $CLUSTER_NAME ]]; then
   if [[ -f ${PROXYSQL_DATADIR}/mode ]] ; then
     MODE=$(cat ${PROXYSQL_DATADIR}/mode)
@@ -259,6 +258,9 @@ update_cluster(){
 
 mode_change_check(){
   if [ $debug -eq 1 ];then echoit "DEBUG START mode_change_check" ;fi
+  if [[ -z $CLUSTER_NAME ]]; then
+      HOST_PRIORITY_FILE="${HOST_PRIORITY_FILE}_${CLUSTER_NAME}"
+  fi
 
   if [ -f $HOST_PRIORITY_FILE ];then
     # Get the list of hosts from the host_priority file ignoring blanks and any lines that start with '#'

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -258,7 +258,10 @@ update_cluster(){
 
 mode_change_check(){
   if [ $debug -eq 1 ];then echoit "DEBUG START mode_change_check" ;fi
-  HOST_PRIORITY_FILE=${PROXYSQL_DATADIR}/${CLUSTER_NAME}_host_priority
+
+  if [[ ! -f $HOST_PRIORITY_FILE ]]; then
+    HOST_PRIORITY_FILE=${PROXYSQL_DATADIR}/${CLUSTER_NAME}_host_priority
+  fi
 
   if [ -f $HOST_PRIORITY_FILE ];then
     # Get the list of hosts from the host_priority file ignoring blanks and any lines that start with '#'


### PR DESCRIPTION
This PR adds support for host priority while handling multiple clusters within the same ProxySQL.

It takes into consideration old file name (present on /etc/proxysql-admin.cnf) to avoid breaking the functionality when a user upgrades from a previous version of proxysql-admin 