### PR TITLE
PSQLADM-97 : Tests don't work with PXC 5.6

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -886,6 +886,8 @@ function enable_proxysql() {
       fi
     done
 
+    # TODO: kennt, shouldn't this be on the slave node?
+    # since that is where we will be querying for the slave status
     # GRANT REPLICATION CLIENT permissions to the monitoring user account
     echo -e "\nGranting 'REPLICATION CLIENT' privilege to $MONITOR_USERNAME@$USER_HOST_RANGE"
     mysql_exec "GRANT REPLICATION CLIENT ON *.* TO '$MONITOR_USERNAME'@'$USER_HOST_RANGE';"

--- a/tests/desynced-host-testsuite.bats
+++ b/tests/desynced-host-testsuite.bats
@@ -28,10 +28,11 @@ declare WEIGHTS=()
 
 load test-common
 
-wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
+WSREP_CLUSTER_NAME=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
+MYSQL_VERSION=$(cluster_exec "select @@version")
 
 # Note: 4110/4210  is left as an unprioritized node
-if [[ $wsrep_cluster_name == "cluster_one" ]]; then
+if [[ $WSREP_CLUSTER_NAME == "cluster_one" ]]; then
   PORT_1=4130
   PORT_2=4120
   PORT_NOPRIO=4110
@@ -114,13 +115,13 @@ function verify_initial_state() {
 }
 
 
-@test "run proxysql-admin -d ($wsrep_cluster_name)" {
+@test "run proxysql-admin -d ($WSREP_CLUSTER_NAME)" {
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
   echo "$output" >&2
   [ "$status" -eq  0 ]
 }
 
-@test "run proxysql-admin -e ($wsrep_cluster_name)" {
+@test "run proxysql-admin -e ($WSREP_CLUSTER_NAME)" {
   echo "priority_list is $PRIORITY_LIST" >& 2
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --writer-is-reader=ondemand <<< 'n'
   [ "$status" -eq  0 ]
@@ -136,7 +137,7 @@ function verify_initial_state() {
 }
 
 
-@test "desync node activation ($wsrep_cluster_name)" {
+@test "desync node activation ($WSREP_CLUSTER_NAME)" {
   #skip
   # PREPARE for the test
   # ========================================================
@@ -463,7 +464,7 @@ function verify_initial_state() {
 }
 
 
-@test "desync a writer node ($wsrep_cluster_name)" {
+@test "desync a writer node ($WSREP_CLUSTER_NAME)" {
   #skip
   # PREPARE for the test
   # ========================================================
@@ -579,8 +580,10 @@ function verify_initial_state() {
 }
 
 
-@test "desync node activation (nodes are disabled) ($wsrep_cluster_name)" {
+@test "desync node activation (nodes are disabled) ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
+
   # PREPARE for the test
   # ========================================================
   test_preparation

--- a/tests/host-priority-testsuite.bats
+++ b/tests/host-priority-testsuite.bats
@@ -25,10 +25,12 @@ declare STATUS=()
 
 load test-common
 
-wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
+WSREP_CLUSTER_NAME=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
+MYSQL_VERSION=$(cluster_exec "select @@version")
+
 
 # Note: 4110/4210  is left as an unprioritized node
-if [[ $wsrep_cluster_name == "cluster_one" ]]; then
+if [[ $WSREP_CLUSTER_NAME == "cluster_one" ]]; then
   PORT_1=4130
   PORT_2=4120
   PORT_NOPRIO=4110
@@ -131,13 +133,13 @@ function verify_initial_state() {
 }
 
 
-@test "run proxysql-admin -d ($wsrep_cluster_name)" {
+@test "run proxysql-admin -d ($WSREP_CLUSTER_NAME)" {
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
   echo "$output" >&2
   [ "$status" -eq  0 ]
 }
 
-@test "run proxysql-admin -e ($wsrep_cluster_name)" {
+@test "run proxysql-admin -e ($WSREP_CLUSTER_NAME)" {
   echo "priority_list is $PRIORITY_LIST" >& 2
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --writer-is-reader=ondemand --write-node=$PRIORITY_LIST <<< 'n'
   [ "$status" -eq  0 ]
@@ -153,7 +155,7 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing stopping (noprio 1 2) ($wsrep_cluster_name)" {
+@test "host-priority testing stopping (noprio 1 2) ($WSREP_CLUSTER_NAME)" {
   #skip
   # PREPARE for the test
   # ========================================================
@@ -341,7 +343,7 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing stopping (noprio 2 1) ($wsrep_cluster_name)" {
+@test "host-priority testing stopping (noprio 2 1) ($WSREP_CLUSTER_NAME)" {
   #skip
   # PREPARE for the test
   # ========================================================
@@ -564,7 +566,7 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing stopping (1 noprio 2) ($wsrep_cluster_name)" {
+@test "host-priority testing stopping (1 noprio 2) ($WSREP_CLUSTER_NAME)" {
   #skip
   # PREPARE for the test
   # ========================================================
@@ -750,7 +752,7 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing stopping (1 2 noprio) ($wsrep_cluster_name)" {
+@test "host-priority testing stopping (1 2 noprio) ($WSREP_CLUSTER_NAME)" {
   #skip
   # PREPARE for the test
   # ========================================================
@@ -906,7 +908,7 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing stopping (2 noprio 1) ($wsrep_cluster_name)" {
+@test "host-priority testing stopping (2 noprio 1) ($WSREP_CLUSTER_NAME)" {
   #skip
   # PREPARE for the test
   # ========================================================
@@ -1096,7 +1098,7 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing stopping (2 1 noprio) ($wsrep_cluster_name)" {
+@test "host-priority testing stopping (2 1 noprio) ($WSREP_CLUSTER_NAME)" {
   #skip
   # PREPARE for the test
   # ========================================================
@@ -1256,8 +1258,10 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing disabling (noprio 1 2) ($wsrep_cluster_name)" {
+@test "host-priority testing disabling (noprio 1 2) ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
+
   # PREPARE for the test
   # ========================================================
   test_preparation
@@ -1424,8 +1428,10 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing disabling (noprio 2 1) ($wsrep_cluster_name)" {
+@test "host-priority testing disabling (noprio 2 1) ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
+
   # PREPARE for the test
   # ========================================================
   test_preparation
@@ -1618,8 +1624,10 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing disabling (1 noprio 2) ($wsrep_cluster_name)" {
+@test "host-priority testing disabling (1 noprio 2) ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
+
   # PREPARE for the test
   # ========================================================
   test_preparation
@@ -1803,8 +1811,10 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing disabling (1 2 noprio) ($wsrep_cluster_name)" {
+@test "host-priority testing disabling (1 2 noprio) ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
+
   # PREPARE for the test
   # ========================================================
   test_preparation
@@ -1962,8 +1972,10 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing disabling (2 noprio 1) ($wsrep_cluster_name)" {
+@test "host-priority testing disabling (2 noprio 1) ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
+
   # PREPARE for the test
   # ========================================================
   test_preparation
@@ -2129,8 +2141,10 @@ function verify_initial_state() {
 }
 
 
-@test "host-priority testing disabling (2 1 noprio) ($wsrep_cluster_name)" {
+@test "host-priority testing disabling (2 1 noprio) ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
+
   # PREPARE for the test
   # ========================================================
   test_preparation
@@ -2301,7 +2315,7 @@ function verify_initial_state() {
 }
 
 
-@test "priority-list has no active nodes ($wsrep_cluster_name)" {
+@test "priority-list has no active nodes and stop writer ($WSREP_CLUSTER_NAME)" {
   #skip
   # PREPARE for the test
   # ========================================================
@@ -2419,6 +2433,58 @@ function verify_initial_state() {
   [ "${read_weight[0]}" -eq 1000 ]
   [ "${read_weight[1]}" -eq 1000 ]
   [ "${read_weight[2]}" -eq 1000 ]
+}
+
+
+@test "priority-list has no active nodes and stop reader ($WSREP_CLUSTER_NAME)" {
+  #skip
+  # PREPARE for the test
+  # ========================================================
+  test_preparation
+  verify_initial_state
+
+  # Store some special variables
+  host=${write_host[0]}
+
+  local new_priority_list="127.0.0.1:9000,127.0.0.1:9001"
+
+  # Swap the old priority list for the new priority list in the
+  # galera_checker
+  GALERA_CHECKER=$(proxysql_exec "SELECT filename FROM scheduler WHERE id=$SCHEDULER_ID")
+  GALERA_CHECKER_ARGS=$(proxysql_exec "SELECT arg1 FROM scheduler WHERE id=$SCHEDULER_ID")
+  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST}/${new_priority_list}/g")
+
+  echo $GALERA_CHECKER_ARGS >&2
+
+  # Run the checker, no change
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='host-priority $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_port[0]}" -eq "$PORT_1" ]
+  [ "${read_port[0]}" -eq "$PORT_1" ]
+  [ "${read_port[1]}" -eq "$PORT_NOPRIO" ]
+  [ "${read_port[2]}" -eq "$PORT_2" ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
 
   # TEST stop reader node
   # ========================================================
@@ -2526,7 +2592,60 @@ function verify_initial_state() {
   [ "${read_weight[0]}" -eq 1000 ]
   [ "${read_weight[1]}" -eq 1000 ]
   [ "${read_weight[2]}" -eq 1000 ]
+}
 
+
+@test "priority-list has no active nodes and disable writer ($WSREP_CLUSTER_NAME)" {
+  #skip
+  require_pxc_maint_mode
+
+  # PREPARE for the test
+  # ========================================================
+  test_preparation
+  verify_initial_state
+
+  # Store some special variables
+  host=${write_host[0]}
+
+  local new_priority_list="127.0.0.1:9000,127.0.0.1:9001"
+
+  # Swap the old priority list for the new priority list in the
+  # galera_checker
+  GALERA_CHECKER=$(proxysql_exec "SELECT filename FROM scheduler WHERE id=$SCHEDULER_ID")
+  GALERA_CHECKER_ARGS=$(proxysql_exec "SELECT arg1 FROM scheduler WHERE id=$SCHEDULER_ID")
+  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST}/${new_priority_list}/g")
+
+  echo $GALERA_CHECKER_ARGS >&2
+
+  # Run the checker, no change
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='host-priority $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_port[0]}" -eq "$PORT_1" ]
+  [ "${read_port[0]}" -eq "$PORT_1" ]
+  [ "${read_port[1]}" -eq "$PORT_NOPRIO" ]
+  [ "${read_port[2]}" -eq "$PORT_2" ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
 
   # TEST disable writer node (pxc_maint_mode)
   # ========================================================
@@ -2631,7 +2750,60 @@ function verify_initial_state() {
   [ "${read_weight[0]}" -eq 1000 ]
   [ "${read_weight[1]}" -eq 1000 ]
   [ "${read_weight[2]}" -eq 1000 ]
+}
 
+
+@test "priority-list has no active nodes and disable reader ($WSREP_CLUSTER_NAME)" {
+  #skip
+  require_pxc_maint_mode
+
+  # PREPARE for the test
+  # ========================================================
+  test_preparation
+  verify_initial_state
+
+  # Store some special variables
+  host=${write_host[0]}
+
+  local new_priority_list="127.0.0.1:9000,127.0.0.1:9001"
+
+  # Swap the old priority list for the new priority list in the
+  # galera_checker
+  GALERA_CHECKER=$(proxysql_exec "SELECT filename FROM scheduler WHERE id=$SCHEDULER_ID")
+  GALERA_CHECKER_ARGS=$(proxysql_exec "SELECT arg1 FROM scheduler WHERE id=$SCHEDULER_ID")
+  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST}/${new_priority_list}/g")
+
+  echo $GALERA_CHECKER_ARGS >&2
+
+  # Run the checker, no change
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='host-priority $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_port[0]}" -eq "$PORT_1" ]
+  [ "${read_port[0]}" -eq "$PORT_1" ]
+  [ "${read_port[1]}" -eq "$PORT_NOPRIO" ]
+  [ "${read_port[2]}" -eq "$PORT_2" ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
 
   # TEST disable reader node (pxc_maint_mode)
   # ========================================================
@@ -2744,7 +2916,7 @@ function verify_initial_state() {
 }
 
 
-@test "match the priority-list in the middle of the list ($wsrep_cluster_name)" {
+@test "match the priority-list in the middle of the list ($WSREP_CLUSTER_NAME)" {
   #skip
   # PREPARE for the test
   # ========================================================

--- a/tests/test-common.bash
+++ b/tests/test-common.bash
@@ -271,7 +271,7 @@ function restart_server() {
   if [[ ! $new_start_cmd =~ --user=$restart_user ]]; then
     options+="--user=$restart_user"
   fi
-  nohup $new_start_cmd $options 3>- &>/dev/null &
+  nohup $new_start_cmd $options 3>&- &>/dev/null &
 }
 
 function dump_nodes() {
@@ -288,4 +288,10 @@ function dump_runtime_nodes() {
   echo "$lineno Dumping runtime server info : $msg" >&2
   proxysql_exec "SELECT hostgroup_id,hostname,port,status,comment,weight FROM runtime_mysql_servers WHERE hostgroup_id IN ($WRITE_HOSTGROUP_ID, $READ_HOSTGROUP_ID) ORDER BY hostgroup_id,status,hostname,port" >&2
   echo "" >&2
+}
+
+function require_pxc_maint_mode() {
+  if [[ $MYSQL_VERSION =~ ^5.5 || $MYSQL_VERSION =~ ^5.6 ]]; then
+    skip "requires pxc_maint_mode"
+  fi
 }

--- a/tests/writer-is-reader-testsuite.bats
+++ b/tests/writer-is-reader-testsuite.bats
@@ -29,8 +29,11 @@ declare WEIGHTS=()
 declare GALERA_CHECKER
 declare GALERA_CHECKER_ARGS
 
+
 load test-common
 
+WSREP_CLUSTER_NAME=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
+MYSQL_VERSION=$(cluster_exec "select @@version")
 
 function test_preparation() {
   local sched_id
@@ -123,23 +126,20 @@ function verify_initial_state() {
   fi
 }
 
-
-wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
-
-@test "run proxysql-admin -d ($wsrep_cluster_name)" {
+@test "run proxysql-admin -d ($WSREP_CLUSTER_NAME)" {
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin -d
   echo "$output"
   [ "$status" -eq  0 ]
 }
 
-@test "run proxysql-admin -e ($wsrep_cluster_name)" {
+@test "run proxysql-admin -e ($WSREP_CLUSTER_NAME)" {
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin -e --writer-is-reader=never <<< 'n'
   echo "$output"
   [ "$status" -eq  0 ]
 }
 
 
-@test "run proxysql_galera_checker ($wsrep_cluster_name)" {
+@test "run proxysql_galera_checker ($WSREP_CLUSTER_NAME)" {
   #skip
 
   # SETUP (determine some of the parameters, such as READ/WRITE nodes)
@@ -166,7 +166,7 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=never stop/start a reader ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=never stop/start a reader ($WSREP_CLUSTER_NAME)" {
   #skip
 
   # SYNC up with the runtime
@@ -307,7 +307,7 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=never stop/start a writer ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=never stop/start a writer ($WSREP_CLUSTER_NAME)" {
   #skip
 
   # SYNC up with the runtime
@@ -460,8 +460,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=never disable/enable a reader ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=never disable/enable a reader ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)
@@ -576,8 +577,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=never disable/enable a writer ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=never disable/enable a writer ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)
@@ -721,7 +723,7 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=never stopping all readers ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=never stopping all readers ($WSREP_CLUSTER_NAME)" {
   #skip
 
   # SYNC up with the runtime
@@ -879,8 +881,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=never disabling all readers ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=never disabling all readers ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)
@@ -1023,8 +1026,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=never mix stop/disable ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=never mix stop/disable ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)
@@ -1156,7 +1160,7 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=always stop/start a reader ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=always stop/start a reader ($WSREP_CLUSTER_NAME)" {
   #skip
 
   # SYNC up with the runtime
@@ -1329,7 +1333,7 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=always stop/start a writer ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=always stop/start a writer ($WSREP_CLUSTER_NAME)" {
   #skip
 
   # SYNC up with the runtime
@@ -1495,8 +1499,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=always disable/enable a reader ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=always disable/enable a reader ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)
@@ -1619,8 +1624,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=always disable/enable a writer ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=always disable/enable a writer ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)
@@ -1786,7 +1792,7 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=always stopping all readers ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=always stopping all readers ($WSREP_CLUSTER_NAME)" {
   #skip
 
   # SYNC up with the runtime
@@ -1969,8 +1975,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=always disabling all readers ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=always disabling all readers ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)
@@ -2136,8 +2143,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=always mix stop/disable  ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=always mix stop/disable  ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)
@@ -2287,7 +2295,7 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=ondemand stop/start a reader ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=ondemand stop/start a reader ($WSREP_CLUSTER_NAME)" {
   #skip
 
   # SYNC up with the runtime
@@ -2460,7 +2468,7 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=ondemand stop/start a writer ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=ondemand stop/start a writer ($WSREP_CLUSTER_NAME)" {
   #skip
 
   # SYNC up with the runtime
@@ -2629,8 +2637,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=ondemand disable/enable a reader ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=ondemand disable/enable a reader ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)
@@ -2752,8 +2761,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=ondemand stop/start a writer ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=ondemand disable/enable a writer ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)
@@ -2921,7 +2931,7 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=ondemand stopping all readers ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=ondemand stopping all readers ($WSREP_CLUSTER_NAME)" {
   #skip
 
   # SYNC up with the runtime
@@ -3110,8 +3120,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=ondemand disabling all readers ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=ondemand disabling all readers ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)
@@ -3283,8 +3294,9 @@ wsrep_cluster_name=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
 }
 
 
-@test "test --writer-is-reader=ondemand mix stop/disable ($wsrep_cluster_name)" {
+@test "test --writer-is-reader=ondemand mix stop/disable ($WSREP_CLUSTER_NAME)" {
   #skip
+  require_pxc_maint_mode
 
   # SYNC up with the runtime
   # (For a consistent starting point)


### PR DESCRIPTION
Issue:
The tests fail in various places.  Ther are several reasons.
The first reason is that some of the tests disable the nodes
using pxc_maint_mode which is not supported in PXC 5.6. The
second reason is the differences in permissions/passwords
between 5.6 and 5.7.

Solution:
Add a version check and skip any test using pxc_maint_mode.
Also initialize the nodes differently (for accounts/permissions)
for 5.6