### PR TITLE
PSQLADM-67 : With singlewrite mode, Galera checker is not changing writer hostgroup id when nodes become ONLINE from OFFLINE_SOFT

### DIFF
--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -368,6 +368,20 @@ update_cluster(){
         echoit "${ws_hg_id}:${i} node set to OFFLINE_SOFT status to ProxySQL database." 
         CHECK_STATUS=1
       fi
+      if [ "$MODE" == "singlewrite" ]; then
+        checkwriter_hid=`proxysql_exec "select hostgroup_id from mysql_servers where comment='WRITE' and status='ONLINE' and hostgroup_id in ($WRITE_HOSTGROUP_ID)"`
+        if [[ -z "$checkwriter_hid" ]]; then
+          current_hosts=(`proxysql_exec "SELECT hostname,port FROM mysql_servers WHERE  status='ONLINE' and comment='READ' and hostgroup_id='$READ_HOSTGROUP_ID' ORDER BY random() LIMIT 1" | sed 's|\t|:|g' | tr '\n' ' '`)
+          if [[ ! -z $current_hosts ]]; then
+            ws_ip=$(echo $current_hosts | cut -d':' -f1)
+            ws_port=$(echo $current_hosts | cut -d':' -f2)
+            echoit "No writer found, promoting $ws_ip:$ws_port as writer node!"
+            proxysql_exec "UPDATE mysql_servers set hostgroup_id = $WRITE_HOSTGROUP_ID, comment='WRITE', weight=1000000 WHERE hostname='$ws_ip' and port=$ws_port"
+            check_cmd $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check proxysql login credentials"
+            CHECK_STATUS=1
+          fi
+        fi
+      fi
     fi
   done
   if [ $debug -eq 1 ];then echoit "DEBUG End update_cluster" ;fi


### PR DESCRIPTION
If we do not have any write node in `singlewrite` mode, this will PR will promote one of the read nodes to write node