### PR TITLE
PSQLADM-113 : proxysql_galera_checker assumes parameters given in lon…

### DIFF
--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -1934,8 +1934,11 @@ function main() {
   MYSQL_PASSWORD=$(echo $mysql_credentials | awk '{print $2}')
 
   # Search for the scheduler id that corresponds to our write hostgroup
-  scheduler_id=$(proxysql_exec $LINENO -Ns "SELECT id FROM scheduler where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID %'")
-  cluster_name=$(proxysql_exec $LINENO -Ns "SELECT comment FROM scheduler WHERE id=${scheduler_id}")
+  scheduler_id=$(proxysql_exec $LINENO -Ns "SELECT id FROM scheduler where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID %' OR arg1 LIKE '%-w $HOSTGROUP_WRITER_ID %'")
+  if [[ -z $scheduler_id ]]; then
+    error $LINENO "Cannot find the scheduler row with write hostgroup : $HOSTGROUP_WRITER_ID"
+  fi
+  cluster_name=$(proxysql_exec $LINENO -Ns "SELECT comment FROM scheduler WHERE id=${scheduler_id}" 2>>$ERR_FILE)
   if [[ -z $cluster_name ]]; then
     #
     # Could not find the cluster name from the scheduler,

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -822,7 +822,7 @@ function parse_args() {
   debug $LINENO "#### PROXYSQL NODE MONITOR ARGUMENT CHECKING"
   debug $LINENO "MODE: $MODE"
   debug $LINENO "check mode name from proxysql data directory "
-  CLUSTER_NAME=$(proxysql_exec $LINENO "SELECT comment from scheduler where arg1 LIKE '%--write-hg=$WRITE_HOSTGROUP_ID %'")
+  CLUSTER_NAME=$(proxysql_exec $LINENO "SELECT comment from scheduler where arg1 LIKE '%--write-hg=$WRITE_HOSTGROUP_ID %' OR arg1 LIKE '%-w $WRITE_HOSTGROUP_ID %'")
   check_cmd $LINENO $? "Cannot connect to ProxySQL at $PROXYSQL_HOSTNAME:$PROXYSQL_PORT"
   if [[ ! -z $p_mode ]] ; then
     MODE=$p_mode

--- a/tools/run_galera_checker
+++ b/tools/run_galera_checker
@@ -153,7 +153,7 @@ if [[ -z $WRITE_HG ]]; then
 fi
 
 # Retrieve the scheduler information for this write hostgroup
-scheduler_id=$(exec_sql "-Ns" "SELECT id FROM scheduler WHERE arg1 like '% --write-hg=$WRITE_HOSTGROUP_ID %'")
+scheduler_id=$(exec_sql "-Ns" "SELECT id FROM scheduler WHERE arg1 like '% --write-hg=$WRITE_HOSTGROUP_ID %' OR  arg1 like '% -w $WRITE_HOSTGROUP_ID %'")
 if [[ -z $scheduler_id ]]; then
   echo "Error: Could not retrieve the scheduler for write hostgroup: $WRITE_HG"
   exit 1
@@ -167,7 +167,7 @@ if [[ -z $galera_checker || -z $galera_checker_args ]]; then
 fi
 
 if [[ $DEBUG -ne 0 ]]; then
-  if [[ ! " $galera_checker_args " =~ "[[:space:]]--debug[[:space:]]" ]]; then
+  if [[ ! " $galera_checker_args " =~ [[:space:]]--debug[[:space:]] ]]; then
     galera_checker_args+=" --debug"
   fi
 fi
@@ -188,8 +188,7 @@ if [[ -n $NODE_MONITOR_LOG ]]; then
   galera_checker_args+=" --node-monitor-log=$NODE_MONITOR_LOG"  
 fi
 
-echo "$galera_checker_args"
-# TODO: Do we need to setup the paths?
+# TODO: kennt, should support --log-text also
 
 # Execute the galera checker statement
 ${galera_checker} "${galera_checker_args}"


### PR DESCRIPTION
…g format

Issue:
The proxysql_galera_checker searches the scheduler based on the
write hostgroups.  But we are searching by the long option (--write-hg)
and therefore was not able to find the correct row if the short option (-w)
was used.

Solution:
Also search based on the short option (-w <hostgroup>)