### PR TITLE
PSQLADM-127 : proxysql_galera_checker corrupts scheduler cnfiguration…

### DIFF
--- a/doc/proxysql_galera_checker.md
+++ b/doc/proxysql_galera_checker.md
@@ -1,6 +1,6 @@
 # proxysql_galera_checker usage info.
 
-`proxysql_galera_checker` script will check Percona XtraDB Cluster desynced nodes, and temporarily deactivate them. Currently, this script is developed to work with proxysql-admin [script](https://github.com/percona/proxysql-admin-tool/blob/v1.4.12-dev/README.md)
+`proxysql_galera_checker` script will check Percona XtraDB Cluster desynced nodes, and temporarily deactivate them. Currently, this script is developed to work with proxysql-admin [script](https://github.com/percona/proxysql-admin-tool/blob/v1.4.13-dev/README.md)
 
 This script will also call `proxysql_node_monitor` script. Monitor script will check cluster node membership, and re-configure ProxySQL if cluster membership changes occur. 
 

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -49,7 +49,7 @@ fi
 #
 # Script parameters/constants
 #
-readonly    PROXYSQL_ADMIN_VERSION="1.4.12"
+readonly    PROXYSQL_ADMIN_VERSION="1.4.13"
 declare  -i DEBUG=0
 
 #

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -18,7 +18,7 @@ set -o nounset    # no undefined variables
 # Script parameters/constants
 #
 declare  -i DEBUG=0
-readonly    PROXYSQL_ADMIN_VERSION="1.4.12"
+readonly    PROXYSQL_ADMIN_VERSION="1.4.13"
 
 #Timeout exists for instances where mysqld may be hung
 declare  -i TIMEOUT=10
@@ -84,9 +84,9 @@ function log() {
 
   if [[ -n $ERR_FILE ]]; then
     if [[ -n $lineno && $DEBUG -ne 0 ]]; then
-      echo -e "[$(date +%Y-%m-%d\ %H:%M:%S)] (line $lineno) $*" >> $ERR_FILE
+      echo -e "[$(date +%Y-%m-%d\ %H:%M:%S)] $$ (line $lineno) $*" >> $ERR_FILE
     else
-      echo -e "[$(date +%Y-%m-%d\ %H:%M:%S)] $*" >> $ERR_FILE
+      echo -e "[$(date +%Y-%m-%d\ %H:%M:%S)] $$ $*" >> $ERR_FILE
     fi
   fi
 }
@@ -2063,7 +2063,7 @@ function remove_slave_from_write_hostgroup() {
 #   NUMBER_WRITERS
 #
 function main() {
-  local cluster_name
+  local cluster_name=""
   local mysql_credentials
   local scheduler_id
 
@@ -2075,8 +2075,10 @@ function main() {
   scheduler_id=$(proxysql_exec $LINENO -Ns "SELECT id FROM scheduler where arg1 LIKE '%--write-hg=$HOSTGROUP_WRITER_ID %' OR arg1 LIKE '%-w $HOSTGROUP_WRITER_ID %'")
   if [[ -z $scheduler_id ]]; then
     error $LINENO "Cannot find the scheduler row with write hostgroup : $HOSTGROUP_WRITER_ID"
+  else
+    cluster_name=$(proxysql_exec $LINENO -Ns "SELECT comment FROM scheduler WHERE id=${scheduler_id}" 2>>$ERR_FILE)
   fi
-  cluster_name=$(proxysql_exec $LINENO -Ns "SELECT comment FROM scheduler WHERE id=${scheduler_id}" 2>>$ERR_FILE)
+
   if [[ -z $cluster_name ]]; then
     #
     # Could not find the cluster name from the scheduler,
@@ -2101,12 +2103,21 @@ function main() {
       #
       # We've found the cluster name so update the scheduler args
       #
-      local arg1 my_path
-      arg1=$(proxysql_exec $LINENO -Ns "SELECT arg1 from scheduler where id=${scheduler_id}")
-      my_path=$(echo ${PROXYSQL_DATADIR}/${cluster_name}_proxysql_galera_check.log | sed  's#\/#\\\/#g')
-      arg1=$(echo $arg1 | sed "s/--log=.*/--log=$my_path/g")
+      if [[ -z $scheduler_id ]]; then
+        warning "$LINENO" "Cannot update scheduler due to missing scheduler_id"
+      else
+        local arg1 my_path
+        log "$LINENO" "Updating scheduler for cluster:${cluster_name} write_hg:$HOSTGROUP_WRITER_ID"
+        arg1=$(proxysql_exec $LINENO -Ns "SELECT arg1 from scheduler where id=${scheduler_id}")
+        if [[ -z $arg1 ]]; then
+          warning $LINENO "Cannot update scheduler due to missing arguments (arg1 is empty)"
+        else
+          my_path=$(echo ${PROXYSQL_DATADIR}/${cluster_name}_proxysql_galera_check.log | sed  's#\/#\\\/#g')
+          arg1=$(echo $arg1 | sed "s/--log=.*/--log=$my_path/g")
 
-      proxysql_exec $LINENO -Ns "UPDATE scheduler set comment='$cluster_name',arg1='$arg1' where id=${scheduler_id};load scheduler to runtime;save scheduler to disk"
+          proxysql_exec $LINENO -Ns "UPDATE scheduler set comment='$cluster_name',arg1='$arg1' where id=${scheduler_id};load scheduler to runtime;save scheduler to disk"
+        fi
+      fi
     fi
   fi
 

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -21,7 +21,7 @@ declare NRED=""
 #
 
 declare -i  DEBUG=0
-readonly    PROXYSQL_ADMIN_VERSION="1.4.12"
+readonly    PROXYSQL_ADMIN_VERSION="1.4.13"
 
 declare     CONFIG_FILE="/etc/proxysql-admin.cnf"
 declare     ERR_FILE="/dev/null"

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -45,6 +45,8 @@ declare USE_IPVERSION="v4"
 
 declare ALLOW_SHUTDOWN="Yes"
 
+declare PROXYSQL_EXTRA_OPTIONS=""
+
 #
 # Useful functions
 # ================================================
@@ -85,6 +87,9 @@ Options:
                       May be used with --no-test to startup only one cluster.
   --ipv4              Run the tests using IPv4 addresses (default)
   --ipv6              Run the tests using IPv6 addresses
+  --proxysql-options=OPTIONS
+                      Specify additional options that will be passed
+                      to proxysql.
 EOF
 }
 
@@ -118,6 +123,9 @@ function parse_args() {
           ;;
         --ipv6)
           USE_IPVERSION="v6"
+          ;;
+        --proxysql-options)
+          PROXYSQL_EXTRA_OPTIONS=$value
           ;;
         *)
           echo "ERROR: unknown parameter \"$param\""
@@ -486,7 +494,7 @@ if [[ ! -x $PROXYSQL_BASE/usr/bin/proxysql ]]; then
   echo "ERROR! Could not find proxysql executable : $PROXYSQL_BASE/usr/bin/proxysql"
   exit 1
 fi
-$PROXYSQL_BASE/usr/bin/proxysql -D $WORKDIR/proxysql_db  $WORKDIR/proxysql_db/proxysql.log &
+$PROXYSQL_BASE/usr/bin/proxysql -D $WORKDIR/proxysql_db $PROXYSQL_EXTRA_OPTIONS $WORKDIR/proxysql_db/proxysql.log &
 echo "....ProxySQL started"
 
 


### PR DESCRIPTION
… after restart

Issue
Stopping and restarting proxysql while an instance of proxysql_galera_checker
is running may cause the scheduler row to be corrupted.

Solution
Check to see that proxysql query errors are handled correctly (don't write
out to the scheduler if we do not have the correct arguments)

Also, update the version to 1.4.13
Also added the pid to the proxysql_galera_checker log output