### PR TITLE
PSQLADM-125 : The function "check_is_galera_checker_running" isn't pr…

### DIFF
--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -863,6 +863,9 @@ function check_is_galera_checker_running() {
       ps -p $GPID > /dev/null 2>&1
       if [[ $? -eq 0 ]]; then
         log "$LINENO" "ProxySQL galera checker process already running."
+
+        # We don't want to remove this file on cleanup
+        CHECKER_PIDFILE=""
         exit 1
       else
         echo $$ > $CHECKER_PIDFILE


### PR DESCRIPTION
…eventing multiple instances of the script from running

Issue
This was a regression.  The script is allowing multiple instances of the proxysql_galera_checker
to run, when it shouldn't be allowing them to run.

Solution
We were deleting the galera_checker.pid file ALL the time.  Thus a second instance of the script
would delete the pid file from a previous instance of the script, which would then allow
a third instance of the script to run at the same time as the first instance.

We no longer allow one instane of the script from removing the pid file if the creator of the
pid file is still running.