### PR TITLE
PSQLADM-126 : Script is showing an error when --syncusers is invoked

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -1350,13 +1350,14 @@ function adduser(){
 #
 function get_proxysql_users() {
   local proxysql_users
-  proxysql_users=$(proxysql_exec "$LINENO" "SELECT username,password FROM mysql_users where password!='' and default_hostgroup=$WRITE_HOSTGROUP_ID" "" "hide_output" |
+  proxysql_users=$(proxysql_exec "$LINENO" "SELECT username,password FROM mysql_users where password!='' and default_hostgroup=$WRITE_HOSTGROUP_ID" "" "hide_output")
+  check_cmd $? $LINENO "Failed to load user list from ProxySQL database."\
+                       "\n-- Please check the ProxySQL connection parameters and status."
+  proxysql_users=$(echo "$proxysql_users" |
                       sed 's/\t/,/g' |
                       egrep -v "username,password" |
                       sort |
                       uniq )
-  check_cmd $? $LINENO "Failed to load user list from ProxySQL database."\
-                       "\n-- Please check the ProxySQL connection parameters and status."
   printf "$proxysql_users"
 }
 

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -397,8 +397,12 @@ LOCALHOST_NAME=$(cat /etc/hosts | grep "^${LOCALHOST_IP}" | awk '{ print $2 }')
 declare ROOT_FS=$WORKDIR
 mkdir -p $WORKDIR/logs
 
+echo "Shutting down currently running mysqld instances"
 ps -ef | egrep "mysqld" | grep "$(whoami)" | egrep -v "grep" | xargs kill -9 2>/dev/null
 ps -ef | egrep "node..sock" | grep "$(whoami)" | egrep -v "grep" | xargs kill -9 2>/dev/null
+
+echo "Shutting down currently running proxysql instances"
+sudo ps -ef | egrep "proxysql" | grep "$(whoami)" | egrep -v "grep" | xargs kill -9 2>/dev/null
 
 #
 # Check file locations before doing anything
@@ -607,7 +611,7 @@ if [[ $RUN_TEST -eq 1 ]]; then
       ${PXC_BASEDIR}/bin/mysql --user=admin --password=admin --host=$LOCALHOST_IP --port=6032 --protocol=tcp \
         -e "select hostgroup_id,hostname,port,status,comment from mysql_servers order by hostgroup_id,status,hostname,port" 2>/dev/null
       echo "********************************"
-      echo "* $test_file failed, the servers (ProxySQL+PXC)will be left running"
+      echo "* $test_file failed, the servers (ProxySQL+PXC) will be left running"
       echo "* for debugging purposes."
       echo "********************************"
       ALLOW_SHUTDOWN="No"


### PR DESCRIPTION
Issue
When working with a proxysql instance wiht no entries in the mysql_users,
an error would be reported (since we weren't getting any values back
from proxysql).

Note that the syncusers would still function correctly.

Solution
Move the check of the return value to the query (the query will succeed
but return no data).  The error occurs in the pipeline processing of
the query result.