### PR TITLE
PSQLADM-68 : Make scripts IPv6 compatible

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -509,6 +509,64 @@ function monitor_exec() {
   return $?
 }
 
+# Separates the IP address from the port in a network address
+# Works for IPv4 and IPv6
+#
+# Globals:
+#   None
+#
+# Params:
+#   1. The network address to be parsed
+#
+# Outputs:
+#   A string with a space separating the IP address from the port
+#
+function separate_ip_port_from_address()
+{
+  #
+  # Break address string into host:port/path parts
+  #
+  local address=$1
+
+  ip_addr=${address%:*}
+  port=${address##*:}
+
+  # Remove any braces that surround the ip address portion
+  ip_addr=${ip_addr#\[}
+  ip_addr=${ip_addr%\]}
+
+  echo "${ip_addr} ${port}"
+}
+
+# Combines the IP address and port into a network address
+# Works for IPv4 and IPv6
+# (If the IP address is IPv6, the IP portion will have brackets)
+#
+# Globals:
+#   None
+#
+# Params:
+#   1: The IP address portion
+#   2: The port
+#
+# Outputs:
+#   A string containing the full network address
+#
+function combine_ip_port_into_address()
+{
+  local ip_addr=$1
+  local port=$2
+  local addr
+
+  if [[ ! $ip_addr =~ \[.*\] && $ip_addr =~ .*:.* ]] ; then
+    # If there are no brackets and it does have a ':', then add the brackets
+    # because this is an unbracketed IPv6 address
+    addr="[${ip_addr}]:${port}"
+  else
+    addr="${ip_addr}:${port}"
+  fi
+  echo $addr
+}
 
 # Check proxysql running status
 #
@@ -959,8 +1017,9 @@ function enable_proxysql() {
   if [[ -n $SLAVE_NODES ]];then
     echo -e "\nVerifying specified slave nodes"
     for i in $SLAVE_NODES; do
-      SLAVE_HOSTNAME=`echo $i | cut -d: -f1`
-      SLAVE_PORT=`echo $i | cut -d: -f2`
+      ws_address=$(separate_ip_port_from_address "$i")
+      SLAVE_HOSTNAME=`echo $ws_address | cut -d' ' -f1`
+      SLAVE_PORT=`echo $ws_address | cut -d' ' -f2`
 
       # Verify we can connect to the slave
       slave_exec "$LINENO" 'show slave status\G' > /dev/null
@@ -974,8 +1033,12 @@ function enable_proxysql() {
                         cut -d: -f2 |
                         tr '\n' ':' |
                         sed 's/:$//g')
+      local slave_master_address=$(separate_ip_port_from_address "$slave_master")
+      local slave_master_ip=$(echo $slave_master_address | cut -d' ' -f1)
+      local slave_master_port=$(echo $slave_master_address | cut -d' ' -f2)
+      slave_master_address=$(combine_ip_port_into_address "$slave_master_ip", "$slave_master_port")
       if [[ ${wsrep_address[*]} != *"$slave_master"* ]]; then
-        error $LINENO "The slave node's master ($slave_master) is not in the list"\
+        error $LINENO "The slave node's master ($slave_master_address) is not in the list"\
                       "\n-- of WSREP incoming address(${wsrep_address[*]})."\
                       "\n-- The specified slave is not replicating from any of the PXC nodes,"\
                       "\n-- this is not supported.  Please configure ProxySQL manually."
@@ -1011,10 +1074,12 @@ function enable_proxysql() {
     check_cmd $? $LINENO "Failed to delete the existing servers with hostgroup: ${WRITE_HOSTGROUP_ID}"\
                          "\n-- Please check the ProxySQL connection parameters and status."
     for i in "${wsrep_address[@]}"; do  
-      local ws_ip=$(echo "$i" | cut -d':' -f1)
-      local ws_port=$(echo "$i" | cut -d':' -f2)
+      local ws_address=$(separate_ip_port_from_address "$i")
+      local ws_ip=$(echo "$ws_address" | cut -d' ' -f1)
+      local ws_port=$(echo "$ws_address" | cut -d' ' -f2)
+      ws_address=$(combine_ip_port_into_address "$ws_ip" "$ws_port")
       proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$WRITE_HOSTGROUP_ID,$ws_port,1000,'READWRITE');"
-      check_cmd $? $LINENO "Failed to add the PXC server node $ws_ip:$ws_port."\
+      check_cmd $? $LINENO "Failed to add the PXC server node $ws_address."\
                            "\n-- Please check the ProxySQL connection parameters and status."
     done
 
@@ -1031,23 +1096,27 @@ function enable_proxysql() {
     if [[ $QUICK_DEMO -eq 0 ]]; then
       local writer_ws_ip
       local writer_ws_port
+      local writer_ws_address
 
       if [ -z "$WRITE_NODE" ]; then
         writer_ws_ip=$(mysql_exec "$LINENO" "show variables like 'wsrep_provider_options'" |
                         grep -o -P '(?<=base_host =).*(?=; base_port)' |
                         xargs)
         writer_ws_port=$CLUSTER_PORT
+        writer_ws_address=$(combine_ip_port_into_address "$writer_ws_ip" "$writer_ws_port")
       else
-        writer_ws_ip=$(echo "$WRITE_NODE" | awk -F':' '{print $1}')
-        writer_ws_port=$(echo "$WRITE_NODE" | awk -F':' '{print $2}')
+        writer_ws_address=$(separate_ip_port_from_address "$WRITE_NODE")
+        writer_ws_ip=$(echo "$writer_ws_address" | cut -d' ' -f1)
+        writer_ws_port=$(echo "$writer_ws_address" | cut -d' ' -f2)
         if [ -z "$writer_ws_port" ];then
           writer_ws_port=3306
         fi
+        writer_ws_address=$(combine_ip_port_into_address "$writer_ws_ip" "$writer_ws_port")
 
         # TODO: kennt, do we want to display the error message?
         exec_sql $LINENO "$CLUSTER_USERNAME" "$CLUSTER_PASSWORD" "$writer_ws_ip" "$writer_ws_port" "select @@port" &>/dev/null
         if [ $? -ne 0 ]; then 
-          error $LINENO "Failed to establish a connection to the write node $writer_ws_ip:$writer_ws_port."\
+          error $LINENO "Failed to establish a connection to the write node $writer_ws_address."\
                         "\n-- Please check that the write node is alive and the connection parameters are correct"; 
           proxysql_exec "$LINENO" "DELETE FROM mysql_users WHERE default_hostgroup in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID);"
           check_cmd $? $LINENO "Failed to delete PXC user from ProxySQL."\
@@ -1060,12 +1129,14 @@ function enable_proxysql() {
       check_cmd $? $LINENO "Could not get the wsrep_provider_options from the PXC cluster"\
                            "\n-- Please check the PXC connection parameters and status."      
       writer_ws_port=$CLUSTER_PORT
+      writer_ws_address=$(combine_ip_port_into_address $writer_ws_ip $writer_ws_port)
     fi
     proxysql_exec "$LINENO" "DELETE FROM mysql_servers WHERE hostgroup_id=$WRITE_HOSTGROUP_ID"
     check_cmd $? $LINENO "Failed to delete the existing servers with hostgroup: ${WRITE_HOSTGROUP_ID}"\
                          "\n-- Please check the ProxySQL connection parameters and status."
-    if [[ ${wsrep_address[*]} != *"$writer_ws_ip:$writer_ws_port"* ]]; then
-      error $LINENO "Writer node cluster address($writer_ws_ip:$writer_ws_port) does not exist"\
+
+    if [[ ${wsrep_address[*]} != *"$writer_ws_address"* ]]; then
+      error $LINENO "Writer node cluster address($writer_ws_address) does not exist"\
                     "\n-- in WSREP incoming address(${wsrep_address[*]})."
       echo -e "-- Different wsrep incoming and cluster IP addresses are not supported"
       echo -e "-- by proxysql-admin at this time.  Please configure ProxySQL manually."
@@ -1082,19 +1153,20 @@ function enable_proxysql() {
       host_priority="--priority=$P_HOST_PRIORITY"
     fi
 
-    for i in "${wsrep_address[@]}"; do  
-      local ws_ip=$(echo "$i" | cut -d':' -f1)
-      local ws_port=$(echo "$i" | cut -d':' -f2)
+    for i in "${wsrep_address[@]}"; do
+      local ws_address=$(separate_ip_port_from_address $i)
+      local ws_ip=$(echo "$ws_address" | cut -d' ' -f1)
+      local ws_port=$(echo "$ws_address" | cut -d' ' -f2)
       if [ "$ws_ip" == "$writer_ws_ip" ] && [ "$ws_port" == "$writer_ws_port" ]; then
         proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$writer_ws_ip',$WRITE_HOSTGROUP_ID,$writer_ws_port,1000000,'WRITE');"
-        check_cmd $? $LINENO "Failed to add the PXC server node $writer_ws_ip:$writer_ws_port."\
+        check_cmd $? $LINENO "Failed to add the PXC server node $ws_address."\
                              "\n-- Please check the ProxySQL connection parameters and status."
         echo -e "\nWrite node info"
         proxysql_exec "$LINENO" "SELECT hostname,hostgroup_id,port,weight,comment FROM mysql_servers WHERE hostgroup_id=$WRITE_HOSTGROUP_ID" "-t"
         echo ""
       else
         proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$READ_HOSTGROUP_ID,$ws_port,1000,'READ');"
-        check_cmd $? $LINENO "Failed to add the PXC server node $ws_ip:$ws_port."\
+        check_cmd $? $LINENO "Failed to add the PXC server node $i."\
                               "\n-- Please check the ProxySQL connection parameters and status."
       fi
     done
@@ -1111,10 +1183,11 @@ function enable_proxysql() {
   if [ -n "$SLAVE_NODES" ];then
     echo -e "\nAdding the following slave server nodes to ProxySQL:"
     for i in $SLAVE_NODES;do
-      local ws_ip=$(echo "$i" | cut -d':' -f1)
-      local ws_port=$(echo "$i" | cut -d':' -f2)
+      local ws_address=$(separate_ip_port_from_address "$i")
+      local ws_ip=$(echo "$ws_address" | cut -d' ' -f1)
+      local ws_port=$(echo "$ws_address" | cut -d' ' -f2)
       proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$SLAVEREAD_HOSTGROUP_ID,$ws_port,1000,'SLAVEREAD');"
-      check_cmd $? $LINENO "Failed to add the slave node $ws_ip:$ws_port."\
+      check_cmd $? $LINENO "Failed to add the slave node $i."\
                            "\n-- Please check the ProxySQL connection parameters and status."
 
       proxysql_load_to_runtime_save_to_disk "MYSQL SERVERS" $LINENO

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -392,6 +392,67 @@ function mysql_exec() {
   return $retoutput
 }
 
+
+# Separates the IP address from the port in a network address
+# Works for IPv4 and IPv6
+#
+# Globals:
+#   None
+#
+# Params:
+#   1. The network address to be parsed
+#
+# Outputs:
+#   A string with a space separating the IP address from the port
+#
+function separate_ip_port_from_address()
+{
+  #
+  # Break address string into host:port/path parts
+  #
+  local address=$1
+
+  ip_addr=${address%:*}
+  port=${address##*:}
+
+  # Remove any braces that surround the ip address portion
+  ip_addr=${ip_addr#\[}
+  ip_addr=${ip_addr%\]}
+
+  echo "${ip_addr} ${port}"
+}
+
+# Combines the IP address and port into a network address
+# Works for IPv4 and IPv6
+# (If the IP address is IPv6, the IP portion will have brackets)
+#
+# Globals:
+#   None
+#
+# Params:
+#   1: The IP address portion
+#   2: The port
+#
+# Outputs:
+#   A string containing the full network address
+#
+function combine_ip_port_into_address()
+{
+  local ip_addr=$1
+  local port=$2
+  local addr
+
+  if [[ ! $ip_addr =~ \[.*\] && $ip_addr =~ .*:.* ]] ; then
+    # If there are no brackets and it does have a ':', then add the brackets
+    # because this is an unbracketed IPv6 address
+    addr="[${ip_addr}]:${port}"
+  else
+    addr="${ip_addr}:${port}"
+  fi
+  echo $addr
+}
+
+
 # upgrade scheduler from old layout to new layout
 #
 # Globals:
@@ -516,6 +577,9 @@ function change_server_status() {
   local status=$5
   local reader_status=$6
   local comment=$7
+  local address
+
+  address=$(combine_ip_port_into_address "$server" "$port")
 
   # If we have a PRIORITY_NODE, then we don't have a WRITER entry
   # to upgrade, but we do have a READER entry, so upgrade that
@@ -523,11 +587,11 @@ function change_server_status() {
     proxysql_exec $lineno -Ns "INSERT INTO mysql_servers
           (hostname,hostgroup_id,port,weight,status,comment)
           VALUES ('$server',$hostgroup,$port,1000000,'$status','WRITE');"
-    log "$lineno" "Adding server $hostgroup:$server:$port with status $status. Reason: $comment"
+    log "$lineno" "Adding server $hostgroup:$address with status $status. Reason: $comment"
   else
     proxysql_exec $lineno -Ns "UPDATE mysql_servers
           set status = '$status' WHERE hostgroup_id = $hostgroup AND hostname = '$server' AND port = $port;" 2>>${ERR_FILE}
-    log "$lineno" "Changing server $hostgroup:$server:$port to status $status. Reason: $comment"
+    log "$lineno" "Changing server $hostgroup:$address to status $status. Reason: $comment"
   fi
 }
 
@@ -873,6 +937,8 @@ function writer_is_reader_check() {
     fi
 
     local regex="(^|[[:space:]])${HOSTGROUP_READER_ID}[[:blank:]]${server}[[:blank:]]${port}[[:blank:]]"
+    local address
+    address=$(combine_ip_port_into_address "$server" "$port")
 
     if [[ $WRITER_IS_READER == "always" || $WRITER_IS_READER == "ondemand" ]]; then
       #
@@ -890,14 +956,14 @@ function writer_is_reader_check() {
           comment="OFFLINE_SOFT"
         fi
         proxysql_exec $LINENO -Ns "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,status,comment) VALUES ('$server',$HOSTGROUP_READER_ID,$port,1000,'$comment','READ');"
-        check_cmd $LINENO $? "writer-is-reader($WRITER_IS_READER): Failed to add $HOSTGROUP_READER_ID:$server:$port"
-        log_if_success $LINENO $? "writer-is-reader($WRITER_IS_READER): Adding reader $HOSTGROUP_READER_ID:$server:$port with status OFFLINE_SOFT"
+        check_cmd $LINENO $? "writer-is-reader($WRITER_IS_READER): Failed to add $HOSTGROUP_READER_ID:$address"
+        log_if_success $LINENO $? "writer-is-reader($WRITER_IS_READER): Adding reader $HOSTGROUP_READER_ID:$address with status OFFLINE_SOFT"
         echo "1" > ${reload_check_file}
       elif [[ $WRITER_IS_READER == "ondemand" && $stat == "ONLINE" && $number_readers_online -gt 1 ]]; then
         # If the reader node is ONLINE and there is another reader
         # Then we can deactivate this reader node (if ondemand)
         proxysql_exec $LINENO -Ns "UPDATE mysql_servers SET status='OFFLINE_SOFT' WHERE hostgroup_id=$HOSTGROUP_READER_ID AND hostname='$server' AND port=$port"
-        log_if_success $LINENO $? "Updating $hostgroup:$server:$port to OFFLINE_SOFT because writers prefer to not be readers (writer-is-reader:ondemand)"
+        log_if_success $LINENO $? "Updating $hostgroup:$address to OFFLINE_SOFT because writers prefer to not be readers (writer-is-reader:ondemand)"
         echo "1" > ${reload_check_file}
       fi
     elif [[ $WRITER_IS_READER == "never" ]]; then
@@ -907,8 +973,8 @@ function writer_is_reader_check() {
       if [[ $servers =~ $regex ]]; then
         # Delete the corresponding READER entry
         proxysql_exec $LINENO -Ns "DELETE FROM mysql_servers WHERE hostgroup_id=$HOSTGROUP_READER_ID and hostname='$server' and port=$port"
-        check_cmd $LINENO $? "writer-is-reader(never): Failed to remove $HOSTGROUP_READER_ID:$server:$port"
-        log_if_success $LINENO $? "writer-is-reader(never): Removing reader $HOSTGROUP_READER_ID:$server:$port"
+        check_cmd $LINENO $? "writer-is-reader(never): Failed to remove $HOSTGROUP_READER_ID:$address"
+        log_if_success $LINENO $? "writer-is-reader(never): Removing reader $HOSTGROUP_READER_ID:$address"
         echo "1" > ${reload_check_file}
       fi
     fi
@@ -994,6 +1060,8 @@ function ensure_one_writer_node() {
     local wsrep_status
     local pxc_main_mode
     local result
+    local address
+    address=$(combine_ip_port_into_address "$host" "$port")
     result=$(mysql_exec $LINENO "$host" "$port" -Nns "SHOW STATUS LIKE 'wsrep_local_state'; SHOW VARIABLES LIKE 'pxc_maint_mode';" 2>>${DEBUG_ERR_FILE})
     wsrep_status=$(echo "$result" | grep "wsrep_local_state" | awk '{ print $2 }')
     pxc_main_mode=$(echo "$result" | grep "pxc_maint_mode" | awk '{ print $2 }')
@@ -1007,9 +1075,9 @@ function ensure_one_writer_node() {
     fi
 
     local write_stat=$(echo "$line" | awk '{print $3}')
-    debug $LINENO "Looking at $host:$port write_status:$write_stat"
+    debug $LINENO "Looking at $address write_status:$write_stat"
 
-    log $LINENO "Promoting $host:$port as writer node..."
+    log $LINENO "Promoting $address as writer node..."
 
     # We have an ONLINE reader node
     # if ondemand or always keep the reader node (may need to move it to OFFLINE_SOFT)
@@ -1023,11 +1091,11 @@ function ensure_one_writer_node() {
           "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,status,comment)
            VALUES ('$host',$HOSTGROUP_WRITER_ID,$port,1000000,'ONLINE','WRITE');"
         check_cmd $LINENO $? "Cannot add a PXC writer node to ProxySQL, Please check ProxySQL login credentials"
-        log_if_success $LINENO $? "Added $HOSTGROUP_WRITER_ID:$host:$port as a writer."
+        log_if_success $LINENO $? "Added $HOSTGROUP_WRITER_ID:$address as a writer."
       else
         # Writer exists, move writer to ONLINE
         proxysql_exec $LINENO -Ns "UPDATE mysql_servers SET status='ONLINE',comment='WRITE',weight=1000000 WHERE hostgroup_id=$HOSTGROUP_WRITER_ID AND hostname='$host' AND port=$port"
-        check_cmd $LINENO $? "Cannot update the PXC node $HOSTGROUP_WRITER_ID:$host:$port, Please check the ProxySQL login credentials"
+        check_cmd $LINENO $? "Cannot update the PXC node $HOSTGROUP_WRITER_ID:$address, Please check the ProxySQL login credentials"
         log_if_success $LINENO $? "Updated ${HOSTGROUP_WRITER_ID}:${host}:${port} node in ProxySQL."
       fi
     else
@@ -1036,11 +1104,11 @@ function ensure_one_writer_node() {
         proxysql_exec $$LINENO -Ns\
             "UPDATE mysql_servers set status='ONLINE',hostgroup_id=$HOSTGROUP_WRITER_ID, comment='WRITE', weight=1000000 WHERE hostgroup_id=$HOSTGROUP_READER_ID and hostname='$host' and port=$port"
         check_cmd $LINENO $? "Cannot update PXC writer in ProxySQL, Please check ProxySQL login credentials"
-        log_if_success $LINENO $? "Added $HOSTGROUP_WRITER_ID:$host:$port as a writer node."
+        log_if_success $LINENO $? "Added $HOSTGROUP_WRITER_ID:$address as a writer node."
       else
         # Writer exists, move writer to ONLINE, remove reader
         proxysql_exec $LINENO -Ns "UPDATE mysql_servers SET status='ONLINE',comment='WRITE',weight=1000000 WHERE hostgroup_id=$HOSTGROUP_WRITER_ID AND hostname='$host' AND port=$port"
-        check_cmd $LINENO $? "Cannot update the PXC node $HOSTGROUP_WRITER_ID:$host:$port, Please check the ProxySQL login credentials"
+        check_cmd $LINENO $? "Cannot update the PXC node $HOSTGROUP_WRITER_ID:$address, Please check the ProxySQL login credentials"
         log_if_success $LINENO $? "Updated ${HOSTGROUP_WRITER_ID}:${host}:${port} node in ProxySQL."
 
         proxysql_exec $LINENO -Ns "DELETE FROM mysql_servers WHERE hostgroup_id=$HOSTGROUP_READER_ID and hostname='$host' and port=$port"
@@ -1123,7 +1191,17 @@ function build_proxysql_list_with_priority() {
 
   for prio in "${priority_list[@]}"; do
     local psql_entry
-    psql_entry=$(echo "$proxysql_list" | grep "^${prio}[^[[:space:]]]*")
+    local prio_entry
+    local prio_ip
+    local prio_port
+    prio_entry=$(separate_ip_port_from_address "$prio")
+    prio_ip=$(echo "$prio_entry" | cut -d' ' -f1)
+    prio_port=$(echo "$prio_entry" | cut -d' ' -f2)
+    prio_entry="$prio_ip$sep$prio_port"
+    # properly escape the characters for grep
+    prio_entry_re="$(printf '%s' "$prio_entry" | sed 's/[.[\*^$]/\\&/g')"
+
+    psql_entry=$(echo "$proxysql_list" | grep "^${prio_entry_re}[^[[:space:]]]*")
     if [[ $? -eq 0 && -n ${psql_entry} ]]; then
       # Add entries that are in the priority list and in the proxysql list
       new_proxysql_list+=($psql_entry)
@@ -1141,11 +1219,11 @@ function build_proxysql_list_with_priority() {
         reader_query=1
       fi
       if [[ -n $reader_list ]]; then
-        if echo $reader_list | grep -E -q "(^|[[:space:]])${prio}($|[[:space:]])*"; then
+        if echo $reader_list | grep -E -q "(^|[[:space:]])${prio_entry_re}($|[[:space:]])*"; then
           # If this address is a reader, add a fake writer entry
           # If detected to be online, the writer check algorithm
           # will insert an entry
-          new_proxysql_list+=("${prio}${sep}${HOSTGROUP_WRITER_ID}${sep}OFFLINE_SOFT${sep}WRITE${sep}PRIORITY_NODE")
+          new_proxysql_list+=("${prio_entry}${sep}${HOSTGROUP_WRITER_ID}${sep}OFFLINE_SOFT${sep}WRITE${sep}PRIORITY_NODE")
         fi
       fi
     fi
@@ -1158,9 +1236,14 @@ function build_proxysql_list_with_priority() {
   if [[ -n ${priority_list[@]+"${priority_list[@]}"} ]]; then
     local priority_string="${priority_list[@]}"
     for row in ${proxysql_list}; do
-      local addr=$(echo $row | cut -d "$sep" -f 1,2)
-      local re="(^|[[:space:]])${addr}($|[[:space:]])"
-      if ! echo $priority_string | grep -E -q "(^|[[:space:]])${addr}($|[[:space:]])"; then
+      local host=$(echo $row | cut -d "$sep" -f 1)
+      local port=$(echo $row | cut -d "$sep" -f 2)
+      local addr=$(combine_ip_port_into_address "$host" "$port")
+
+      # properly escape the characters for grep -E
+      addr_re="$(printf '%s' "$addr" | sed 's/[.[\*^$()+?{|]/\\&/g')"
+
+      if ! echo $priority_string | grep -E -q "(^|[[:space:]])${addr_re}($|[[:space:]])"; then
         new_proxysql_list+=($row)
       fi
     done
@@ -1212,14 +1295,14 @@ function update_writers() {
   if [[ -n $priority_list ]]; then
     #
     # Need to do some processing of the lists so that we can pass them down
-    # Assume that the fields cannot contain the ':' character'
+    # Assume that the fields cannot contain the ';' character'
     # Can't use "local -n" becaus of Centos6 (needs newer bash version)
     #
     local prio_list=${priority_list}
-    local pxsql_list=$(echo "${proxysql_list[@]}" | tr '\t' ':' | tr '\n' ' ')
+    local pxsql_list=$(echo "${proxysql_list[@]}" | tr '\t' ';' | tr '\n' ' ')
 
-    proxysql_list=$(build_proxysql_list_with_priority ":" "$pxsql_list" "$prio_list")
-    proxysql_list=$(echo "${proxysql_list}" | tr ' ' '\n' | tr ':' ' ')
+    proxysql_list=$(build_proxysql_list_with_priority ";" "$pxsql_list" "$prio_list")
+    proxysql_list=$(echo "${proxysql_list}" | tr ' ' '\n' | tr ';' ' ')
   fi
 
   if [[ -z ${proxysql_list[@]+"${proxysql_list[@]}"} ]]; then
@@ -1242,6 +1325,8 @@ function update_writers() {
     local wsrep_status
     local pxc_main_mode
     local result
+    local address
+    address=$(combine_ip_port_into_address "$server" "$port")
     result=$(mysql_exec $LINENO "$server" "$port" -Nns "SHOW STATUS LIKE 'wsrep_local_state'; SHOW VARIABLES LIKE 'pxc_maint_mode';" 2>>${DEBUG_ERR_FILE})
     wsrep_status=$(echo "$result" | grep "wsrep_local_state" | awk '{ print $2 }')
     pxc_main_mode=$(echo "$result" | grep "pxc_maint_mode" | awk '{ print $2 }')
@@ -1261,7 +1346,7 @@ function update_writers() {
       continue
     fi
 
-    log "" "--> Checking WRITE server $hostgroup:$server:$port, current status $stat, wsrep_local_state $wsrep_status"
+    log "" "--> Checking WRITE server $hostgroup:$address, current status $stat, wsrep_local_state $wsrep_status"
 
     # we have to limit amount of writers, WSREP status OK, AND node is marked ONLINE
     # PXC and ProxySQL agreee on the status
@@ -1269,7 +1354,7 @@ function update_writers() {
     if [ $NUMBER_WRITERS -gt 0 -a "${wsrep_status}" = "4" -a "$stat" == "ONLINE" -a "${pxc_main_mode}" == "DISABLED" ] ; then
       if [[ $number_writers_online -lt $NUMBER_WRITERS ]]; then
         number_writers_online=$(( $number_writers_online + 1 ))
-        log "" "server $hostgroup:$server:$port is already ONLINE: ${number_writers_online} of ${NUMBER_WRITERS} write nodes"
+        log "" "server $hostgroup:$address is already ONLINE: ${number_writers_online} of ${NUMBER_WRITERS} write nodes"
       else
         number_writers_online=$(( $number_writers_online + 1 ))
         change_server_status $LINENO $HOSTGROUP_WRITER_ID "$server" $port "OFFLINE_SOFT" "$rdstat" \
@@ -1296,7 +1381,7 @@ function update_writers() {
                                  "max write nodes reached (${NUMBER_WRITERS})"
             echo "1" > ${reload_check_file}
           elif [[ $rdstat != "PRIORITY_NODE" ]]; then
-             log $LINENO "server $hostgroup:$server:$port is already OFFLINE_SOFT, max write nodes reached (${NUMBER_WRITERS})"
+             log $LINENO "server $hostgroup:$address is already OFFLINE_SOFT, max write nodes reached (${NUMBER_WRITERS})"
           fi
         fi
       # we do not have to limit
@@ -1321,10 +1406,10 @@ function update_writers() {
       echo "1" > ${reload_check_file}
     # wsrep:not ok  pxc:--  status:offline soft
     elif [ "${wsrep_status}" != "4" -a "$stat" = "OFFLINE_SOFT" -a "$rdstat" != "PRIORITY_NODE" ]; then
-      log "" "server $hostgroup:$server:$port is already OFFLINE_SOFT, WSREP status is ${wsrep_status} which is not ok"
+      log "" "server $hostgroup:$address is already OFFLINE_SOFT, WSREP status is ${wsrep_status} which is not ok"
     # wsrep:--  pxc:not ok  status:offline soft
     elif [ "${pxc_main_mode}" != "DISABLED" -a "$stat" = "OFFLINE_SOFT" -a "$rdstat" != "PRIORITY_NODE" ]; then
-      log "" "server $hostgroup:$server:$port is already OFFLINE_SOFT, pxc_maint_mode is ${pxc_main_mode} which is not ok"
+      log "" "server $hostgroup:$address is already OFFLINE_SOFT, pxc_maint_mode is ${pxc_main_mode} which is not ok"
     fi
   done
 }
@@ -1351,7 +1436,9 @@ function set_slave_status() {
   local ws_ip=$3
   local ws_port=$4
   local ws_status=$5
-  local node_id="${ws_hg_id}:${ws_ip}:${ws_port}"
+  local ws_address
+  ws_address=$(combine_ip_port_into_address "$ws_ip" "$ws_port")
+  local node_id="${ws_hg_id}:${ws_address}"
 
   # This function will get and return a status of a slave node, 4=GOOD, 2=BEHIND, 0=OTHER
   local slave_status
@@ -1359,7 +1446,7 @@ function set_slave_status() {
   log $LINENO "--> Checking SLAVE server ${node_id}"
 
   slave_status=$(mysql_exec $LINENO "$ws_ip" "$ws_port" -nsE "SHOW SLAVE STATUS")
-  check_cmd $LINENO $? "Cannot get status from the slave $ws_ip:$ws_port, Please check cluster login credentials"
+  check_cmd $LINENO $? "Cannot get status from the slave $ws_address, Please check cluster login credentials"
 
   slave_status=$(echo "$slave_status" | sed 's/ //g')
   echo "$slave_status" | grep "^Master_Host:" >/dev/null
@@ -1369,8 +1456,8 @@ function set_slave_status() {
     # Only changing the status here as another node might be in the writer hostgroup
     #
     proxysql_exec $LINENO -Ns "UPDATE mysql_servers SET status = 'OFFLINE_HARD'  WHERE hostname='$ws_ip' and port=$ws_port;"
-    check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check ProxySQL admin credentials"
-    log_if_success $LINENO $? "slave server ${ws_ip}:${ws_port} set to OFFLINE_HARD status in ProxySQL (cannot determine slave status)."
+    check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster node $ws_address to ProxySQL database, Please check ProxySQL admin credentials"
+    log_if_success $LINENO $? "slave server ${ws_address} set to OFFLINE_HARD status in ProxySQL (cannot determine slave status)."
     echo "1" > ${reload_check_file}
   else
     local slave_master_host slave_io_running slave_sql_running seconds_behind
@@ -1393,11 +1480,11 @@ function set_slave_status() {
       #
       if [ "$ws_status" != "OFFLINE_HARD" ];then
         proxysql_exec $LINENO -Ns "UPDATE mysql_servers SET status = 'OFFLINE_HARD' WHERE hostname='$ws_ip' and port=$ws_port;"
-        check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check ProxySQL login credentials"
-        log_if_success $LINENO $? "slaver server ${ws_ip}:${ws_port} set to OFFLINE_HARD status in ProxySQL (io:$slave_io_running sql:$slave_sql_running)."
+        check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster node $ws_address to ProxySQL database, Please check ProxySQL login credentials"
+        log_if_success $LINENO $? "slave server ${ws_address} set to OFFLINE_HARD status in ProxySQL (io:$slave_io_running sql:$slave_sql_running)."
         echo "1" > ${reload_check_file}
       else
-        log $LINENO "slave server (${ws_hg_id}:${ws_ip}:${ws_port}) current status '$ws_status' in ProxySQL. (io:$slave_io_running sql:$slave_sql_running)"
+        log $LINENO "slave server (${ws_hg_id}:${ws_address}) current status '$ws_status' in ProxySQL. (io:$slave_io_running sql:$slave_sql_running)"
       fi
     elif [[ $slave_io_running == "Yes" ]]; then
       #
@@ -1408,8 +1495,8 @@ function set_slave_status() {
         # Slave is more than the set number of seconds behind, return status 2
         if [ "$ws_status" != "OFFLINE_SOFT" ];then
           proxysql_exec $LINENO -Ns "UPDATE mysql_servers SET status = 'OFFLINE_SOFT' WHERE hostname='$ws_ip' and port=$ws_port;"
-          check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port to ProxySQL database, Please check ProxySQL login credentials"
-          log_if_success $LINENO $? "slave server ${ws_ip}:${ws_port} set to OFFLINE_SOFT status in ProxySQL (slave is too far behind:$seconds_behind). (io:$slave_io_running sql:$slave_sql_running)"
+          check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster node $ws_address to ProxySQL database, Please check ProxySQL login credentials"
+          log_if_success $LINENO $? "slave server ${ws_address} set to OFFLINE_SOFT status in ProxySQL (slave is too far behind:$seconds_behind). (io:$slave_io_running sql:$slave_sql_running)"
           echo "1" > ${reload_check_file}
         else
           log $LINENO "slave server (${node_id}) current status '$ws_status' in ProxySQL. (io:$slave_io_running sql:$slave_sql_running)"
@@ -1421,8 +1508,8 @@ function set_slave_status() {
         #
         if [ "$ws_status" != "ONLINE" ];then
           proxysql_exec $LINENO -Ns "UPDATE mysql_servers SET status = 'ONLINE' WHERE hostgroup_id=$HOSTGROUP_SLAVEREADER_ID AND hostname='$ws_ip' and port=$ws_port;"
-          check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port in ProxySQL, Please check ProxySQL login credentials"
-          log_if_success $LINENO $? "slave server $HOSTGROUP_SLAVEREADER_ID:${ws_ip}:${ws_port} set to ONLINE status in ProxySQL. (io:$slave_io_running sql:$slave_sql_running)"
+          check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster node $ws_address in ProxySQL, Please check ProxySQL login credentials"
+          log_if_success $LINENO $? "slave server $HOSTGROUP_SLAVEREADER_ID:${ws_address} set to ONLINE status in ProxySQL. (io:$slave_io_running sql:$slave_sql_running)"
           if [[ $ws_hg_id -ne $HOSTGROUP_SLAVEREADER_ID ]]; then
             log $LINENO "slave server (${node_id}) current status '$ws_status' in ProxySQL. (io:$slave_io_running sql:$slave_sql_running)"
           fi
@@ -1439,10 +1526,10 @@ function set_slave_status() {
       # So leave it ONLINE in this state.
       #
       if [[ $ws_status == "ONLINE" ]]; then
-        log $LINENO "slave server ${ws_ip}:${ws_port} status:'${ws_status}' maintained in case the cluster is down. (io:$slave_io_running sql:$slave_sql_running)"
+        log $LINENO "slave server ${ws_address} status:'${ws_status}' maintained in case the cluster is down. (io:$slave_io_running sql:$slave_sql_running)"
       else
         proxysql_exec $LINENO -Ns "UPDATE mysql_servers SET status = 'OFFLINE_SOFT' WHERE hostname='$ws_ip' and port=$ws_port;"
-        log $LINENO "slave server ${ws_ip}:${ws_port} status:'OFFLINE_SOFT'. (io:$slave_io_running sql:$slave_sql_running)"
+        log $LINENO "slave server ${ws_address} status:'OFFLINE_SOFT'. (io:$slave_io_running sql:$slave_sql_running)"
         echo "1" > ${reload_check_file}
       fi
     fi
@@ -1511,6 +1598,8 @@ function update_readers() {
     local wsrep_status
     local pxc_main_mode
     local result
+    local address
+    address=$(combine_ip_port_into_address "$server" "$port")
     result=$(mysql_exec $LINENO "$server" "$port" -Nns "SHOW STATUS LIKE 'wsrep_local_state'; SHOW VARIABLES LIKE 'pxc_maint_mode';" 2>>${DEBUG_ERR_FILE})
     wsrep_status=$(echo "$result" | grep "wsrep_local_state" | awk '{ print $2 }')
     pxc_main_mode=$(echo "$result" | grep "pxc_maint_mode" | awk '{ print $2 }')
@@ -1524,13 +1613,13 @@ function update_readers() {
       pxc_main_mode="DISABLED"
     fi
 
-    log "" "--> Checking READ server $hostgroup:$server:$port, current status $stat, wsrep_local_state $wsrep_status"
+    log "" "--> Checking READ server $hostgroup:$address, current status $stat, wsrep_local_state $wsrep_status"
 
     if [[ $WRITER_IS_READER == "ondemand" && $writer_stat == "ONLINE" ]] ; then
       if [ $online_readonly_nodes_found -eq 0 ] ; then
         # WSREP:ok  PXC:ok  STATUS:online
         if [ "${wsrep_status}" = "4" -a "$stat" == "ONLINE" -a "${pxc_main_mode}" == "DISABLED" ] ; then
-          log "" "server $hostgroup:$server:$port is already ONLINE, is also write node in ONLINE state, not enough non-ONLINE readers found"
+          log "" "server $hostgroup:$address is already ONLINE, is also write node in ONLINE state, not enough non-ONLINE readers found"
         fi
 
         # WSREP:ok  PXC:ok  STATUS:not online
@@ -1553,17 +1642,17 @@ function update_readers() {
         fi
         # WSREP:ok  PXC:ok  STATUS:not online
         if [ "${wsrep_status}" = "4" -a "$stat" != "ONLINE" -a "${pxc_main_mode}" == "DISABLED" ] ; then
-          log "" "server $hostgroup:$server:$port is $stat, keeping node as $stat,as it is an ONLINE writer and we prefer not to have writers as readers (writer-is-reader:ondemand)"
+          log "" "server $hostgroup:$address is $stat, keeping node as $stat,as it is an ONLINE writer and we prefer not to have writers as readers (writer-is-reader:ondemand)"
         fi
       fi
     else
       # WSREP:ok  PXC:ok  STATUS:online
       if [ "${wsrep_status}" = "4" -a "$stat" == "ONLINE" -a "${pxc_main_mode}" == "DISABLED" ] ; then
-        log "" "server $hostgroup:$server:$port is already ONLINE"
+        log "" "server $hostgroup:$address is already ONLINE"
         online_readonly_nodes_found=$(( $online_readonly_nodes_found + 1 ))
       # WSREP:ok  PXC:not ok  STATUS:not online
       elif [ "${wsrep_status}" = "4" -a "$stat" != "ONLINE" -a "${pxc_main_mode}" != "DISABLED" ] ; then
-        log "" "server $hostgroup:$server:$port is $stat"
+        log "" "server $hostgroup:$address is $stat"
       fi
 
       # WSREP status OK, but node is not marked ONLINE
@@ -1589,7 +1678,7 @@ function update_readers() {
       echo "1" > ${reload_check_file}
     # WSREP:not ok  STATUS:offline soft
     elif [ "${wsrep_status}" != "4" -a "$stat" = "OFFLINE_SOFT" ]; then
-      log "" "server $hostgroup:$server:$port is already OFFLINE_SOFT, WSREP status is ${wsrep_status} which is not ok"
+      log "" "server $hostgroup:$address is already OFFLINE_SOFT, WSREP status is ${wsrep_status} which is not ok"
     fi
   done
 }
@@ -1631,6 +1720,8 @@ function search_for_desynced_writers() {
         local wsrep_status
         local pxc_main_mode
         local result
+        local address
+        address=$(combine_ip_port_into_address "$server" "$port")
         result=$(mysql_exec $LINENO "$server" "$port" -Nns "SHOW STATUS LIKE 'wsrep_local_state'; SHOW VARIABLES LIKE 'pxc_maint_mode';" 2>>${DEBUG_ERR_FILE})
         wsrep_status=$(echo "$result" | grep "wsrep_local_state" | awk '{ print $2 }')
         pxc_main_mode=$(echo "$result" | grep "pxc_maint_mode" | awk '{ print $2 }')
@@ -1646,11 +1737,11 @@ function search_for_desynced_writers() {
 
         # Nodes in maintenance are not allowed
         if [[ $pxc_main_mode != "DISABLED" ]]; then
-          log "" "Skipping $hostgroup:$server:$port node is in pxc_maint_mode:$pxc_main_mode"
+          log "" "Skipping $hostgroup:$address node is in pxc_maint_mode:$pxc_main_mode"
           break
         fi
 
-        log "" "Checking $hostgroup:$server:$port for node in DONOR state, status $stat , wsrep_local_state $wsrep_status"
+        log "" "Checking $hostgroup:$address for node in DONOR state, status $stat , wsrep_local_state $wsrep_status"
         if [ "${wsrep_status}" = "2" -a "$stat" != "ONLINE" ]; then
           # if we are on Donor/Desync and not online in mysql_servers -> proceed
 
@@ -1661,7 +1752,7 @@ function search_for_desynced_writers() {
             proxysql_exec $LINENO -Ns \
               "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment)
                   VALUES ('$server',$HOSTGROUP_WRITER_ID,$port,1000000,'WRITE');"
-            log $LINENO "Adding server $HOSTGROUP_WRITER_ID:$server:$port with status ONLINE. Reason: WSREP status is DESYNC/DONOR, as this is the only node we will put this one online"
+            log $LINENO "Adding server $HOSTGROUP_WRITER_ID:$address with status ONLINE. Reason: WSREP status is DESYNC/DONOR, as this is the only node we will put this one online"
           else
             change_server_status $LINENO $HOSTGROUP_WRITER_ID "$server" $port "ONLINE" ""\
                                  "WSREP status is DESYNC/DONOR, as this is the only node we will put this one online"
@@ -1717,6 +1808,8 @@ function search_for_desynced_readers() {
         local wsrep_status
         local pxc_main_mode
         local result
+        local address
+        address=$(combine_ip_port_into_address "$server" "$port")
         result=$(mysql_exec $LINENO "$server" "$port" -Nns "SHOW STATUS LIKE 'wsrep_local_state'; SHOW VARIABLES LIKE 'pxc_maint_mode';" 2>>${DEBUG_ERR_FILE})
         wsrep_status=$(echo "$result" | grep "wsrep_local_state" | awk '{ print $2 }')
         pxc_main_mode=$(echo "$result" | grep "pxc_maint_mode" | awk '{ print $2 }')
@@ -1732,11 +1825,11 @@ function search_for_desynced_readers() {
 
         # Nodes in maintenance are not allowed
         if [[ $pxc_main_mode != "DISABLED" ]]; then
-          log "" "Skipping $hostgroup:$server:$port node is in pxc_maint_mode:$pxc_main_mode"
+          log "" "Skipping $hostgroup:$address node is in pxc_maint_mode:$pxc_main_mode"
           break
         fi
 
-        log "" "Checking $hostgroup:$server:$port for node in DONOR state, status $stat , wsrep_local_state $wsrep_status"
+        log "" "Checking $hostgroup:$address for node in DONOR state, status $stat , wsrep_local_state $wsrep_status"
         if [ "${wsrep_status}" = "2" -a "$stat" != "ONLINE" ];then
           # if we are on Donor/Desync an not online in mysql_servers -> proceed
           change_server_status $LINENO $HOSTGROUP_READER_ID "$server" $port "ONLINE" ""\
@@ -1886,8 +1979,9 @@ function add_slave_to_write_hostgroup() {
                                            AND hostgroup_id='$HOSTGROUP_SLAVEREADER_ID'
                                            ORDER BY random() LIMIT 1")
       if [[ -n $next_host ]]; then
-        host=$(echo "$next_host" | awk '{ print $1 }')
-        port=$(echo "$next_host" | awk '{ print $2 }')
+        local host=$(echo "$next_host" | awk '{ print $1 }')
+        local port=$(echo "$next_host" | awk '{ print $2 }')
+        local address=$(combine_ip_port_into_address "$host" "$port")
 
         # Found a node, update the READER to ONLINE
         proxysql_exec $LINENO -Ns "UPDATE mysql_servers
@@ -1895,20 +1989,21 @@ function add_slave_to_write_hostgroup() {
                                     WHERE hostgroup_id=$HOSTGROUP_SLAVEREADER_ID
                                       AND hostname='$host'
                                       AND port=$port"
-        log_if_success $LINENO $? "slave server ${HOSTGROUP_SLAVEREADER_ID}:$host:$port set to ONLINE status in ProxySQL."
+        log_if_success $LINENO $? "slave server ${HOSTGROUP_SLAVEREADER_ID}:$address set to ONLINE status in ProxySQL."
         echo 1 > "${reload_check_file}"
       fi
     fi
 
     if [[ -n $next_host ]]; then
-      host=$(echo "$next_host" | awk '{ print $1 }')
-      port=$(echo "$next_host" | awk '{ print $2 }')
+      local host=$(echo "$next_host" | awk '{ print $1 }')
+      local port=$(echo "$next_host" | awk '{ print $2 }')
+      local address=$(combine_ip_port_into_address "$host" "$port")
 
       proxysql_exec $LINENO -Ns "INSERT INTO mysql_servers
             (hostname,hostgroup_id,port,weight,status,comment)
             VALUES ('$host',$HOSTGROUP_WRITER_ID,$port,1000000,'ONLINE','SLAVEREAD');"
-      check_cmd $LINENO $? "Cannot add Percona XtraDB Cluster node $host:$port to ProxySQL, Please check ProxySQL login credentials"
-      log_if_success $LINENO $? "slave server ${HOSTGROUP_WRITER_ID}:$host:$port set to ONLINE status in ProxySQL."
+      check_cmd $LINENO $? "Cannot add Percona XtraDB Cluster node $address to ProxySQL, Please check ProxySQL login credentials"
+      log_if_success $LINENO $? "slave server ${HOSTGROUP_WRITER_ID}:$address set to ONLINE status in ProxySQL."
       echo 1 > "${reload_check_file}"
     else
       log $LINENO "Could not find any slave readers to promote to a writer"

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -396,6 +396,65 @@ function slave_exec() {
   return $retoutput
 }
 
+# Separates the IP address from the port in a network address
+# Works for IPv4 and IPv6
+#
+# Globals:
+#   None
+#
+# Params:
+#   1. The network address to be parsed
+#
+# Outputs:
+#   A string with a space separating the IP address from the port
+#
+function separate_ip_port_from_address()
+{
+  #
+  # Break address string into host:port/path parts
+  #
+  local address=$1
+
+  ip_addr=${address%:*}
+  port=${address##*:}
+
+  # Remove any braces that surround the ip address portion
+  ip_addr=${ip_addr#\[}
+  ip_addr=${ip_addr%\]}
+
+  echo "${ip_addr} ${port}"
+}
+
+# Combines the IP address and port into a network address
+# Works for IPv4 and IPv6
+# (If the IP address is IPv6, the IP portion will have brackets)
+#
+# Globals:
+#   None
+#
+# Params:
+#   1: The IP address portion
+#   2: The port
+#
+# Outputs:
+#   A string containing the full network address
+#
+function combine_ip_port_into_address()
+{
+  local ip_addr=$1
+  local port=$2
+  local addr
+
+  if [[ ! $ip_addr =~ \[.*\] && $ip_addr =~ .*:.* ]] ; then
+    # If there are no brackets and it does have a ':', then add the brackets
+    # because this is an unbracketed IPv6 address
+    addr="[${ip_addr}]:${port}"
+  else
+    addr="${ip_addr}:${port}"
+  fi
+  echo $addr
+}
+
 
 # Update Percona XtraDB Cluster nodes in ProxySQL database
 # This will take care of nodes that have gone up or gone down
@@ -424,6 +483,7 @@ function update_cluster() {
   local current_hosts=""
   local is_current_hosts_empty=0
   local wsrep_address=""
+  local ws_address
   local ws_ip
   local ws_port
   local ws_hg_status
@@ -436,7 +496,21 @@ function update_cluster() {
   if [[ -n host_info ]]; then
     # Extract the hostname and port from the rows
     # Creates a string of "host:port" separated by spaces
-    current_hosts=$(echo "$host_info" | cut -d' ' -f1 | tr '\n' ' ')
+    current_hosts=""
+
+    while read line; do
+      if [[ -z $line ]]; then
+        continue
+      fi
+      net_address=$(echo $line | cut -d' ' -f1)
+      net_address=$(separate_ip_port_from_address $net_address)
+      local ip_addr=$(echo $net_address | cut -d' ' -f1)
+      local port=$(echo $net_address | cut -d' ' -f2)
+      net_address=$(combine_ip_port_into_address "$ip_addr" "$port")
+      current_hosts+="$net_address "
+    done< <(printf "$host_info\n")
+
+    current_hosts=${current_hosts% }
   fi
 
   if [[ -n $cluster_host && -n $cluster_port ]]; then
@@ -466,9 +540,9 @@ function update_cluster() {
     fi
 
     log $LINENO "Cluster node (${i}) does not exist in ProxySQL, adding as a $MODE_COMMENT node"
-
-    ws_ip=$(echo $i | cut -d':' -f1)
-    ws_port=$(echo $i | cut -d':' -f2)
+    ws_address=$(separate_ip_port_from_address "$i")
+    ws_ip=$(echo $ws_address | cut -d' ' -f1)
+    ws_port=$(echo $ws_address | cut -d' ' -f2)
 
     # Add the node as a reader
     local hostgroup
@@ -479,12 +553,12 @@ function update_cluster() {
     if [[ -n $hostgroup ]]; then
       # Update reader to OFFLINE_SOFT if new PXC node in ProxySQL
       proxysql_exec $LINENO "UPDATE mysql_servers SET status='OFFLINE_SOFT',weight=1000,comment='$MODE_COMMENT' WHERE hostname='${ws_ip}' AND port=${ws_port} AND hostgroup_id=${hostgroup}"
-      check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster node $ws_ip:$ws_port (hostgroup $hostgroup) to ProxySQL database, Please check ProxySQL login credentials"
+      check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster node $ws_address (hostgroup $hostgroup) to ProxySQL database, Please check ProxySQL login credentials"
       log_if_success $LINENO $? "Updated ${hostgroup}:${i} node in the ProxySQL database."
     else
       # Insert a reader if new PXC node not in ProxySQL
       proxysql_exec $LINENO "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$DEFAULT_HOSTGROUP_ID,$ws_port,1000,'$MODE_COMMENT');"
-      check_cmd $LINENO $? "Cannot add Percona XtraDB Cluster node $ws_ip:$ws_port (hostgroup $DEFAULT_HOSTGROUP_ID) to ProxySQL database, Please check ProxySQL login credentials"
+      check_cmd $LINENO $? "Cannot add Percona XtraDB Cluster node $ws_address (hostgroup $DEFAULT_HOSTGROUP_ID) to ProxySQL database, Please check ProxySQL login credentials"
       log_if_success $LINENO $? "Added ${DEFAULT_HOSTGROUP_ID}:${i} node into ProxySQL database."
     fi
 
@@ -508,16 +582,17 @@ function update_cluster() {
     # The current host in current_hosts was not found in cluster membership,
     # set it OFFLINE_SOFT unless its a slave node
     #
-    ws_ip=$(echo $i | cut -d':' -f1)
-    ws_port=$(echo $i | cut -d':' -f2)
+    ws_address=$(separate_ip_port_from_address "$i")
+    ws_ip=$(echo $ws_address | cut -d' ' -f1)
+    ws_port=$(echo $ws_address | cut -d' ' -f2)
 
     # This is supported by status, so OFFLINE should come before ONLINE
     # Note that the status is in DESC order, so "ONLINE : OFFLINE_SOFT : OFFLINE_HARD"
     # This is needed because there may be multiple entries
     ws_hg_status=$(proxysql_exec $LINENO "SELECT hostgroup_id,status,comment from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port ORDER BY status DESC LIMIT 1")
-    ws_hg_id=$(echo $ws_hg_status | cut -d' ' -f1)
-    ws_status=$(echo $ws_hg_status | cut -d' ' -f2)
-    ws_comment=$(echo $ws_hg_status | cut -d' ' -f3)
+    ws_hg_id=$(echo -e "$ws_hg_status" | cut -f1)
+    ws_status=$(echo -e "$ws_hg_status" | cut -f2)
+    ws_comment=$(echo -e "$ws_hg_status" | cut -f3)
 
     if [ "$ws_comment" == "SLAVEREAD" ]; then
       # This update now happens in proxysql_galera_checker
@@ -553,15 +628,22 @@ function update_cluster() {
     if [[ -n $current_hosts && " ${current_hosts} " =~ " ${i} " ]]; then
       # Lookup the status in the host_info
       local host
-      host=$(echo "$host_info" | grep "${i}" | head -1)
-      ws_ip=$(echo $i | cut -d':' -f1)
-      ws_port=$(echo $i | cut -d':' -f2)
+
+      ws_address=$(separate_ip_port_from_address "$i")
+      ws_ip=$(echo $ws_address | cut -d' ' -f1)
+      ws_port=$(echo $ws_address | cut -d' ' -f2)
+
+      # properly escape the characters for grep
+      local re_i="$(printf '%s' "$ws_ip:$ws_port" | sed 's/[.[\*^$]/\\&/g')"
+      host=$(echo "$host_info" | grep "${re_i}" | head -1)
+
       ws_hg_id=$(echo $host | cut -d' ' -f2)
       ws_status=$(echo $host | cut -d' ' -f3)
       log "" "Cluster node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL."
     else
-      ws_ip=$(echo $i | cut -d':' -f1)
-      ws_port=$(echo $i | cut -d':' -f2)
+      ws_address=$(separate_ip_port_from_address "$i")
+      ws_ip=$(echo $ws_address | cut -d' ' -f1)
+      ws_port=$(echo $ws_address | cut -d' ' -f2)
       ws_hg_status=$(proxysql_exec $LINENO "SELECT hostgroup_id,status from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port")
       ws_hg_id=$(echo $ws_hg_status | cut -d' ' -f1)
       ws_status=$(echo $ws_hg_status | cut -d' ' -f2)

--- a/tests/async-slave-testsuite.bats
+++ b/tests/async-slave-testsuite.bats
@@ -50,6 +50,11 @@ else
   PORT_SLAVE2=4295
 fi
 
+if [[ USE_IPVERSION == "v6" ]]; then
+  LOCALHOST_IP="[::1]"
+else
+  LOCALHOST_IP="127.0.0.1"
+fi
 
 # Sets up the general test setup
 #   (1) Deactivates the scheduler
@@ -121,9 +126,9 @@ function verify_initial_state() {
   [ "${read_weight[2]}" -eq 1000 ]
 
   result=$(retrieve_slavenode_status "${slave_host[0]}" "${slave_port[0]}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "Yes" ]
@@ -143,15 +148,15 @@ function verify_initial_state() {
   [ "$status" -eq 0 ]
   
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "Yes" ]
   [ "${slave_sql_running}" = "Yes" ]
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --include-slaves=127.0.0.1:$PORT_SLAVE1 --use-slave-as-writer=yes --writer-is-reader=ondemand <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --include-slaves=$LOCALHOST_IP:$PORT_SLAVE1 --use-slave-as-writer=yes --writer-is-reader=ondemand <<< 'n'
   [ "$status" -eq  0 ]
 
   #
@@ -211,9 +216,9 @@ function verify_initial_state() {
   
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
   echo $result >&2
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "No" ]
@@ -255,9 +260,9 @@ function verify_initial_state() {
   [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
   
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "Yes" ]
@@ -311,9 +316,9 @@ function verify_initial_state() {
   [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
   
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "Yes" ]
@@ -355,9 +360,9 @@ function verify_initial_state() {
   [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
   
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "Yes" ]
@@ -398,9 +403,9 @@ function verify_initial_state() {
   [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
   
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "No" ]
@@ -442,9 +447,9 @@ function verify_initial_state() {
   [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
   
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "Yes" ]
@@ -1216,7 +1221,7 @@ function verify_initial_state() {
   #proxysql_exec "UPDATE scheduler SET active=1 WHERE id=$SCHEDULER_ID; LOAD scheduler TO RUNTIME"
 }
 
-@test "run proxysql-admin -d (restart fot use-slave-as-writer tests) ($WSREP_CLUSTER_NAME)" {
+@test "run proxysql-admin -d (restart for use-slave-as-writer tests) ($WSREP_CLUSTER_NAME)" {
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
   echo "$output" >&2
   [ "$status" -eq  0 ]
@@ -1228,15 +1233,15 @@ function verify_initial_state() {
   [ "$status" -eq 0 ]
 
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "Yes" ]
   [ "${slave_sql_running}" = "Yes" ]
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --include-slaves=127.0.0.1:$PORT_SLAVE1 --use-slave-as-writer=no --writer-is-reader=ondemand <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --include-slaves=$LOCALHOST_IP:$PORT_SLAVE1 --use-slave-as-writer=no --writer-is-reader=ondemand <<< 'n'
   [ "$status" -eq  0 ]
 
   #
@@ -1296,9 +1301,9 @@ function verify_initial_state() {
 
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
   echo $result >&2
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "No" ]
@@ -1340,9 +1345,9 @@ function verify_initial_state() {
   [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
 
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "Yes" ]
@@ -1396,9 +1401,9 @@ function verify_initial_state() {
   [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
 
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "Yes" ]
@@ -1440,9 +1445,9 @@ function verify_initial_state() {
   [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
 
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "Yes" ]
@@ -1483,9 +1488,9 @@ function verify_initial_state() {
   [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
 
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "No" ]
@@ -1527,9 +1532,9 @@ function verify_initial_state() {
   [ "${slave_hostgroup[0]}" -eq $READ_HOSTGROUP_ID ]
 
   result=$(retrieve_slavenode_status "${CLUSTER_HOSTNAME}" "${PORT_SLAVE1}")
-  master_host=$(echo "$result" | cut -d: -f1)
-  slave_io_running=$(echo "$result" | cut -d: -f2)
-  slave_sql_running=$(echo "$result" | cut -d: -f3)
+  master_host=$(echo -e "$result" | cut -f1)
+  slave_io_running=$(echo -e "$result" | cut -f2)
+  slave_sql_running=$(echo -e "$result" | cut -f3)
 
   [ -n "${master_host}" ]
   [ "${slave_io_running}" = "Yes" ]

--- a/tests/desynced-host-testsuite.bats
+++ b/tests/desynced-host-testsuite.bats
@@ -41,7 +41,12 @@ else
   PORT_2=4220
   PORT_NOPRIO=4210
 fi
-PRIORITY_LIST="127.0.0.1:${PORT_1},127.0.0.1:${PORT_2}"
+if [[ $USE_IPVERSION == "v4" ]]; then
+  LOCALHOST_IP="127.0.0.1"
+else
+  LOCALHOST_IP="[::1]"
+fi
+PRIORITY_LIST="${LOCALHOST_IP}:${PORT_1},${LOCALHOST_IP}:${PORT_2}"
 
 
 # Sets up the general priority tests

--- a/tests/host-priority-testsuite.bats
+++ b/tests/host-priority-testsuite.bats
@@ -1,4 +1,4 @@
-## proxysql_GALERA_CHECKER host priority tests
+# proxysql_GALERA_CHECKER host priority tests
 #
 # Testing Hints:
 # If there is a problem in the test, it's useful to enable the "debug"
@@ -39,8 +39,14 @@ else
   PORT_2=4220
   PORT_NOPRIO=4210
 fi
-PRIORITY_LIST="127.0.0.1:${PORT_1},127.0.0.1:${PORT_2}"
 
+if [[ $USE_IPVERSION == "v4" ]]; then
+  LOCALHOST_IP="127.0.0.1"
+else
+  LOCALHOST_IP="[::1]"
+fi
+PRIORITY_LIST="${LOCALHOST_IP}:${PORT_1},${LOCALHOST_IP}:${PORT_2}"
+PRIORITY_LIST_re=$(printf '%s' "$PRIORITY_LIST" | sed 's/[.[\*^$]/\\&/g')
 
 # Sets up the general priority tests
 #   (1) Deactivates the scheduler
@@ -2338,13 +2344,14 @@ function verify_initial_state() {
   retrieve_writer_info
   host=${write_host[0]}
 
-  local new_priority_list="127.0.0.1:9000,127.0.0.1:9001"
+  local new_priority_list="${LOCALHOST_IP}:9000,${LOCALHOST_IP}:9001"
+  local new_priority_list_re=$(printf '%s' "$new_priority_list" | sed 's/[.[\*^$]/\\&/g')
 
   # Swap the old priority list for the new priority list in the
   # galera_checker
   GALERA_CHECKER=$(proxysql_exec "SELECT filename FROM scheduler WHERE id=$SCHEDULER_ID")
   GALERA_CHECKER_ARGS=$(proxysql_exec "SELECT arg1 FROM scheduler WHERE id=$SCHEDULER_ID")
-  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST}/${new_priority_list}/g")
+  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST_re}/${new_priority_list_re}/g")
 
   echo $GALERA_CHECKER_ARGS >&2
 
@@ -2460,13 +2467,14 @@ function verify_initial_state() {
   retrieve_writer_info
   host=${write_host[0]}
 
-  local new_priority_list="127.0.0.1:9000,127.0.0.1:9001"
+  local new_priority_list="${LOCALHOST_IP}:9000,${LOCALHOST_IP}:9001"
+  local new_priority_list_re=$(printf '%s' "$new_priority_list" | sed 's/[.[\*^$]/\\&/g')
 
   # Swap the old priority list for the new priority list in the
   # galera_checker
   GALERA_CHECKER=$(proxysql_exec "SELECT filename FROM scheduler WHERE id=$SCHEDULER_ID")
   GALERA_CHECKER_ARGS=$(proxysql_exec "SELECT arg1 FROM scheduler WHERE id=$SCHEDULER_ID")
-  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST}/${new_priority_list}/g")
+  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST_re}/${new_priority_list_re}/g")
 
   echo $GALERA_CHECKER_ARGS >&2
 
@@ -2623,13 +2631,14 @@ function verify_initial_state() {
   host=${write_host[0]}
   writer_port=${write_port[0]}
 
-  local new_priority_list="127.0.0.1:9000,127.0.0.1:9001"
+  local new_priority_list="${LOCALHOST_IP}:9000,${LOCALHOST_IP}:9001"
+  local new_priority_list_re=$(printf '%s' "$new_priority_list" | sed 's/[.[\*^$]/\\&/g')
 
   # Swap the old priority list for the new priority list in the
   # galera_checker
   GALERA_CHECKER=$(proxysql_exec "SELECT filename FROM scheduler WHERE id=$SCHEDULER_ID")
   GALERA_CHECKER_ARGS=$(proxysql_exec "SELECT arg1 FROM scheduler WHERE id=$SCHEDULER_ID")
-  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST}/${new_priority_list}/g")
+  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST_re}/${new_priority_list_re}/g")
 
   echo $GALERA_CHECKER_ARGS >&2
 
@@ -2782,13 +2791,14 @@ function verify_initial_state() {
   retrieve_writer_info
   host=${write_host[0]}
 
-  local new_priority_list="127.0.0.1:9000,127.0.0.1:9001"
+  local new_priority_list="${LOCALHOST_IP}:9000,${LOCALHOST_IP}:9001"
+  local new_priority_list_re=$(printf '%s' "$new_priority_list" | sed 's/[.[\*^$]/\\&/g')
 
   # Swap the old priority list for the new priority list in the
   # galera_checker
   GALERA_CHECKER=$(proxysql_exec "SELECT filename FROM scheduler WHERE id=$SCHEDULER_ID")
   GALERA_CHECKER_ARGS=$(proxysql_exec "SELECT arg1 FROM scheduler WHERE id=$SCHEDULER_ID")
-  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST}/${new_priority_list}/g")
+  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST_re}/${new_priority_list_re}/g")
 
   echo $GALERA_CHECKER_ARGS >&2
 
@@ -2944,7 +2954,8 @@ function verify_initial_state() {
   retrieve_writer_info
   host=${write_host[0]}
 
-  local new_priority_list="127.0.0.1:9000,127.0.0.1:${PORT_2},127.0.0.1:9001"
+  local new_priority_list="${LOCALHOST_IP}:9000,${LOCALHOST_IP}:${PORT_2},${LOCALHOST_IP}:9001"
+  local new_priority_list_re=$(printf '%s' "$new_priority_list" | sed 's/[.[\*^$]/\\&/g')
 
   # Swap the old priority list for the new priority list in the
   # galera_checker
@@ -2983,7 +2994,7 @@ function verify_initial_state() {
   [ "${read_weight[1]}" -eq 1000 ]
   [ "${read_weight[2]}" -eq 1000 ]
 
-  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST}/${new_priority_list}/g")
+  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/${PRIORITY_LIST_re}/${new_priority_list_re}/g")
 
   # Run the checker, node 2 should be the writer (new priority list)
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='host-priority $LINENO'")

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -85,6 +85,8 @@ echo "$output"
 @test "run the check for updating runtime_mysql_servers table ($WSREP_CLUSTER_NAME)" {
   #skip
   # check initial writer info
+  # Give proxysql a change to run the galera_checker script
+  sleep 5
   first_writer_port=$(proxysql_exec "select port from mysql_servers where hostgroup_id='$WRITE_HOSTGROUP_ID';" 2>/dev/null)
   first_writer_status=$(proxysql_exec "select status from mysql_servers where hostgroup_id='$WRITE_HOSTGROUP_ID';" 2>/dev/null)
   first_writer_weight=$(proxysql_exec "select weight from mysql_servers where hostgroup_id='$WRITE_HOSTGROUP_ID';" 2>/dev/null)
@@ -94,8 +96,6 @@ echo "$output"
   [ "$first_writer_status" = "ONLINE" ]
   [ "$first_writer_weight" = "1000000" ]
   [ "$first_writer_comment" = "WRITE" ]
-
-  echo "first_writer_start_cmd = $first_writer_start_cmd" >&2
 
   # check that the tables are equal at start
   mysql_servers=$(proxysql_exec "select * from mysql_servers where hostgroup_id in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID) order by port;" 2>/dev/null)

--- a/tests/test-common.bash
+++ b/tests/test-common.bash
@@ -200,12 +200,12 @@ function retrieve_slavenode_status() {
   status=$(mysql_exec "${host}" "${port}" 'SHOW SLAVE STATUS\G' "--silent" | sed 's/ //g')
 
   result=""
-  result+=$(echo "$status" | grep "^Master_Host:" | cut -d: -f2)
-  result+=":"
+  result+=$(echo "$status" | grep "^Master_Host:" | cut -d: -f2-)
+  result+="\t"
   result+=$(echo "$status" | grep "^Slave_IO_Running:" | cut -d: -f2)
-  result+=":"
+  result+="\t"
   result+=$(echo "$status" | grep "^Slave_SQL_Running:" | cut -d: -f2)
-  result+=":"
+  result+="\t"
   result+=$(echo "$status" | grep "^Seconds_Behind_Master:" | cut -d: -f2)
 
   echo "$result"

--- a/tests/writer-is-reader-testsuite.bats
+++ b/tests/writer-is-reader-testsuite.bats
@@ -2505,7 +2505,7 @@ function verify_initial_state() {
   $PXC_BASEDIR/bin/mysqladmin $pxc_socket -u root shutdown
 
   # Run the checker, should move writer to OFFLINE_SOFT reader
-  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --debug")
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS}")
   [ "$status" -eq 0 ]
 
   # nodes are ordered by status,host,port,hostgroup


### PR DESCRIPTION
Issue
Scripts are not compatible with IPv6 formatted addresses.
The major problem is that we parse the IP addr and port
by breaking on the ':', which is a problem for IPv6 addresses
since they include ':' in the address.

Solution
Fixup the places where we use addresses.
Also add an "--ipv6" option to the test scripts.