### PR TITLE
PSQLADM-107 : include-slaves - do not move slaves into write hostgrou…

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -71,6 +71,7 @@ declare    CLUSTER_PORT=""
 declare    SLAVE_NODES=""
 declare    SLAVE_HOSTNAME=""
 declare    SLAVE_PORT=""
+declare    SLAVE_IS_WRITER=""
 
 declare    MODE="singlewrite"
 declare -i NODE_CHECK_INTERVAL=3000
@@ -178,9 +179,14 @@ Options:
                                      the highest priority.
   --include-slaves=host_name:port    Add specified slave node(s) to ProxySQL, these nodes will go
                                      into the reader hostgroup and will only be put into
-                                     the writer hostgroup if all cluster nodes are down.
+                                     the writer hostgroup if all cluster nodes are down (this
+                                     depends on the value of --use-slave-as-writer).
                                      Slaves must be read only.  Can accept a comma delimited list.
                                      If this is used make sure 'read_only=1' is in the slave's my.cnf
+  --use-slave-as-writer=<yes/no>     If this value is 'yes', then a slave may be used as a writer
+                                     if the entire cluster is down. If 'no', then a slave
+                                     will not be used as a writer. This option is required
+                                     if '--include-slaves' is used.
   --writer-is-reader=<value>         Defines if the writer node also accepts writes.
                                      Possible values are 'always', 'never', and 'ondemand'.
                                      'ondemand' means that the writer node only accepts reads
@@ -1127,7 +1133,7 @@ function enable_proxysql() {
   else
     number_writers=0
   fi
-  proxysql_exec "$LINENO" "INSERT INTO SCHEDULER (active,interval_ms,filename,arg1,comment) VALUES (1,$NODE_CHECK_INTERVAL,'$proxysql_galera_check','--config-file=$CONFIG_FILE --writer-is-reader=$WRITER_IS_READER --write-hg=$WRITE_HOSTGROUP_ID --read-hg=$READ_HOSTGROUP_ID --writer-count=$number_writers --mode=$MODE $host_priority --log=$PROXYSQL_DATADIR/${cluster_name}_proxysql_galera_check.log','$cluster_name');"
+  proxysql_exec "$LINENO" "INSERT INTO SCHEDULER (active,interval_ms,filename,arg1,comment) VALUES (1,$NODE_CHECK_INTERVAL,'$proxysql_galera_check','--config-file=$CONFIG_FILE --writer-is-reader=$WRITER_IS_READER --write-hg=$WRITE_HOSTGROUP_ID --read-hg=$READ_HOSTGROUP_ID --writer-count=$number_writers --mode=$MODE $host_priority --use-slave-as-writer=$SLAVE_IS_WRITER --log=$PROXYSQL_DATADIR/${cluster_name}_proxysql_galera_check.log','$cluster_name');"
   check_cmd $? $LINENO "Failed to add the PXC monitoring scheduler in ProxySQL."\
                        "\n-- Please check the ProxySQL connection parameters and status."
 
@@ -1461,7 +1467,7 @@ function parse_args() {
   # TODO: kennt, what happens if we don't have a functional getopt()?
   # Check if we have a functional getopt(1)
   if ! getopt --test; then
-    go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-datadir:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,include-slaves:,use-existing-monitor-password,without-cluster-app-user,writer-is-reader:,enable,disable,adduser,syncusers,sync-multi-cluster-users,version,debug,help \
+    go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-datadir:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,include-slaves:,use-slave-as-writer:,use-existing-monitor-password,without-cluster-app-user,writer-is-reader:,enable,disable,adduser,syncusers,sync-multi-cluster-users,version,debug,help \
     --name="$(basename "$0")" -- "$@")"
     check_cmd $? $LINENO "Script error: getopt() failed with arguments: $@"
     eval set -- "$go_out"
@@ -1675,6 +1681,10 @@ function parse_args() {
         SLAVE_NODES=`echo "$2" | sed 's/,/ /g'`
         shift 2
         ;;
+      --use-slave-as-writer )
+        SLAVE_IS_WRITER="$2"
+        shift 2
+        ;;
       --quick-demo )
         shift
         QUICK_DEMO=1
@@ -1821,6 +1831,21 @@ function parse_args() {
     exit 1
   fi
 
+  if [[ -n $SLAVE_NODES ]]; then
+    if [[ -z $SLAVE_IS_WRITER ]]; then
+      error "" "Missing option: If --include-slaves is used, then --use-slave-as-writer must be set also"
+      exit 1
+    fi
+  elif [[ -z $SLAVE_IS_WRITER ]]; then
+    SLAVE_IS_WRITER="no"
+  fi
+
+  if [[ ! $SLAVE_IS_WRITER =~ ^(yes|YES|no|NO)$ ]]; then
+    error "" "Invalid --use-slave-as-writer option: '$SLAVE_IS_WRITER'"
+    echo "Please choose yes or no"
+    exit 1
+  fi
+
   readonly WRITE_HOSTGROUP_ID
   readonly READ_HOSTGROUP_ID
   readonly SLAVEREAD_HOSTGROUP_ID
@@ -1829,6 +1854,9 @@ function parse_args() {
   readonly WRITE_NODES
   readonly ENABLE_PRIORITY
   readonly P_HOST_PRIORITY
+
+  readonly SLAVE_NODES
+  readonly SLAVE_IS_WRITER
 
   readonly ENABLE
   readonly DISABLE

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -47,6 +47,8 @@ declare -i  NUMBER_WRITERS=0
 
 declare     WRITER_IS_READER="ondemand"
 
+declare     SLAVE_IS_WRITER="yes"
+
 declare     P_MODE=""
 declare     P_PRIORITY=""
 
@@ -170,7 +172,10 @@ Options:
                                       'ondemand' means that the writer node only accepts reads
                                       if there are no other readers.
                                       (default: 'never')
-
+  --use-slave-as-writer=<yes/no>      If this is 'yes' then slave nodes may
+                                      be added to the write hostgroup if all other
+                                      cluster nodes are down.
+                                      (default: 'yes')
   -h, --help                          Display script usage information
   -v, --version                       Print version info
 
@@ -536,7 +541,7 @@ function parse_args() {
   # TODO: kennt, what happens if we don't have a functional getopt()?
   # Check if we have a functional getopt(1)
   if ! getopt --test; then
-    go_out="$(getopt --options=w:r:c:l:n:m:p:vh --longoptions=write-hg:,read-hg:,config-file:,log:,node-monitor-log:,writer-count:,mode:,priority:,writer-is-reader:,log-text:,version,debug,help \
+    go_out="$(getopt --options=w:r:c:l:n:m:p:vh --longoptions=write-hg:,read-hg:,config-file:,log:,node-monitor-log:,writer-count:,mode:,priority:,writer-is-reader:,use-slave-as-writer:,log-text:,version,debug,help \
     --name="$(basename "$0")" -- "$@")"
     if [[ $? -ne 0 ]]; then
       # no place to send output
@@ -577,6 +582,9 @@ function parse_args() {
         ;;
       --debug)
         DEBUG=1
+        shift
+        ;;
+      *)
         shift
         ;;
     esac
@@ -660,6 +668,10 @@ function parse_args() {
         WRITER_IS_READER="$2"
         shift 2
       ;;
+      --use-slave-as-writer )
+        SLAVE_IS_WRITER="$2"
+        shift 2
+      ;;
       --debug )
         # Not handled here, see above
         shift
@@ -718,6 +730,17 @@ function parse_args() {
     exit 1
   fi
 
+  if [[ ! $SLAVE_IS_WRITER =~ ^(yes|YES|no|NO)$ ]]; then
+    error "" "Invalid --use-slave-as-writer option: '$SLAVE_IS_WRITER'"
+    echo "Please choose either yes or no"
+    exit 1
+  fi
+  if [[ $SLAVE_IS_WRITER =~ ^(yes|YES)$ ]]; then
+    SLAVE_IS_WRITER="yes"
+  else
+    SLAVE_IS_WRITER="no"
+  fi
+
   # These may get set in the config file, but they are not used
   # by this script.  So to avoid confusion and problems, remove
   # these variables explicitly.
@@ -735,6 +758,7 @@ function parse_args() {
   readonly NUMBER_WRITERS
 
   readonly WRITER_IS_READER
+  readonly SLAVE_IS_WRITER
 
   readonly P_PRIORITY
   readonly P_MODE
@@ -2167,7 +2191,11 @@ function main() {
 
     log $LINENO "###### ASYNC-SLAVE ACTIVITY ######"
 
-    if [[ $number_readers_online -eq 0 && $number_writers_online -eq 0 ]]; then
+    # If use-slave-as-writer is set, then we do not allow slaves to
+    # be added, however we still call the remove slave writers
+    # in case the option was just changed.
+
+    if [[ $SLAVE_IS_WRITER == "yes" && $number_readers_online -eq 0 && $number_writers_online -eq 0 ]]; then
       # No cluster nodes active, add a slave to the writer hostgroup
       debug $LINENO "Nothing in the cluster, checking slavereaders"
       add_slave_to_write_hostgroup "${reload_check_file}"

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -712,6 +712,9 @@ function parse_args() {
         DEBUG=1
         shift
         ;;
+      *)
+        shift
+        ;;
     esac
   done
 

--- a/tests/async-slave-testsuite.bats
+++ b/tests/async-slave-testsuite.bats
@@ -151,7 +151,7 @@ function verify_initial_state() {
   [ "${slave_io_running}" = "Yes" ]
   [ "${slave_sql_running}" = "Yes" ]
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --include-slaves=127.0.0.1:$PORT_SLAVE1 --writer-is-reader=ondemand <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --include-slaves=127.0.0.1:$PORT_SLAVE1 --use-slave-as-writer=yes --writer-is-reader=ondemand <<< 'n'
   [ "$status" -eq  0 ]
 
   #
@@ -1209,6 +1209,1047 @@ function verify_initial_state() {
   [ "${slave_port[1]}" -eq $PORT_SLAVE1 ]
   [ "${slave_status[1]}" = "ONLINE" ]
   [ "${slave_hostgroup[1]}" -eq $READ_HOSTGROUP_ID ]
+
+
+  # REACTIVATE the scheduler
+  # ========================================================
+  #proxysql_exec "UPDATE scheduler SET active=1 WHERE id=$SCHEDULER_ID; LOAD scheduler TO RUNTIME"
+}
+
+@test "run proxysql-admin -d (restart fot use-slave-as-writer tests) ($WSREP_CLUSTER_NAME)" {
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  echo "$output" >&2
+  [ "$status" -eq  0 ]
+}
+
+@test "run proxysql-admin -e --use-slave-as-writer=no ($WSREP_CLUSTER_NAME)" {
+  echo "$LINENO Starting the slave on port:$PORT_SLAVE1" >&2
+  run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "START SLAVE"
+  [ "$status" -eq 0 ]
+
+  result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
+  master_host=$(echo "$result" | cut -d: -f1)
+  slave_io_running=$(echo "$result" | cut -d: -f2)
+  slave_sql_running=$(echo "$result" | cut -d: -f3)
+
+  [ -n "${master_host}" ]
+  [ "${slave_io_running}" = "Yes" ]
+  [ "${slave_sql_running}" = "Yes" ]
+
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --include-slaves=127.0.0.1:$PORT_SLAVE1 --use-slave-as-writer=no --writer-is-reader=ondemand <<< 'n'
+  [ "$status" -eq  0 ]
+
+  #
+  # DEACTIVATE the scheduler line (call proxysql_GALERA_CHECKER manually)
+  # For ALL of the tests
+  # ========================================================
+  local sched_id
+  sched_id=$(proxysql_exec "SELECT id FROM scheduler WHERE arg1 like '% --write-hg=$WRITE_HOSTGROUP_ID %'")
+  run proxysql_exec "UPDATE scheduler SET active=0 WHERE id=$sched_id; LOAD scheduler TO RUNTIME"
+  [ "$status" -eq  0 ]
+}
+
+@test "stopping and restarting the slave --use-slave-as-writer=no ($WSREP_CLUSTER_NAME)" {
+  #skip
+  # PREPARE for the test
+  # ========================================================
+  test_preparation
+  verify_initial_state
+
+  # Store some special variables
+  retrieve_writer_info
+  host=${write_host[0]}
+
+  # Stop the slave
+  echo "$LINENO Stopping the slave on port:$PORT_SLAVE1" >&2
+  run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "STOP SLAVE"
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "OFFLINE_HARD" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
+  echo $result >&2
+  master_host=$(echo "$result" | cut -d: -f1)
+  slave_io_running=$(echo "$result" | cut -d: -f2)
+  slave_sql_running=$(echo "$result" | cut -d: -f3)
+
+  [ -n "${master_host}" ]
+  [ "${slave_io_running}" = "No" ]
+  [ "${slave_sql_running}" = "No" ]
+
+  # Restart the slave
+  echo "$LINENO Starting the slave on port:$PORT_SLAVE1" >&2
+  run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "START SLAVE"
+  [ "$status" -eq 0 ]
+  sleep 3
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
+  master_host=$(echo "$result" | cut -d: -f1)
+  slave_io_running=$(echo "$result" | cut -d: -f2)
+  slave_sql_running=$(echo "$result" | cut -d: -f3)
+
+  [ -n "${master_host}" ]
+  [ "${slave_io_running}" = "Yes" ]
+  [ "${slave_sql_running}" = "Yes" ]
+
+}
+
+@test "stopping and starting the slave threads --use-slave-as-writer=no ($WSREP_CLUSTER_NAME)" {
+  #skip
+  # PREPARE for the test
+  # ========================================================
+  test_preparation
+  verify_initial_state
+
+  # Store some special variables
+  retrieve_writer_info
+  host=${write_host[0]}
+
+  # Stop the slave SQL thread
+  echo "$LINENO Stopping the slave sql thread on port:$PORT_SLAVE1" >&2
+  run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "STOP SLAVE SQL_THREAD"
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "OFFLINE_HARD" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
+  master_host=$(echo "$result" | cut -d: -f1)
+  slave_io_running=$(echo "$result" | cut -d: -f2)
+  slave_sql_running=$(echo "$result" | cut -d: -f3)
+
+  [ -n "${master_host}" ]
+  [ "${slave_io_running}" = "Yes" ]
+  [ "${slave_sql_running}" = "No" ]
+
+  # Restart the slave SQL thread
+  echo "$LINENO Starting the slave on port:$PORT_SLAVE1" >&2
+  run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "START SLAVE"
+  [ "$status" -eq 0 ]
+  sleep 3
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
+  master_host=$(echo "$result" | cut -d: -f1)
+  slave_io_running=$(echo "$result" | cut -d: -f2)
+  slave_sql_running=$(echo "$result" | cut -d: -f3)
+
+  [ -n "${master_host}" ]
+  [ "${slave_io_running}" = "Yes" ]
+  [ "${slave_sql_running}" = "Yes" ]
+
+  # Stop the slave IO thread
+  echo "$LINENO Stopping the slave IO thread on port:$PORT_SLAVE1" >&2
+  run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "STOP SLAVE IO_THREAD"
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
+  master_host=$(echo "$result" | cut -d: -f1)
+  slave_io_running=$(echo "$result" | cut -d: -f2)
+  slave_sql_running=$(echo "$result" | cut -d: -f3)
+
+  [ -n "${master_host}" ]
+  [ "${slave_io_running}" = "No" ]
+  [ "${slave_sql_running}" = "Yes" ]
+
+  # Restart the slave IO thread
+  echo "$LINENO Starting the slave on port:$PORT_SLAVE1" >&2
+  run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "START SLAVE"
+  [ "$status" -eq 0 ]
+  sleep 3
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
+  master_host=$(echo "$result" | cut -d: -f1)
+  slave_io_running=$(echo "$result" | cut -d: -f2)
+  slave_sql_running=$(echo "$result" | cut -d: -f3)
+
+  [ -n "${master_host}" ]
+  [ "${slave_io_running}" = "Yes" ]
+  [ "${slave_sql_running}" = "Yes" ]
+
+}
+
+
+@test "slave activation after stopping the entire cluster --use-slave-as-writer=no ($WSREP_CLUSTER_NAME)" {
+  #skip
+  # PREPARE for the test
+  # ========================================================
+  test_preparation
+  verify_initial_state
+
+  # Store some special variables
+  retrieve_writer_info
+  host=${write_host[0]}
+
+  # store startup values
+  ps_row1=$(ps aux | grep "mysqld" | grep "port=$PORT_1")
+  restart_cmd1=$(echo $ps_row1 | sed 's:^.* /:/:')
+  restart_user1=$(echo $ps_row1 | awk '{ print $1 }')
+  pxc_socket1=$(echo $restart_cmd1 | grep -o "\-\-socket=[^ ]* ")
+
+  ps_row2=$(ps aux | grep "mysqld" | grep "port=$PORT_2")
+  restart_cmd2=$(echo $ps_row2 | sed 's:^.* /:/:')
+  restart_user2=$(echo $ps_row2 | awk '{ print $1 }')
+  pxc_socket2=$(echo $restart_cmd2 | grep -o "\-\-socket=[^ ]* ")
+
+  ps_row3=$(ps aux | grep "mysqld" | grep "port=$PORT_3")
+  restart_cmd3=$(echo $ps_row3 | sed 's:^.* /:/:')
+  restart_user3=$(echo $ps_row3 | awk '{ print $1 }')
+  pxc_socket3=$(echo $restart_cmd3 | grep -o "\-\-socket=[^ ]* ")
+
+  # TEST shutdown the entire cluster (slave should become active)
+  # ========================================================
+  # shutdown node1
+  echo "$LINENO Shutting down node : $host:$PORT_1..." >&2
+  run $PXC_BASEDIR/bin/mysqladmin $pxc_socket1 -u root shutdown
+  [ "$status" -eq 0 ]
+
+  # shutdown node2
+  echo "$LINENO Shutting down node : $host:$PORT_2..." >&2
+  run $PXC_BASEDIR/bin/mysqladmin $pxc_socket2 -u root shutdown
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_port[0]}" -eq $PORT_3 ]
+  [[ $PORT_1 -eq ${read_port[0]} || $PORT_1 -eq ${read_port[1]} ]]
+  [[ $PORT_2 -eq ${read_port[0]} || $PORT_2 -eq ${read_port[1]} ]]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  # rerun
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_HARD" ]
+  [ "${read_status[1]}" = "OFFLINE_HARD" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_port[0]}" -eq $PORT_3 ]
+  [[ $PORT_1 -eq ${read_port[0]} || $PORT_1 -eq ${read_port[1]} ]]
+  [[ $PORT_2 -eq ${read_port[0]} || $PORT_2 -eq ${read_port[1]} ]]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  # shutdown node3
+  echo "$LINENO Shutting down node : $host:$PORT_3..." >&2
+  run $PXC_BASEDIR/bin/mysqladmin $pxc_socket3 -u root shutdown
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 0 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${read_status[0]}" = "OFFLINE_HARD" ]
+  [ "${read_status[1]}" = "OFFLINE_HARD" ]
+  [ "${read_status[2]}" = "OFFLINE_SOFT" ]
+
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  # rerun, should move all nodes to OFFLINE_HARD
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 0 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${read_status[0]}" = "OFFLINE_HARD" ]
+  [ "${read_status[1]}" = "OFFLINE_HARD" ]
+  [ "${read_status[2]}" = "OFFLINE_HARD" ]
+
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  # rerun, should have no change
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 0 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${read_status[0]}" = "OFFLINE_HARD" ]
+  [ "${read_status[1]}" = "OFFLINE_HARD" ]
+  [ "${read_status[2]}" = "OFFLINE_HARD" ]
+
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  # TEST Stop the slave
+  # ========================================================
+  echo "$LINENO Stopping the slave on port:$PORT_SLAVE1" >&2
+  run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "STOP SLAVE"
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 0 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${read_status[0]}" = "OFFLINE_HARD" ]
+  [ "${read_status[1]}" = "OFFLINE_HARD" ]
+  [ "${read_status[2]}" = "OFFLINE_HARD" ]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "OFFLINE_HARD" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 0 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${read_status[0]}" = "OFFLINE_HARD" ]
+  [ "${read_status[1]}" = "OFFLINE_HARD" ]
+  [ "${read_status[2]}" = "OFFLINE_HARD" ]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "OFFLINE_HARD" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+
+  # TEST Start the slave
+  # ========================================================
+  echo "$LINENO Starting the slave on port:$PORT_SLAVE1" >&2
+  run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "START SLAVE"
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 0 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${read_status[0]}" = "OFFLINE_HARD" ]
+  [ "${read_status[1]}" = "OFFLINE_HARD" ]
+  [ "${read_status[2]}" = "OFFLINE_HARD" ]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+
+
+  # TEST restart a single node
+  # ========================================================
+  echo "$LINENO Starting node (bootstrapping) : $host:$PORT_1..." >&2
+  restart_server "$restart_cmd1" "$restart_user1" "bootstrap"
+  wait_for_server_start $pxc_socket1 1
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_HARD" ]
+  [ "${read_status[1]}" = "OFFLINE_HARD" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_port[0]}" -eq $PORT_1 ]
+
+  [ "${read_port[0]}" -eq $PORT_2 ]
+  [ "${read_port[1]}" -eq $PORT_3 ]
+  [ "${read_port[2]}" -eq $PORT_1 ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+  [ "${slave_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  # TEST restart all nodes
+  # ========================================================
+  echo "$LINENO Starting node : $host:$PORT_2..." >&2
+  restart_server "$restart_cmd2" "$restart_user2"
+  wait_for_server_start $pxc_socket2 2
+
+  echo "$LINENO Starting node : $host:$PORT_3..." >&2
+  restart_server "$restart_cmd3" "$restart_user3"
+  wait_for_server_start $pxc_socket3 3
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[1]}" -eq $PORT_2 ]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+}
+
+
+@test "slave activation after disabling the entire cluster --use-slave-as-writer=no ($WSREP_CLUSTER_NAME)" {
+  #skip
+  require_pxc_maint_mode
+
+  # PREPARE for the test
+  # ========================================================
+  test_preparation
+  #verify_initial_state
+
+  # Store some special variables
+  retrieve_writer_info
+  host=${write_host[0]}
+
+  # TEST disable the entire cluster (with pxc_maint_mode)
+  # ========================================================
+  echo "$LINENO Disabling node : $host:$PORT_2..." >&2
+  run mysql_exec "$host" "$PORT_2" "SET global pxc_maint_mode='maintenance'"
+  [ "$status" -eq 0 ]
+
+  echo "$LINENO Disabling node : $host:$PORT_3..." >&2
+  run mysql_exec "$host" "$PORT_3" "SET global pxc_maint_mode='maintenance'"
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[0]}" -eq $PORT_2 ]
+  [ "${read_port[1]}" -eq $PORT_3 ]
+  [ "${read_port[2]}" -eq $PORT_1 ]
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  echo "$LINENO Disabling node : $host:$PORT_1..." >&2
+  run mysql_exec "$host" "$PORT_1" "SET global pxc_maint_mode='maintenance'"
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[2]}" = "OFFLINE_SOFT" ]
+
+  [ "${write_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[1]}" -eq $PORT_2 ]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  # Rerun the checker, should remove the offline writer
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 0 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[2]}" = "OFFLINE_SOFT" ]
+
+  [ "${read_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[1]}" -eq $PORT_2 ]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  # Rerun the checker, should show no change
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 0 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[2]}" = "OFFLINE_SOFT" ]
+
+  [ "${read_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[1]}" -eq $PORT_2 ]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  # TEST Stop the slave
+  # ========================================================
+  echo "$LINENO Stopping the slave on port:$PORT_SLAVE1" >&2
+  run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "STOP SLAVE"
+  [ "$status" -eq 0 ]
+
+  # Run the checker
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 0 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[2]}" = "OFFLINE_SOFT" ]
+
+  [ "${read_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[1]}" -eq $PORT_2 ]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+  [ "${slave_status[0]}" = "OFFLINE_HARD" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+  # Start the slave
+  echo "$LINENO Starting the slave on port:$PORT_SLAVE1" >&2
+  run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "START SLAVE"
+  [ "$status" -eq 0 ]
+
+  # Run the checker
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 0 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[2]}" = "OFFLINE_SOFT" ]
+
+  [ "${read_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[1]}" -eq $PORT_2 ]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+
+  # Test enable a single node
+  # ========================================================
+  echo "$LINENO Enabling node : $host:$PORT_1..." >&2
+  run mysql_exec "$host" "$PORT_1" "SET global pxc_maint_mode='disabled'"
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[0]}" -eq $PORT_2 ]
+  [ "${read_port[1]}" -eq $PORT_3 ]
+  [ "${read_port[2]}" -eq $PORT_1 ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
+
+
+  # Test enable all the nodes
+  # ========================================================
+  echo "$LINENO Enabling node : $host:$PORT_2..." >&2
+  run mysql_exec "$host" "$PORT_2" "SET global pxc_maint_mode='disabled'"
+  [ "$status" -eq 0 ]
+
+  echo "$LINENO Enabling node : $host:$PORT_3..." >&2
+  run mysql_exec "$host" "$PORT_3" "SET global pxc_maint_mode='disabled'"
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='async-slave $LINENO'")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+  retrieve_slave_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+  [ "${#slave_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[0]}" -eq $PORT_1 ]
+  [ "${read_port[1]}" -eq $PORT_2 ]
+  [ "${read_port[2]}" -eq $PORT_3 ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+
+  [ "${slave_port[0]}" -eq $PORT_SLAVE1 ]
+  [ "${slave_status[0]}" = "ONLINE" ]
+  [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
 
 
   # REACTIVATE the scheduler

--- a/tests/generic-test.bats
+++ b/tests/generic-test.bats
@@ -117,6 +117,12 @@ echo "$output"
         [ "$status" -eq 1 ]
 }
 
+@test 'run proxysql-admin --include-slaves without --use-slave-as-writer' {
+run sudo $WORKDIR/proxysql-admin --include-slave=127.0.0.1:4110
+echo "$output"
+        [ "$status" -eq 1 ]
+}
+
 @test "run proxysql-admin --version check" {
   admin_version=$(sudo $WORKDIR/proxysql-admin -v | grep --extended-regexp -oe '[1-9]\.[0-9]\.[0-9]+')
   proxysql_version=$(sudo $PROXYSQL_BASE/usr/bin/proxysql --help | grep --extended-regexp -oe '[1-9]\.[0-9]\.[0-9]+')


### PR DESCRIPTION
…p even if the whole cluster went down.

Issue
The default behavior (if async slaves are used), is to add an async
slave to the WRITE hostgroup if all PXC nodes are down.

Solution
Make this into an option (--use-slave-as-writer=<yes/no>). This option
is now required to be specified if async-slaves are specified when using
proxysql-admin.