### PR TITLE
PSQLADM-69 : Reading multiple cluster name from scheduler if write ho…

### DIFF
--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -281,14 +281,14 @@ if [[ $CHECK_MONITOR_USER -ne 1 ]]; then
   echoit "Could not establish connection to PXC nodes using ProxySQL monitor credentials. Please check credentials or PXC running status." 
 fi
 
-CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID%'")
+CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID %'")
 if [[ -z $CLUSTER_NAME ]]; then
   CLUSTER_NAME=$(mysql_exec "select @@wsrep_cluster_name" 2>>${ERR_FILE}| tail -1 2>>${ERR_FILE})
   if [[ ! -z $CLUSTER_NAME ]]; then
-    ARG1=$(proxysql_exec "select arg1 from scheduler where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID%'")
+    ARG1=$(proxysql_exec "select arg1 from scheduler where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID %'")
     MY_PATH=$(echo ${PROXYSQL_DATADIR}/${CLUSTER_NAME}_proxysql_galera_check.log | sed  's#\/#\\\/#g')
     ARG1=$(echo $ARG1 | sed "s/--log=.*/--log=$MY_PATH/g")
-    proxysql_exec "update scheduler set comment='$CLUSTER_NAME',arg1='$ARG1' where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID%';load scheduler to runtime;"
+    proxysql_exec "update scheduler set comment='$CLUSTER_NAME',arg1='$ARG1' where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID %';load scheduler to runtime;"
   fi
 fi
 

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -156,7 +156,7 @@ proxysql_exec() {
 if [ $debug -eq 1 ];then echoit "DEBUG MODE: $MODE" ;fi
 
 if [ $debug -eq 1 ];then echoit "DEBUG check mode name from proxysql data directory " ;fi
-CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1 LIKE '%--write-hg=$WRITE_HOSTGROUP_ID%'")
+CLUSTER_NAME=$(proxysql_exec "select comment from scheduler where arg1 LIKE '%--write-hg=$WRITE_HOSTGROUP_ID %'")
 
 if [[ ! -z $P_MODE ]] ; then
   MODE=$P_MODE


### PR DESCRIPTION
…stgroup matches.

Issue:
When we search based on hostgroup ID we were using a regular expression, but it
wasn't terminated properly, we were doing things like '20%' rather than '20 %'.
Thus we would match anything that started with '20', such as '200', '201', etc...

Solution:
Add a space after the hostgroup ID.  When we write out the write hostgroup ID, it
is part of a larger string and will have a space after it.