### PR TITLE
Added --user option in mysql config file and resolved monitor user cr…

### DIFF
--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -158,6 +158,7 @@ function start_pxc_node(){
   echo "enforce-gtid-consistency" >> my.cnf
   echo "log-slave-updates" >> my.cnf
   echo "log-bin" >> my.cnf
+  echo "user=$OS_USER" >> my.cnf
   if [[ $MYSQL_VERSION != "5.6" ]]; then
     echo "wsrep_slave_threads=2" >> my.cnf
     echo "pxc_maint_transition_period=1" >> my.cnf
@@ -241,7 +242,7 @@ function start_async_slave() {
   echo "enforce-gtid-consistency" >> my-slave.cnf
   echo "log-slave-updates" >> my-slave.cnf
   echo "log-bin" >> my-slave.cnf
-
+  echo "user=$OS_USER" >> my-slave.cnf
   # This is a requirement for proxysql-admin
   echo "read-only=1" >> my-slave.cnf
 

--- a/tests/writer-is-reader-testsuite.bats
+++ b/tests/writer-is-reader-testsuite.bats
@@ -133,7 +133,7 @@ function verify_initial_state() {
 }
 
 @test "run proxysql-admin -e ($WSREP_CLUSTER_NAME)" {
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin -e --writer-is-reader=never <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin -e --without-check-monitor-user --writer-is-reader=never <<< 'n'
   echo "$output"
   [ "$status" -eq  0 ]
 }


### PR DESCRIPTION
…edetial issue with writer-is-reader-testsuite.bats

Issues:
1) PXC startup is failing in `proxysql-admin` test suite if we run the suite from `root` user.
2) `writer-is-reader-testsuite.bats` testsuite is failing due to existing monitor user.
```
cluster_one : writer-is-reader-testsuite.bats
 ✓ run proxysql-admin -d (cluster_one)
 ✗ run proxysql-admin -e (cluster_one)
[..]
   ERROR 1045 (28000): Access denied for user 'monitor'@'localhost' (using password: YES)
   ERROR (line:898) : Failed to connect to Percona XtraDB Cluster using monitor credentials.
   -- Please check MONITOR_USERNAME and MONITOR_PASSWORD
```
Solution:
1) Added `--user` option in mysql config file for PXC startup
2) Added `--without-check-monitor-user` option in `proxysql-admin` tool to skip monitor user credetial check.