### PR TITLE
Psqladm 31

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -783,7 +783,7 @@ enable_proxysql(){
   else
     NUMBER_WRITERS=0
   fi
-  proxysql_exec "INSERT INTO SCHEDULER (active,interval_ms,filename,arg1,arg2,arg3,arg4,arg5,comment) VALUES (1,$NODE_CHECK_INTERVAL,'$PROXYSQL_GALERA_CHECK','--write-hg=$WRITE_HOSTGROUP_ID','--read-hg=$READ_HOSTGROUP_ID','--config-file=$CONFIG_FILE','--writer-count=$NUMBER_WRITERS','--log=$PROXYSQL_DATADIR/${CLUSTER_NAME}_proxysql_galera_check.log','$CLUSTER_NAME');"
+  proxysql_exec "INSERT INTO SCHEDULER (active,interval_ms,filename,arg1,comment) VALUES (1,$NODE_CHECK_INTERVAL,'$PROXYSQL_GALERA_CHECK','--write-hg=$WRITE_HOSTGROUP_ID --read-hg=$READ_HOSTGROUP_ID --config-file=$CONFIG_FILE --writer-count=$NUMBER_WRITERS --log=$PROXYSQL_DATADIR/${CLUSTER_NAME}_proxysql_galera_check.log','$CLUSTER_NAME');"
   check_cmd $? "Failed to add the Percona XtraDB Cluster monitoring scheduler in ProxySQL. Please check username, password and other options for connecting to ProxySQL database"
   
   proxysql_exec "LOAD SCHEDULER TO RUNTIME;SAVE SCHEDULER TO DISK;"

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -783,7 +783,7 @@ enable_proxysql(){
   else
     NUMBER_WRITERS=0
   fi
-  proxysql_exec "INSERT INTO SCHEDULER (active,interval_ms,filename,arg1,comment) VALUES (1,$NODE_CHECK_INTERVAL,'$PROXYSQL_GALERA_CHECK','--write-hg=$WRITE_HOSTGROUP_ID --read-hg=$READ_HOSTGROUP_ID --config-file=$CONFIG_FILE --writer-count=$NUMBER_WRITERS --log=$PROXYSQL_DATADIR/${CLUSTER_NAME}_proxysql_galera_check.log','$CLUSTER_NAME');"
+  proxysql_exec "INSERT INTO SCHEDULER (active,interval_ms,filename,arg1,comment) VALUES (1,$NODE_CHECK_INTERVAL,'$PROXYSQL_GALERA_CHECK','--config-file=$CONFIG_FILE --write-hg=$WRITE_HOSTGROUP_ID --read-hg=$READ_HOSTGROUP_ID --writer-count=$NUMBER_WRITERS --log=$PROXYSQL_DATADIR/${CLUSTER_NAME}_proxysql_galera_check.log','$CLUSTER_NAME');"
   check_cmd $? "Failed to add the Percona XtraDB Cluster monitoring scheduler in ProxySQL. Please check username, password and other options for connecting to ProxySQL database"
   
   proxysql_exec "LOAD SCHEDULER TO RUNTIME;SAVE SCHEDULER TO DISK;"

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -37,6 +37,16 @@ check_permission(){
   fi
 }
 
+# ProxySQL has only 5 slots for args and will send each argN 
+# between double quotes. We configure all parameters on arg1 field, so we 
+# don't get limited by 5 arguntes only. Below set will reshuffle parameters.
+# example arg1=" --one=1 --two=2" will result in:
+# $1 = --one=1
+# $2 0 --two=2
+if [ "$#" -eq 1 ]; then
+    set -- $1
+fi
+
 # Check if we have a functional getopt(1)
 if ! getopt --test
   then
@@ -182,11 +192,14 @@ if [[ ! -z $CONNECTION_MSG ]]; then
   exit 1
 fi
 
-CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1='--write-hg=$HOSTGROUP_WRITER_ID'")
+CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID%'")
 if [[ -z $CLUSTER_NAME ]]; then
   CLUSTER_NAME=$(mysql_exec "select @@wsrep_cluster_name" 2>>${ERR_FILE}| tail -1 2>>${ERR_FILE})
-  if [[ ! -z $CLUSTER_NAME ]]; then  
-    proxysql_exec "update scheduler set comment='$CLUSTER_NAME',arg5='--log=${PROXYSQL_DATADIR}/${CLUSTER_NAME}_proxysql_galera_check.log' where arg1='--write-hg=$HOSTGROUP_WRITER_ID';load scheduler to runtime;"
+  if [[ ! -z $CLUSTER_NAME ]]; then
+    ARG1=$(proxysql_exec "select arg1 from scheduler where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID%'")
+    MY_PATH=$(echo ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_proxysql_galera_check.log | sed  's#\/#\\\/#g')
+    ARG1=$(echo $ARG1 | sed "s/--log=.*/--log=$MY_PATH/g")
+    proxysql_exec "update scheduler set comment='$CLUSTER_NAME',arg1='$ARG1' where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID%';load scheduler to runtime;"
   fi
 fi
 

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -42,7 +42,7 @@ check_permission(){
 # don't get limited by 5 arguntes only. Below set will reshuffle parameters.
 # example arg1=" --one=1 --two=2" will result in:
 # $1 = --one=1
-# $2 0 --two=2
+# $2 = --two=2
 if [ "$#" -eq 1 ]; then
     set -- $1
 fi

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -278,9 +278,9 @@ if [[ ! -f /usr/bin/proxysql_node_monitor ]] ;then
   exit 1
 else
   if [[ -z $CLUSTER_NAME ]]; then
-    /usr/bin/proxysql_node_monitor --write-hg=$HOSTGROUP_WRITER_ID --read-hg=$HOSTGROUP_READER_ID --config-file=$CONFIG_FILE --log=${PROXYSQL_DATADIR}/proxysql_node_monitor.log
+    /usr/bin/proxysql_node_monitor --config-file=$CONFIG_FILE --write-hg=$HOSTGROUP_WRITER_ID --read-hg=$HOSTGROUP_READER_ID --log=${PROXYSQL_DATADIR}/proxysql_node_monitor.log
   else
-    /usr/bin/proxysql_node_monitor --write-hg=$HOSTGROUP_WRITER_ID --read-hg=$HOSTGROUP_READER_ID --config-file=$CONFIG_FILE --log=${PROXYSQL_DATADIR}/${CLUSTER_NAME}_proxysql_node_monitor.log
+    /usr/bin/proxysql_node_monitor --config-file=$CONFIG_FILE --write-hg=$HOSTGROUP_WRITER_ID --read-hg=$HOSTGROUP_READER_ID --log=${PROXYSQL_DATADIR}/${CLUSTER_NAME}_proxysql_node_monitor.log
   fi
 fi
 

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -135,7 +135,7 @@ proxysql_exec() {
 if [ $debug -eq 1 ];then echoit "DEBUG MODE: $MODE" ;fi
 
 if [ $debug -eq 1 ];then echoit "DEBUG check mode name from proxysql data directory " ;fi
-CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1=$WRITE_HOSTGROUP_ID")
+CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1 LIKE '%--write-hg=$WRITE_HOSTGROUP_ID'")
 if [[ -z $CLUSTER_NAME ]]; then
   if [[ -f ${PROXYSQL_DATADIR}/mode ]] ; then
     MODE=$(cat ${PROXYSQL_DATADIR}/mode)


### PR DESCRIPTION
@rameshvs02  Adjusted the scripts to accept everything on scheduler arg1.

- We need to make sure that we always pass `--config-file` as the first parameter. For example, if we have config file configured with `WRITE_HOSTGROUP=10` but we call `proxysql-admin --write-hostgroup=15`, we will end up having 15 on scheduler table. If we call `proxysql_node_monitor --write-hostgroup=15 --config-file=xxx` or `proxysql_galera_checker --write-hostgroup=15 --config-file=xxx` both will end up using 10 (config file value) instead of 15.

- Adjusted `proxysql_galera_checker` script to reshuffle arguments as ProxySQL  will pass everything as `argv[1] / $1`

TODO: We should port `mode` and `host_priority` to be passed as an argument instead of a physical file. 