### PR TITLE
PSQLADM-53 : proxysql-admin verification on --write-node

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -531,8 +531,14 @@ function separate_ip_port_from_address()
   #
   local address=$1
 
-  ip_addr=${address%:*}
-  port=${address##*:}
+  # Has to have at least one ':' to separate the port from the ip address
+  if [[ $address =~ : ]]; then
+    ip_addr=${address%:*}
+    port=${address##*:}
+  else
+    ip_addr=$address
+    port=""
+  fi
 
   # Remove any braces that surround the ip address portion
   ip_addr=${ip_addr#\[}
@@ -1021,8 +1027,8 @@ function enable_proxysql() {
     echo -e "\nVerifying specified slave nodes"
     for i in $SLAVE_NODES; do
       ws_address=$(separate_ip_port_from_address "$i")
-      SLAVE_HOSTNAME=`echo $ws_address | cut -d' ' -f1`
-      SLAVE_PORT=`echo $ws_address | cut -d' ' -f2`
+      SLAVE_HOSTNAME=$(echo "$ws_address" | cut -d' ' -f1)
+      SLAVE_PORT=$(echo "$ws_address" | cut -d' ' -f2)
 
       # Verify we can connect to the slave
       slave_exec "$LINENO" 'show slave status\G' > /dev/null
@@ -1037,8 +1043,8 @@ function enable_proxysql() {
                         tr '\n' ':' |
                         sed 's/:$//g')
       local slave_master_address=$(separate_ip_port_from_address "$slave_master")
-      local slave_master_ip=$(echo $slave_master_address | cut -d' ' -f1)
-      local slave_master_port=$(echo $slave_master_address | cut -d' ' -f2)
+      local slave_master_ip=$(echo "$slave_master_address" | cut -d' ' -f1)
+      local slave_master_port=$(echo "$slave_master_address" | cut -d' ' -f2)
       slave_master_address=$(combine_ip_port_into_address "$slave_master_ip", "$slave_master_port")
       if [[ ${wsrep_address[*]} != *"$slave_master"* ]]; then
         error $LINENO "The slave node's master ($slave_master_address) is not in the list"\
@@ -1743,15 +1749,10 @@ function parse_args() {
         shift 2
         ;;
       --write-node )
-  #    if [ `grep -o ',' <<< $2 | wc -l` -gt 0 ];then
-        # TODO Validate input
         P_HOST_PRIORITY=$2
-        WRITE_NODES=`echo "$2" | sed 's/,/ /g'`
-        WRITE_NODE=`echo "$WRITE_NODES" | cut -d' ' -f1`
+        WRITE_NODES=$(echo "$2" | sed 's/,/ /g')
+        WRITE_NODE=$(echo "$WRITE_NODES" | cut -d' ' -f1)
         ENABLE_PRIORITY=1
-  #    else
-  #      WRITE_NODE="$2"
-  #    fi
         shift 2
         ;;
       --include-slaves )
@@ -1782,6 +1783,24 @@ function parse_args() {
     esac
   done
 
+  # WRITE_NODES validity check (check to see if the port is included)
+  local ws_address
+  local ws_port
+  if [[ -n $WRITE_NODES ]]; then
+    for node in $WRITE_NODES
+    do
+      ws_address=$(separate_ip_port_from_address "$node")
+      ws_port=$(echo "$ws_address" | cut -d' ' -f2)
+
+      # Check that we have a port and that it only contains digits
+      if [[ -z $ws_port || ! $ws_port =~ ^[[:digit:]]*$ ]]; then
+        error "$LINENO" "--write-node : expected 'address:port' found '$node'"
+        exit 1
+      fi
+
+    done
+  fi
+
   # Check user permission to proxysql datadir
   if [[ -z $PROXYSQL_DATADIR ]]; then
     if [[ -d /var/lib/proxysql ]]; then
@@ -1789,7 +1808,7 @@ function parse_args() {
     elif [[ -d /usr/share/proxysql ]]; then
       PROXYSQL_DATADIR="/usr/share/proxysql"
     else
-      debug "" "Cannot find the ProyxSQL datadir"
+      error "$LINENO" "Could not find the ProxySQL datadir.  Please specify using --proxysql-datadir"
       exit 1
     fi
   fi

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -415,8 +415,14 @@ function separate_ip_port_from_address()
   #
   local address=$1
 
-  ip_addr=${address%:*}
-  port=${address##*:}
+  # Has to have at least one ':' to separate the port from the ip address
+  if [[ $address =~ : ]]; then
+    ip_addr=${address%:*}
+    port=${address##*:}
+  else
+    ip_addr=$address
+    port=""
+  fi
 
   # Remove any braces that surround the ip address portion
   ip_addr=${ip_addr#\[}

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -418,8 +418,14 @@ function separate_ip_port_from_address()
   #
   local address=$1
 
-  ip_addr=${address%:*}
-  port=${address##*:}
+  # Has to have at least one ':' to separate the port from the ip address
+  if [[ $address =~ : ]]; then
+    ip_addr=${address%:*}
+    port=${address##*:}
+  else
+    ip_addr=$address
+    port=""
+  fi
 
   # Remove any braces that surround the ip address portion
   ip_addr=${ip_addr#\[}
@@ -507,8 +513,8 @@ function update_cluster() {
       fi
       net_address=$(echo $line | cut -d' ' -f1)
       net_address=$(separate_ip_port_from_address $net_address)
-      local ip_addr=$(echo $net_address | cut -d' ' -f1)
-      local port=$(echo $net_address | cut -d' ' -f2)
+      local ip_addr=$(echo "$net_address" | cut -d' ' -f1)
+      local port=$(echo "$net_address" | cut -d' ' -f2)
       net_address=$(combine_ip_port_into_address "$ip_addr" "$port")
       current_hosts+="$net_address "
     done< <(printf "$host_info\n")
@@ -544,8 +550,8 @@ function update_cluster() {
 
     log $LINENO "Cluster node (${i}) does not exist in ProxySQL, adding as a $MODE_COMMENT node"
     ws_address=$(separate_ip_port_from_address "$i")
-    ws_ip=$(echo $ws_address | cut -d' ' -f1)
-    ws_port=$(echo $ws_address | cut -d' ' -f2)
+    ws_ip=$(echo "$ws_address" | cut -d' ' -f1)
+    ws_port=$(echo "$ws_address" | cut -d' ' -f2)
 
     # Add the node as a reader
     local hostgroup
@@ -586,8 +592,8 @@ function update_cluster() {
     # set it OFFLINE_SOFT unless its a slave node
     #
     ws_address=$(separate_ip_port_from_address "$i")
-    ws_ip=$(echo $ws_address | cut -d' ' -f1)
-    ws_port=$(echo $ws_address | cut -d' ' -f2)
+    ws_ip=$(echo "$ws_address" | cut -d' ' -f1)
+    ws_port=$(echo "$ws_address" | cut -d' ' -f2)
 
     # This is supported by status, so OFFLINE should come before ONLINE
     # Note that the status is in DESC order, so "ONLINE : OFFLINE_SOFT : OFFLINE_HARD"
@@ -633,8 +639,8 @@ function update_cluster() {
       local host
 
       ws_address=$(separate_ip_port_from_address "$i")
-      ws_ip=$(echo $ws_address | cut -d' ' -f1)
-      ws_port=$(echo $ws_address | cut -d' ' -f2)
+      ws_ip=$(echo "$ws_address" | cut -d' ' -f1)
+      ws_port=$(echo "$ws_address" | cut -d' ' -f2)
 
       # properly escape the characters for grep
       local re_i="$(printf '%s' "$ws_ip:$ws_port" | sed 's/[.[\*^$]/\\&/g')"
@@ -645,8 +651,8 @@ function update_cluster() {
       log "" "Cluster node (${ws_hg_id}:${i}) current status '$ws_status' in ProxySQL."
     else
       ws_address=$(separate_ip_port_from_address "$i")
-      ws_ip=$(echo $ws_address | cut -d' ' -f1)
-      ws_port=$(echo $ws_address | cut -d' ' -f2)
+      ws_ip=$(echo "$ws_address" | cut -d' ' -f1)
+      ws_port=$(echo "$ws_address" | cut -d' ' -f2)
       ws_hg_status=$(proxysql_exec $LINENO "SELECT hostgroup_id,status from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port")
       ws_hg_id=$(echo $ws_hg_status | cut -d' ' -f1)
       ws_status=$(echo $ws_hg_status | cut -d' ' -f2)

--- a/tests/generic-test.bats
+++ b/tests/generic-test.bats
@@ -115,6 +115,19 @@ echo "$output"
 run sudo $WORKDIR/proxysql-admin --write-node
 echo "$output"
         [ "$status" -eq 1 ]
+        [[ "${lines[0]}" =~ .*--write-node.* ]]
+}
+
+@test "run proxysql-admin --write-node with missing port" {
+run sudo $WORKDIR/proxysql-admin --write-node=1.1.1.1,2.2.2.2:44 --disable
+echo "$output"
+        [ "$status" -eq 1 ]
+        [[ "${lines[0]}" =~ ERROR.*--write-node.*expected.* ]]
+
+run sudo $WORKDIR/proxysql-admin --write-node=[1:1:1:1],[2:2:2:2]:44 --disable
+echo "$output"
+        [ "$status" -eq 1 ]
+        [[ "${lines[0]}" =~ ERROR.*--write-node.*expected.* ]]
 }
 
 @test 'run proxysql-admin --include-slaves without --use-slave-as-writer' {


### PR DESCRIPTION
Issue
The options passed in via --write-node are not being validated.
Addresses without ports can be passed in, and then the script will
fail later.

Solution
Verify that a port is specified whenever a node address is passed
in via --write-node.