### PR TITLE
PSQLADM-112 : proxysql_galera_checker: line 1978 P_MODE unbound variable

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -1495,6 +1495,9 @@ function parse_args() {
         QUICK_DEMO=1
         ENABLE=1
         ;;
+      *)
+        shift
+        ;;
     esac
   done
 

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -47,7 +47,7 @@ declare -i  NUMBER_WRITERS=0
 
 declare     WRITER_IS_READER="ondemand"
 
-declare     P_MODE
+declare     P_MODE=""
 declare     P_PRIORITY=""
 
 declare     MYSQL_USERNAME
@@ -165,7 +165,6 @@ Options:
   -p, --priority=<HOST_LIST>          Can accept comma delimited list of write nodes priority
   -m, --mode=[loadbal|singlewrite]    ProxySQL read/write configuration mode,
                                       currently supporting: 'loadbal' and 'singlewrite'
-                                      (default: 'singlewrite')
   --writer-is-reader=<value>          Defines if the writer node also accepts writes.
                                       Possible values are 'always', 'never', and 'ondemand'.
                                       'ondemand' means that the writer node only accepts reads

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -87,7 +87,6 @@ EOF
 
 
 function parse_args() {
-  echo "$@"
   local param value
   local positional_params=""
   while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
Issue
If the mode was not set on the command-line, this variable was used
without being set (thus the error)

Solution
Initialize the variable P_MODE to ""
Also fixed the help text to remove the notice that the mode has a
default value of 'singlewrite'.  This is incorrect as we try to look
for the mode file and will also check the mysql_servers entries to see
if the mode is 'singlewrite' or 'loadbal'