### PR TITLE
PSQLADM-115 : proxysql_node_monitor fails with more than one command …

### DIFF
--- a/doc/proxysql_galera_checker.md
+++ b/doc/proxysql_galera_checker.md
@@ -1,6 +1,6 @@
 # proxysql_galera_checker usage info.
 
-`proxysql_galera_checker` script will check Percona XtraDB Cluster desynced nodes, and temporarily deactivate them. Currently, this script is developed to work with proxysql-admin [script](https://github.com/percona/proxysql-admin-tool/blob/v1.4.11-dev/README.md)
+`proxysql_galera_checker` script will check Percona XtraDB Cluster desynced nodes, and temporarily deactivate them. Currently, this script is developed to work with proxysql-admin [script](https://github.com/percona/proxysql-admin-tool/blob/v1.4.12-dev/README.md)
 
 This script will also call `proxysql_node_monitor` script. Monitor script will check cluster node membership, and re-configure ProxySQL if cluster membership changes occur. 
 

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -49,7 +49,7 @@ fi
 #
 # Script parameters/constants
 #
-readonly    PROXYSQL_ADMIN_VERSION="1.4.11"
+readonly    PROXYSQL_ADMIN_VERSION="1.4.12"
 declare  -i DEBUG=0
 
 #

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -18,7 +18,7 @@ set -o nounset    # no undefined variables
 # Script parameters/constants
 #
 declare  -i DEBUG=0
-readonly    PROXYSQL_ADMIN_VERSION="1.4.11"
+readonly    PROXYSQL_ADMIN_VERSION="1.4.12"
 
 #Timeout exists for instances where mysqld may be hung
 declare  -i TIMEOUT=10
@@ -568,8 +568,8 @@ function upgrade_scheduler(){
 #   3: server address
 #   4: port
 #   5: new status
-#   6: comment
-#   7: reader_status
+#   6: reader_status
+#   7: comment
 #
 function change_server_status() {
   local lineno=$1

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -21,7 +21,7 @@ declare NRED=""
 #
 
 declare -i  DEBUG=0
-readonly    PROXYSQL_ADMIN_VERSION="1.4.11"
+readonly    PROXYSQL_ADMIN_VERSION="1.4.12"
 
 declare     CONFIG_FILE="/etc/proxysql-admin.cnf"
 declare     ERR_FILE="/dev/null"
@@ -998,7 +998,7 @@ function main() {
   CLUSTER_PASSWORD=$(proxysql_exec $LINENO "SELECT variable_value FROM global_variables WHERE variable_name='mysql-monitor_password'" "hide_output")
   check_cmd $LINENO $? "Could not retrieve cluster login info from ProxySQL. Please check ProxySQL login credentials"
 
-  CLUSTER_TIMEOUT=$(proxysql_exec $LINENO "SELECT DISTINCT MAX(interval_ms / 1000 - 1, 1) FROM scheduler")
+  CLUSTER_TIMEOUT=$(proxysql_exec $LINENO "SELECT MAX(MAX(interval_ms / 1000 - 1, 1)) FROM scheduler")
 
   local cluster_host_info
   cluster_host_info=$(find_online_cluster_host)

--- a/tests/async-slave-testsuite.bats
+++ b/tests/async-slave-testsuite.bats
@@ -50,7 +50,7 @@ else
   PORT_SLAVE2=4295
 fi
 
-if [[ USE_IPVERSION == "v6" ]]; then
+if [[ $USE_IPVERSION == "v6" ]]; then
   LOCALHOST_IP="[::1]"
 else
   LOCALHOST_IP="127.0.0.1"
@@ -1222,12 +1222,14 @@ function verify_initial_state() {
 }
 
 @test "run proxysql-admin -d (restart for use-slave-as-writer tests) ($WSREP_CLUSTER_NAME)" {
+  #skip
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
   echo "$output" >&2
   [ "$status" -eq  0 ]
 }
 
 @test "run proxysql-admin -e --use-slave-as-writer=no ($WSREP_CLUSTER_NAME)" {
+  #skip
   echo "$LINENO Starting the slave on port:$PORT_SLAVE1" >&2
   run mysql_exec "$CLUSTER_HOSTNAME" "$PORT_SLAVE1" "START SLAVE"
   [ "$status" -eq 0 ]

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -20,7 +20,7 @@ TEST_SUITES+=("loadbal-testsuite.bats")
 # Variables
 # ================================================
 #
-declare WORKDIR
+declare WORKDIR=""
 declare SCRIPT_PATH=$0
 declare SCRIPT_DIR=$(cd `dirname $0` && pwd)
 
@@ -51,8 +51,6 @@ declare ALLOW_SHUTDOWN="Yes"
 #
 function usage() {
   cat << EOF
-No valid parameters were passed. Need relative workdir setting. Retry.
-
 Usage example:
   $ ${SCRIPT_PATH##*/} /sda/proxysql-testing [<options>]
 
@@ -378,6 +376,11 @@ if [[ $# -eq 0 ]]; then
   exit 1
 fi
 parse_args $*
+
+if [[ -z $WORKDIR ]]; then
+  echo "No valid parameters were passed. Need relative workdir setting. Retry."
+  exit 1
+fi
 trap cleanup_handler EXIT
 
 if [[ $USE_IPVERSION == "v4" ]]; then


### PR DESCRIPTION
…in scheduler

Issue
Where there is more than one scheduler entry (with different interval values)
we return multiple rows when we expect a single row.

Solution
Ensure that only one row is returned.

Also:
- Updated version to 1.4.12
- Fixed an IPv6 testing bug
- Have the test script fail if no WORKDIR is present