### PR TITLE
Removing the need to run the script as root

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -17,12 +17,6 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 
-# Make sure only root can run this script
-if [ "$(id -u)" -ne 0 ]; then
-  echo "ERROR: This script must be run as root!" 1>&2
-  exit 1
-fi
-
 #bash prompt internal configuration
 BD=$(tput bold)
 NBD=$(tput sgr0)
@@ -95,6 +89,16 @@ if ! echo "$go_out" | grep -q 'config-file'; then
       echo "WARNING! Default configuration file (/etc/proxysql-admin.cnf) does not exist"
     fi
   fi
+fi
+
+if [[ -z "$PROXYSQL_DATADIR" ]]; then
+  PROXYSQL_DATADIR='/var/lib/proxysql'
+fi
+
+# Check if we have write permissions on proxysql datadir
+if [[ ! -w  $PROXYSQL_DATADIR ]]; then
+  echo "ERROR: This script must be run as root!" 1>&2
+  exit 1
 fi
 
 for arg
@@ -367,10 +371,6 @@ else
   MONITOR_PASSWORD='monitor'
   CLUSTER_APP_USERNAME='pxc_test_user'
   CLUSTER_APP_PASSWORD=''
-fi
-
-if [[ -z "$PROXYSQL_DATADIR" ]]; then
-  PROXYSQL_DATADIR='/var/lib/proxysql'
 fi
 
 if [[ -z "$NODE_CHECK_INTERVAL" ]]; then

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -391,25 +391,11 @@ fi
 if [ -z $WRITE_HOSTGROUP_ID ];then WRITE_HOSTGROUP_ID=10;fi
 if [ -z $READ_HOSTGROUP_ID ];then READ_HOSTGROUP_ID=11;fi
 
-# We don't use need the correct mode in ${CONFIG_FILE} anymore 
-# We are using ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode
-# Adding this check just for safety to avoid below sed to fail
-if [[ ! -w ${CONFIG_FILE} ]]; then
-  echo "ERROR: cannot write to file ${CONFIG_FILE}"
-  exit 1
-fi
-
 if [ $MODE == "loadbal" ]; then
   SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
   READ_HOSTGROUP_ID=$WRITE_HOSTGROUP_ID
-  if [ -e "${CONFIG_FILE}" ]; then
-    sed -i "0,/^[ \t]*export MODE[ \t]*=.*$/s|^[ \t]*export MODE[ \t]*=.*$|export MODE=\"loadbal\"|" "${CONFIG_FILE}"
-  fi
 elif [ $MODE == "singlewrite" ]; then
   SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
-  if [ -e "${CONFIG_FILE}" ]; then
-    sed -i "0,/^[ \t]*export MODE[ \t]*=.*$/s|^[ \t]*export MODE[ \t]*=.*$|export MODE=\"singlewrite\"|" "${CONFIG_FILE}"
-  fi
 fi
 
 export PIDFILE="/tmp/cluster-proxysql-monitor.pid"

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -391,6 +391,14 @@ fi
 if [ -z $WRITE_HOSTGROUP_ID ];then WRITE_HOSTGROUP_ID=10;fi
 if [ -z $READ_HOSTGROUP_ID ];then READ_HOSTGROUP_ID=11;fi
 
+# We don't use need the correct mode in ${CONFIG_FILE} anymore 
+# We are using ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode
+# Adding this check just for safety to avoid below sed to fail
+if [[ ! -w ${CONFIG_FILE} ]]; then
+  echo "ERROR: cannot write to file ${CONFIG_FILE}"
+  exit 1
+fi
+
 if [ $MODE == "loadbal" ]; then
   SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
   READ_HOSTGROUP_ID=$WRITE_HOSTGROUP_ID


### PR DESCRIPTION
This PR implements #PSQLADM-57

Moved the test to verify `PROXYSQL_DATADIR` variable and added a new check to verify if it's writable by the user running the script.

Also, `/etc/proxysql-admin.cnf` by default is owned by root. There was a `sed` command changing the MODE on that file to ensure it reflects the `--mode` parameter passed when the script was called. This change on the .cnf file is not needed anymore as we create `${PROXYSQL_DATADIR}/${CLUSTER_NAME}_mode` as part of the multi-cluster support