### PR TITLE
PSQLADM-116 : Scheduler is reloading servers on every run

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -192,6 +192,7 @@ Options:
                                      'ondemand' means that the writer node only accepts reads
                                      if there are no other readers.
                                      (default: 'ondemand')
+  --debug                            Enables additional debug logging.
   --help                             Dispalys this help text.
 
 These options are the possible operations for proxysql-admin.

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -178,6 +178,7 @@ Options:
                                       be added to the write hostgroup if all other
                                       cluster nodes are down.
                                       (default: 'yes')
+  --debug                             Enables additional debug logging.
   -h, --help                          Display script usage information
   -v, --version                       Print version info
 
@@ -946,7 +947,8 @@ function writer_is_reader_check() {
       #
       # Ensure that there is a corresponding entry in mysql_servers
       #
-      if [[ ! $servers =~ $regex ]]; then
+      local reader_row=$(echo "$servers" | grep -E "$regex")
+      if [[ -z $reader_row ]]; then
         # We did not find a matching row, insert the corresponding READER entry
 
         # If we are to always have a reader, or if there are no other
@@ -964,9 +966,15 @@ function writer_is_reader_check() {
       elif [[ $WRITER_IS_READER == "ondemand" && $stat == "ONLINE" && $number_readers_online -gt 1 ]]; then
         # If the reader node is ONLINE and there is another reader
         # Then we can deactivate this reader node (if ondemand)
-        proxysql_exec $LINENO -Ns "UPDATE mysql_servers SET status='OFFLINE_SOFT' WHERE hostgroup_id=$HOSTGROUP_READER_ID AND hostname='$server' AND port=$port"
-        log_if_success $LINENO $? "Updating $hostgroup:$address to OFFLINE_SOFT because writers prefer to not be readers (writer-is-reader:ondemand)"
-        echo "1" > ${reload_check_file}
+
+        # This should only do this if there is a corresponding READ entry that is NOT "OFFLINE_SOFT"
+        # Search through the $servers for an entry corresponding to the READ data
+        local reader_status=$(echo -e "$reader_row" | cut -f4)
+        if [[ $reader_status != "OFFLINE_SOFT" ]]; then
+          proxysql_exec $LINENO -Ns "UPDATE mysql_servers SET status='OFFLINE_SOFT' WHERE hostgroup_id=$HOSTGROUP_READER_ID AND hostname='$server' AND port=$port"
+          log_if_success $LINENO $? "Updating $hostgroup:$address to OFFLINE_SOFT because writers prefer to not be readers (writer-is-reader:ondemand)"
+          echo "1" > ${reload_check_file}
+        fi
       fi
     elif [[ $WRITER_IS_READER == "never" ]]; then
       #

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -126,6 +126,7 @@ Options:
                                       whenever this script is run (useful for debugging).
   --reload-check-file=PATH            Specify file used to notify proysql_galera_checker
                                       of a change in server configuration
+  --debug                             Enables additional debug logging.
   -h, --help                          Display script usage information
   -v, --version                       Print version info
 EOF


### PR DESCRIPTION
Issue
We were querying for the max interval but got multiple rows back.
I was originally using DISTINCT to separate the intervals, but should
also do a MAX also.

Solution
Use MAX instead to get a single value back.

Also, added --debug to the usage()