### PR TITLE
PSQLADM-31 : Handle multiple proxysql instances in proxysql-admin

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -417,6 +417,15 @@ fi
 
 export PIDFILE="/tmp/cluster-proxysql-monitor.pid"
 
+#Check proxysql running status
+check_proxysql(){
+  check_proxysql=$(mysql -u${PROXYSQL_USERNAME} -p${PROXYSQL_PASSWORD} -h${PROXYSQL_HOSTNAME} -P${PROXYSQL_PORT} --protocol=tcp -Bse 'SELECT @@admin-version;' 2>/dev/null)
+  if [ -z $check_proxysql ]; then
+    echo "ProxySQL is not running, please check the error log at $PROXYSQL_DATADIR/proxysql.log"
+    exit 1
+  fi
+}
+
 proxysql_exec() {
   query=$1
   args=$2
@@ -458,13 +467,6 @@ check_cmd(){
   MPID=$1
   ERROR_MSG=$2
   if [ "${MPID}" -ne 0 ]; then echo -e "\nERROR: $ERROR_MSG. Terminating!"; exit 1; fi
-}
-
-check_proxysql(){
-  if ! pidof proxysql >/dev/null ; then
-    echo "ProxySQL is not running, please check the error log at $PROXYSQL_DATADIR/proxysql.log"
-    exit 1
-  fi
 }
 
 CLUSTER_NAME=$(mysql_exec "select @@wsrep_cluster_name;")
@@ -558,10 +560,7 @@ enable_proxysql(){
     PROXYSQL_NODE_MONITOR=$(which proxysql_node_monitor)
   fi
   # Check for existing proxysql process
-  if ! pidof proxysql >/dev/null ; then
-    echo "ProxySQL is not running; please start the proxysql service"
-    exit 1
-  fi
+  check_proxysql
   proxysql_connection_check
 
   # Checking an existing host priority file if its there

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -784,7 +784,7 @@ enable_proxysql(){
   else
     NUMBER_WRITERS=0
   fi
-  proxysql_exec "INSERT  INTO SCHEDULER (active,interval_ms,filename,arg1,arg2,arg3,arg4,arg5,comment) VALUES (1,$NODE_CHECK_INTERVAL,'$PROXYSQL_GALERA_CHECK',$WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID,$NUMBER_WRITERS,1,'$PROXYSQL_DATADIR/${CLUSTER_NAME}_proxysql_galera_check.log','$CLUSTER_NAME');"
+  proxysql_exec "INSERT INTO SCHEDULER (active,interval_ms,filename,arg1,arg2,arg3,arg4,arg5,comment) VALUES (1,$NODE_CHECK_INTERVAL,'$PROXYSQL_GALERA_CHECK','--write-hg=$WRITE_HOSTGROUP_ID','--read-hg=$READ_HOSTGROUP_ID','--config-file=$CONFIG_FILE','--writer-count=$NUMBER_WRITERS','--log=$PROXYSQL_DATADIR/${CLUSTER_NAME}_proxysql_galera_check.log','$CLUSTER_NAME');"
   check_cmd $? "Failed to add the Percona XtraDB Cluster monitoring scheduler in ProxySQL. Please check username, password and other options for connecting to ProxySQL database"
   
   proxysql_exec "LOAD SCHEDULER TO RUNTIME;SAVE SCHEDULER TO DISK;"

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -66,11 +66,11 @@ do
   case "$arg" in
     -- ) shift; break;;
     -w | --write-hg )
-      export HOSTGROUP_WRITER_ID="$2"
+      export WRITE_HG="$2"
       shift 2
     ;;
     -r | --read-hg )
-      export HOSTGROUP_READER_ID="$2"
+      export READ_HG="$2"
       shift 2
     ;;
     --config-file )
@@ -137,10 +137,19 @@ TIMEOUT=5
 # DEFAULTS
 if [[ -z $HOSTGROUP_WRITER_ID ]]; then
   HOSTGROUP_WRITER_ID="1"
+else
+  if [[ ! -z $WRITE_HG ]]; then
+    HOSTGROUP_WRITER_ID=$WRITE_HG
+  fi
 fi
 if [[ -z $HOSTGROUP_READER_ID ]]; then
   HOSTGROUP_READER_ID="-1"
+else
+  if [[ ! -z $READ_HG ]]; then
+    HOSTGROUP_READER_ID=$READ_HG
+  fi
 fi
+
 if [[ -z $NUMBER_WRITERS ]]; then
   NUMBER_WRITERS=0
 fi

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -1,17 +1,122 @@
 #!/bin/bash
 ## inspired by Percona clustercheck.sh
 
-ERR_FILE="${5:-/dev/null}"
+usage () {
+  echo "Usage:"
+  echo "  proxysql_galera_checker --write-hg=10 --read-hg=11 --config-file=/etc/proxysql-admin.cnf --log=/var/lib/proxysql/pxc_test_proxysql_galera_check.log"
+  echo ""
+  echo "Options:"
+  echo "  -w, --write-hg=<NUMBER>     Specify ProxySQL write hostgroup."
+  echo "  -r, --read-hg=<NUMBER>      Specify ProxySQL read hostgroup."
+  echo "  -c, --config-file=PATH      Specify ProxySQL-admin configuration file."
+  echo "  -l, --log=PATH              Specify proxysql_galera_checker log file."
+  echo "  -n, --writer-count=<NUMBER> Maximum number of write hostgroup_id node that can be marked ONLINE"
+  echo "                              When 0 (default), all nodes can be marked ONLINE"
+  echo "  -h, --help                  Display script usage information"
+  echo "  -v, --version               Print version info"
+  echo ""
+  echo "Notes about the mysql_servers in ProxySQL:"
+  echo ""
+  echo "- NODE STATUS      * Nodes that are in status OFFLINE_HARD will not be checked nor will their status be changed"
+  echo "                   * SHUNNED nodes are not to be used with Galera based systems, they will be checked and status"
+  echo "                   will be changed to either ONLINE or OFFLINE_SOFT."
+  echo ""
+  echo ""
+  echo "When no nodes were found to be in wsrep_local_state=4 (SYNCED) for either"
+  echo "read or write nodes, then the script will try 5 times for each node to try"
+  echo "to find nodes wsrep_local_state=4 (SYNCED) or wsrep_local_state=2 (DONOR/DESYNC)"
+
+}
+
+# Check user permission to needed file.
+check_permission(){
+  file_checker=$1
+  if [ ! -r $file_checker ] ; then
+    echo "ERROR: You do not have permission to access $file_checker file."
+    exit 1
+  fi
+}
+
+# Check if we have a functional getopt(1)
+if ! getopt --test
+  then
+  go_out="$(getopt --options=w:r:c:l:n:vh --longoptions=write-hg:,read-hg:,config-file:,log:,writer-count:,version,help \
+  --name="$(basename "$0")" -- "$@")"
+  test $? -eq 0 || exit 1
+  eval set -- "$go_out"
+fi
+
+if [[ $go_out == " --" ]];then
+  usage
+  exit 1
+fi
+
+for arg
+do
+  case "$arg" in
+    -- ) shift; break;;
+    -w | --write-hg )
+      export HOSTGROUP_WRITER_ID="$2"
+      shift 2
+    ;;
+    -r | --read-hg )
+      export HOSTGROUP_READER_ID="$2"
+      shift 2
+    ;;
+    --config-file )
+      CONFIG_FILE="$2"
+      shift 2
+      if [ -z "${CONFIG_FILE}" ]; then
+        echo "ERROR: The configuration file location (--config-file) was not provided. Terminating."
+        exit 1
+      fi
+      if [ -e "${CONFIG_FILE}" ]; then
+        # Loading configuration from ${CONFIG_FILE}
+        check_permission "${CONFIG_FILE}"
+        source "${CONFIG_FILE}"
+      else
+        echo "ERROR: The configuration file ${CONFIG_FILE} specified by --config-file does not exist. Terminating."
+        exit 1
+      fi
+    ;;
+    -l | --log )
+      export ERR_FILE="$2"
+      shift 2
+    ;;
+    -n | --writer-count )
+      export NUMBER_WRITERS="$2"
+      shift 2
+    ;;
+    -v | --version )
+      echo "proxysql_galera_checker version 1.4.9"
+      exit 0
+    ;;
+    -h | --help )
+      usage
+      exit 0
+    ;;
+  esac
+done
+
+if [[ -z $CONFIG_FILE ]]; then
+  # Reading default variables from default configuration file location.
+  if [ -e "/etc/proxysql-admin.cnf" ]; then
+    # Loading default configuration from /etc/proxysql-admin.cnf
+    check_permission  "/etc/proxysql-admin.cnf"
+    source /etc/proxysql-admin.cnf
+    CONFIG_FILE="/etc/proxysql-admin.cnf"
+  else
+    echo "ERROR! Default configuration file (/etc/proxysql-admin.cnf) does not exist. Terminating"
+	exit 1
+  fi
+fi
+
+if [[ -z $ERR_FILE ]]; then
+  ERR_FILE="/dev/null"
+fi
 echoit(){
   echo "[$(date +%Y-%m-%d\ %H:%M:%S)] $1" >> $ERR_FILE
 }
-if [[ -f /etc/proxysql-admin.cnf ]]; then
-  source /etc/proxysql-admin.cnf
-else
-  echo "Assert! proxysql-admin configuration file :/etc/proxysql-admin.cnf does not exists, Terminating!"
-  exit 1
-fi
-#
 
 if [[ -z "$PROXYSQL_DATADIR" ]]; then
   PROXYSQL_DATADIR='/var/lib/proxysql'
@@ -19,45 +124,20 @@ fi
 
 #Timeout exists for instances where mysqld/proxysql may be hung
 TIMEOUT=5
-
-function usage()
-{
-  cat << EOF
-
-Usage: $0 <hostgroup_id write> [hostgroup_id read] [number writers] [writers are readers 0|1] [log_file]
-
-- HOSTGROUP WRITERS   (required)  (0..)   The hostgroup_id that contains nodes that will server 'writes'
-- HOSTGROUP READERS   (optional)  (0..)   The hostgroup_id that contains nodes that will server 'reads'
-- NUMBER WRITERS      (optional)  (0..)   Maximum number of write hostgroup_id node that can be marked ONLINE
-                                          When 0 (default), all nodes can be marked ONLINE
-- WRITERS ARE READERS (optional)  (0|1)   When 1 (default), ONLINE nodes in write hostgroup_id will prefer not
-                                          to be ONLINE in read hostgroup_id
-- LOG_FILE            (optional)  file    logfile where node state checks & changes are written to (verbose)
-
-
-Notes about the mysql_servers in ProxySQL:
-
-- WEIGHT           Hosts with a higher weight will be prefered to be put ONLINE
-- NODE STATUS      * Nodes that are in status OFFLINE_HARD will not be checked nor will their status be changed
-                   * SHUNNED nodes are not to be used with Galera based systems, they will be checked and status
-                     will be changed to either ONLINE or OFFLINE_SOFT.
-
-
-When no nodes were found to be in wsrep_local_state=4 (SYNCED) for either
-read or write nodes, then the script will try 5 times for each node to try
-to find nodes wsrep_local_state=4 (SYNCED) or wsrep_local_state=2 (DONOR/DESYNC)
-
-This is to avoid $0 to mark all nodes as OFFLINE_SOFT
-
-EOF
-}
-
-
 # DEFAULTS
-HOSTGROUP_WRITER_ID="${1}"
-HOSTGROUP_READER_ID="${2:--1}"
-NUMBER_WRITERS="${3:-0}"
-WRITER_IS_READER="${4:-1}"
+if [[ -z $HOSTGROUP_WRITER_ID ]]; then
+  HOSTGROUP_WRITER_ID="1"
+fi
+if [[ -z $HOSTGROUP_READER_ID ]]; then
+  HOSTGROUP_READER_ID="-1"
+fi
+if [[ -z $NUMBER_WRITERS ]]; then
+  NUMBER_WRITERS=0
+fi
+
+#With WRITER_IS_READER=1, ONLINE nodes in write hostgroup_id will prefer not to be ONLINE in read hostgroup_id
+WRITER_IS_READER=1
+
 #Timeout exists for instances where mysqld may be hung
 TIMEOUT=10
 
@@ -102,11 +182,11 @@ if [[ ! -z $CONNECTION_MSG ]]; then
   exit 1
 fi
 
-CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$HOSTGROUP_WRITER_ID")
+CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1='--write-hg=$HOSTGROUP_WRITER_ID'")
 if [[ -z $CLUSTER_NAME ]]; then
   CLUSTER_NAME=$(mysql_exec "select @@wsrep_cluster_name" 2>>${ERR_FILE}| tail -1 2>>${ERR_FILE})
   if [[ ! -z $CLUSTER_NAME ]]; then  
-    proxysql_exec "update scheduler set comment='$CLUSTER_NAME',arg5='${PROXYSQL_DATADIR}/${CLUSTER_NAME}_proxysql_galera_check.log' where arg1=$HOSTGROUP_WRITER_ID;load scheduler to runtime;"
+    proxysql_exec "update scheduler set comment='$CLUSTER_NAME',arg5='--log=${PROXYSQL_DATADIR}/${CLUSTER_NAME}_proxysql_galera_check.log' where arg1='--write-hg=$HOSTGROUP_WRITER_ID';load scheduler to runtime;"
   fi
 fi
 
@@ -185,16 +265,10 @@ if [[ ! -f /usr/bin/proxysql_node_monitor ]] ;then
   exit 1
 else
   if [[ -z $CLUSTER_NAME ]]; then
-    /usr/bin/proxysql_node_monitor $HOSTGROUP_WRITER_ID $HOSTGROUP_READER_ID ${PROXYSQL_DATADIR}/proxysql_node_monitor.log
+    /usr/bin/proxysql_node_monitor --write-hg=$HOSTGROUP_WRITER_ID --read-hg=$HOSTGROUP_READER_ID --config-file=$CONFIG_FILE --log=${PROXYSQL_DATADIR}/proxysql_node_monitor.log
   else
-    /usr/bin/proxysql_node_monitor $HOSTGROUP_WRITER_ID $HOSTGROUP_READER_ID ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_proxysql_node_monitor.log
+    /usr/bin/proxysql_node_monitor --write-hg=$HOSTGROUP_WRITER_ID --read-hg=$HOSTGROUP_READER_ID --config-file=$CONFIG_FILE --log=${PROXYSQL_DATADIR}/${CLUSTER_NAME}_proxysql_node_monitor.log
   fi
-fi
-
-if [[ "$1" = '-h' || "$1" = '--help'  || -z "$1" ]]
-then
-  usage
-  exit 0
 fi
 
 test $HOSTGROUP_WRITER_ID -ge 0 &> /dev/null
@@ -207,12 +281,6 @@ fi
 test $HOSTGROUP_READER_ID -ge -1 &> /dev/null
 if [[ $? -ne 0 ]]; then
   echo "ERROR: reader hostgroup_id is not an integer"
-  usage
-  exit 1
-fi
-
-if [[ $# -lt 1 || $# -gt 5 ]]; then
-  echo "ERROR: Invalid number of arguments"
   usage
   exit 1
 fi

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -4,16 +4,111 @@
 
 debug=0
 
-ERR_FILE="${3:-/dev/null}"
+usage () {
+  echo "Usage:"
+  echo "  proxysql_node_monitor --write-hg=10 --read-hg=11 --config-file=/etc/proxysql-admin.cnf --log=/var/lib/proxysql/pxc_test_proxysql_galera_check.log"
+  echo ""
+  echo "Options:"
+  echo "  -w, --write-hg=<NUMBER>     Specify ProxySQL write hostgroup."
+  echo "  -r, --read-hg=<NUMBER>      Specify ProxySQL read hostgroup."
+  echo "  -c, --config-file=PATH      Specify ProxySQL-admin configuration file."
+  echo "  -l, --log=PATH              Specify proxysql_node_monitor log file."
+  echo "  -h, --help                  Display script usage information"
+  echo "  -v, --version               Print version info"
+}
+
+# Check user permission to needed file.
+check_permission(){
+  file_checker=$1
+  if [ ! -r $file_checker ] ; then
+    echo "ERROR: You do not have permission to access $file_checker file."
+    exit 1
+  fi
+}
+
+# Check if we have a functional getopt(1)
+if ! getopt --test
+  then
+  go_out="$(getopt --options=w:r:c:l:vh --longoptions=write-hg:,read-hg:,config-file:,log:,version,help \
+  --name="$(basename "$0")" -- "$@")"
+  test $? -eq 0 || exit 1
+  eval set -- "$go_out"
+fi
+
+if [[ $go_out == " --" ]];then
+  usage
+  exit 1
+fi
+
+for arg
+do
+  case "$arg" in
+    -- ) shift; break;;
+    -w | --write-hg )
+      export WRITE_HOSTGROUP_ID="$2"
+      shift 2
+    ;;
+    -r | --read-hg )
+      export READ_HOSTGROUP_ID="$2"
+      shift 2
+    ;;
+    --config-file )
+      CONFIG_FILE="$2"
+      shift 2
+      if [ -z "${CONFIG_FILE}" ]; then
+        echo "ERROR: The configuration file location (--config-file) was not provided. Terminating."
+        exit 1
+      fi
+      if [ -e "${CONFIG_FILE}" ]; then
+        # Loading configuration from ${CONFIG_FILE}
+        check_permission "${CONFIG_FILE}"
+        source "${CONFIG_FILE}"
+      else
+        echo "ERROR: The configuration file ${CONFIG_FILE} specified by --config-file does not exist. Terminating."
+        exit 1
+      fi
+    ;;
+    -l | --log )
+      export ERR_FILE="$2"
+      shift 2
+    ;;
+    -v | --version )
+      echo "proxysql_galera_checker version 1.4.9"
+      exit 0
+    ;;
+    -h | --help )
+      usage
+      exit 0
+    ;;
+  esac
+done
+
+if [[ -z $CONFIG_FILE ]]; then
+  # Reading default variables from default configuration file location.
+  if [ -e "/etc/proxysql-admin.cnf" ]; then
+    # Loading default configuration from /etc/proxysql-admin.cnf
+    check_permission  "/etc/proxysql-admin.cnf"
+    source /etc/proxysql-admin.cnf
+    CONFIG_FILE="/etc/proxysql-admin.cnf"
+  else
+    echo "ERROR! Default configuration file (/etc/proxysql-admin.cnf) does not exist. Terminating!"
+	exit 1
+  fi
+fi
+# DEFAULTS
+if [[ -z $WRITE_HOSTGROUP_ID ]]; then
+  WRITE_HOSTGROUP_ID="1"
+fi
+if [[ -z $READ_HOSTGROUP_ID ]]; then
+  HOSTGROUP_READER_ID="-1"
+fi
+if [[ -z $ERR_FILE ]]; then
+  ERR_FILE="/dev/null"
+fi
+
 echoit(){
   echo "[$(date +%Y-%m-%d\ %H:%M:%S)] $1" >> $ERR_FILE
 }
-if [ -f /etc/proxysql-admin.cnf ]; then
-  source /etc/proxysql-admin.cnf
-else
-  echoit "Assert! proxysql-admin configuration file :/etc/proxysql-admin.cnf does not exists, Terminating!" 
-  exit 1
-fi
 
 if [[ -z "$PROXYSQL_DATADIR" ]]; then
   PROXYSQL_DATADIR='/var/lib/proxysql'
@@ -22,8 +117,6 @@ fi
 #Timeout exists for instances where mysqld/proxysql may be hung
 TIMEOUT=5
 
-WRITE_HOSTGROUP_ID="${1:-0}"
-READ_HOSTGROUP_ID="${2:-0}"
 SLAVEREAD_HOSTGROUP_ID=$READ_HOSTGROUP_ID
 if [ $SLAVEREAD_HOSTGROUP_ID -eq $WRITE_HOSTGROUP_ID ];then
   let SLAVEREAD_HOSTGROUP_ID+=1

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -45,11 +45,11 @@ do
   case "$arg" in
     -- ) shift; break;;
     -w | --write-hg )
-      export WRITE_HOSTGROUP_ID="$2"
+      export WRITE_HG="$2"
       shift 2
     ;;
     -r | --read-hg )
-      export READ_HOSTGROUP_ID="$2"
+      export READ_HG="$2"
       shift 2
     ;;
     --config-file )
@@ -98,10 +98,19 @@ fi
 # DEFAULTS
 if [[ -z $WRITE_HOSTGROUP_ID ]]; then
   WRITE_HOSTGROUP_ID="1"
+else
+  if [[ ! -z $WRITE_HG ]]; then
+    WRITE_HOSTGROUP_ID=$WRITE_HG
+  fi
 fi
 if [[ -z $READ_HOSTGROUP_ID ]]; then
-  HOSTGROUP_READER_ID="-1"
+  READ_HOSTGROUP_ID="-1"
+else
+  if [[ ! -z $READ_HG ]]; then
+    READ_HOSTGROUP_ID=$READ_HG
+  fi
 fi
+
 if [[ -z $ERR_FILE ]]; then
   ERR_FILE="/dev/null"
 fi


### PR DESCRIPTION
This PR will allow us to handle multiple proxysql instances through `proxysql-admin` on the same box. 

The Galera monitor scripts will check PXC node status using respective `proxysql-admin` configuration files. We can pass these configuration files with `proxysql-admin` enable command and this info will be saved in scheduler table for Galera monitoring scripts reference. 

```
proxysql-admin --enable --config-file=/etc/proxysql-admin_6032.cnf
proxysql-admin --enable --config-file=/etc/proxysql-admin_6132.cnf 
```
With this change, `proxysql-admin` tool will add mode and host priority info in `scheduler` table and  we can get rid of physical files like `<cluster_name>_mode` and `<cluster_name>_host_priority`. 

Scheduler table entry in proxysql database.
```
ProxySQL Instance 1
mysql> select * from scheduler\G
*************************** 1. row ***************************
         id: 2
     active: 1
interval_ms: 3000
   filename: /bin/proxysql_galera_checker
       arg1: --write-hg=10
       arg2: --read-hg=11
       arg3: --config-file=/etc/proxysql-admin_6032.cnf
       arg4: --writer-count=1
       arg5: --log=/var/lib/proxysql_6032/cluster_one_proxysql_galera_check.log
    comment: cluster_one
1 row in set (0.00 sec)

mysql>

ProxySQL instance 2

mysql> select * from scheduler\G
*************************** 1. row ***************************
         id: 2
     active: 1
interval_ms: 3000
   filename: /bin/proxysql_galera_checker
       arg1: --write-hg=10
       arg2: --read-hg=11
       arg3: --config-file=/etc/proxysql-admin_6132.cnf
       arg4: --writer-count=1
       arg5: --log=/var/lib/proxysql_6132/cluster_one_proxysql_galera_check.log
    comment: cluster_one
1 row in set (0.00 sec)

mysql>

```
Prerequisites;
1) For backward compatibility, we need to update existing `scheduler` table based on new change.
```
Existing entry.
mysql> select * from scheduler\G
*************************** 1. row ***************************
         id: 1
     active: 1
interval_ms: 3000
   filename: /bin/proxysql_galera_checker
       arg1: 10
       arg2: 11
       arg3: 1
       arg4: 1
       arg5: /var/lib/proxysql/cluster_one_proxysql_galera_check.log
    comment: cluster_one
1 row in set (0.00 sec)

mysql>
```
Execute below update command on proxysql database;

```
UPDATE scheduler SET arg1 = '--config-file=/etc/proxysql-admin.cnf --write-hg=10 --read-hg=11 
--writer-count=1 --mode=singlewrite 
--priority=192.168.100.20:3306,192.168.100.40:3306,192.168.100.10:3306,192.168.100.30:3306 
--log=/var/lib/proxysql/cluster_one_proxysql_galera_check.log', 
arg2 = 'NULL', 
arg3 = 'NULL', 
arg4 = 'NULL', 
arg5 = 'NULL' 
where id=1 ;
```
Column `arg1` description.

```
--config-file  : Specify ProxySQL-admin configuration file.
--write-hg     : Specify ProxySQL write hostgroup.
--read-hg      : Specify ProxySQL read hostgroup.
--writer-count : Specify write nodes count. 0 for loadbal mode and 1 for singlewrite mode.
--mode         : Specify ProxySQL read/write configuration mode.
--priority     : Specify write nodes priority [ Optional ]
--log          : Specify proxysql_galera_checker log file.
```

Scheduler table info after update command.
```
mysql> select * from scheduler\G
*************************** 1. row ***************************
         id: 1
     active: 1
interval_ms: 3000
   filename: /bin/proxysql_galera_checker
       arg1: --config-file=/etc/proxysql-admin.cnf --write-hg=10 --read-hg=11 
               --writer-count=1 --mode=singlewrite 
               --priority=192.168.100.20:3306,192.168.100.40:3306,192.168.100.10:3306,192.168.100.30:3306 
               --log=/var/lib/proxysql/cluster_one_proxysql_galera_check.log
       arg2: NULL
       arg3: NULL
       arg4: NULL
       arg5: NULL
    comment: cluster_one
1 row in set (0.00 sec)

mysql>

```
