### PR TITLE
syncusers mariadb 10.3 support

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -1437,6 +1437,9 @@ function syncusers() {
     10.2)
       password_field="Password"
       ;;
+    10.3)
+      password_field="Password"
+      ;;
     *)
       error $LINENO "Unexpected database server version: ${mysql_version}"\
                     "\n-- This version of proxysql-admin needs to be updated."


### PR DESCRIPTION
Issue:
Mariadb 10.3 is currently not supported for syncusers command.

Sollution:
Checked the password field in mariadb 10.3 and added it to the version check in the syncusers function.