### PR TITLE
PSQLADM-130 : proxysql_galera_checker script should consider user's c…

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -49,7 +49,7 @@ fi
 #
 # Script parameters/constants
 #
-readonly    PROXYSQL_ADMIN_VERSION="1.4.13"
+readonly    PROXYSQL_ADMIN_VERSION="1.4.13.1"
 declare  -i DEBUG=0
 
 #
@@ -95,6 +95,17 @@ declare -i USE_EXISTING_MONITOR_PASSWORD=0
 declare -i WITH_CLUSTER_APP_USER=1
 
 declare    WRITER_IS_READER="ondemand"
+
+#
+# Default value for max_connections in mysql_servers
+#
+declare    MAX_CONNECTIONS="1000"
+
+#
+# This is the options string to be set in the proxysql_galera_checker
+# command.  This is only set if MAX_CONNECTIONS is set via the command-line
+#
+declare    MAX_CONNECTIONS_ARGS=""
 
 #-------------------------------------------------------------------------------
 #
@@ -192,6 +203,10 @@ Options:
                                      'ondemand' means that the writer node only accepts reads
                                      if there are no other readers.
                                      (default: 'ondemand')
+  --max-connections=<NUMBER>         Value for max_connections in the mysql_servers table.
+                                     This is the maximum number of connections that
+                                     ProxySQL will open to the backend servers.
+                                     (default: 1000)
   --debug                            Enables additional debug logging.
   --help                             Dispalys this help text.
 
@@ -1087,7 +1102,7 @@ function enable_proxysql() {
       local ws_ip=$(echo "$ws_address" | cut -d' ' -f1)
       local ws_port=$(echo "$ws_address" | cut -d' ' -f2)
       ws_address=$(combine_ip_port_into_address "$ws_ip" "$ws_port")
-      proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$WRITE_HOSTGROUP_ID,$ws_port,1000,'READWRITE');"
+      proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment,max_connections) VALUES ('$ws_ip',$WRITE_HOSTGROUP_ID,$ws_port,1000,'READWRITE',$MAX_CONNECTIONS);"
       check_cmd $? $LINENO "Failed to add the PXC server node $ws_address."\
                            "\n-- Please check the ProxySQL connection parameters and status."
     done
@@ -1167,14 +1182,14 @@ function enable_proxysql() {
       local ws_ip=$(echo "$ws_address" | cut -d' ' -f1)
       local ws_port=$(echo "$ws_address" | cut -d' ' -f2)
       if [ "$ws_ip" == "$writer_ws_ip" ] && [ "$ws_port" == "$writer_ws_port" ]; then
-        proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$writer_ws_ip',$WRITE_HOSTGROUP_ID,$writer_ws_port,1000000,'WRITE');"
+        proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment,max_connections) VALUES ('$writer_ws_ip',$WRITE_HOSTGROUP_ID,$writer_ws_port,1000000,'WRITE',$MAX_CONNECTIONS);"
         check_cmd $? $LINENO "Failed to add the PXC server node $ws_address."\
                              "\n-- Please check the ProxySQL connection parameters and status."
         echo -e "\nWrite node info"
         proxysql_exec "$LINENO" "SELECT hostname,hostgroup_id,port,weight,comment FROM mysql_servers WHERE hostgroup_id=$WRITE_HOSTGROUP_ID" "-t"
         echo ""
       else
-        proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$READ_HOSTGROUP_ID,$ws_port,1000,'READ');"
+        proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment,max_connections) VALUES ('$ws_ip',$READ_HOSTGROUP_ID,$ws_port,1000,'READ',$MAX_CONNECTIONS);"
         check_cmd $? $LINENO "Failed to add the PXC server node $i."\
                               "\n-- Please check the ProxySQL connection parameters and status."
       fi
@@ -1195,7 +1210,7 @@ function enable_proxysql() {
       local ws_address=$(separate_ip_port_from_address "$i")
       local ws_ip=$(echo "$ws_address" | cut -d' ' -f1)
       local ws_port=$(echo "$ws_address" | cut -d' ' -f2)
-      proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$SLAVEREAD_HOSTGROUP_ID,$ws_port,1000,'SLAVEREAD');"
+      proxysql_exec "$LINENO" "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment,max_connections) VALUES ('$ws_ip',$SLAVEREAD_HOSTGROUP_ID,$ws_port,1000,'SLAVEREAD',$MAX_CONNECTIONS);"
       check_cmd $? $LINENO "Failed to add the slave node $i."\
                            "\n-- Please check the ProxySQL connection parameters and status."
 
@@ -1215,7 +1230,7 @@ function enable_proxysql() {
   else
     number_writers=0
   fi
-  proxysql_exec "$LINENO" "INSERT INTO SCHEDULER (active,interval_ms,filename,arg1,comment) VALUES (1,$NODE_CHECK_INTERVAL,'$proxysql_galera_check','--config-file=$CONFIG_FILE --writer-is-reader=$WRITER_IS_READER --write-hg=$WRITE_HOSTGROUP_ID --read-hg=$READ_HOSTGROUP_ID --writer-count=$number_writers --mode=$MODE $host_priority --use-slave-as-writer=$SLAVE_IS_WRITER --log=$PROXYSQL_DATADIR/${cluster_name}_proxysql_galera_check.log','$cluster_name');"
+  proxysql_exec "$LINENO" "INSERT INTO SCHEDULER (active,interval_ms,filename,arg1,comment) VALUES (1,$NODE_CHECK_INTERVAL,'$proxysql_galera_check','--config-file=$CONFIG_FILE --writer-is-reader=$WRITER_IS_READER --write-hg=$WRITE_HOSTGROUP_ID --read-hg=$READ_HOSTGROUP_ID --writer-count=$number_writers --mode=$MODE $host_priority --use-slave-as-writer=$SLAVE_IS_WRITER $MAX_CONNECTIONS_ARGS --log=$PROXYSQL_DATADIR/${cluster_name}_proxysql_galera_check.log','$cluster_name');"
   check_cmd $? $LINENO "Failed to add the PXC monitoring scheduler in ProxySQL."\
                        "\n-- Please check the ProxySQL connection parameters and status."
 
@@ -1553,7 +1568,7 @@ function parse_args() {
   # TODO: kennt, what happens if we don't have a functional getopt()?
   # Check if we have a functional getopt(1)
   if ! getopt --test; then
-    go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-datadir:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,include-slaves:,use-slave-as-writer:,use-existing-monitor-password,without-cluster-app-user,writer-is-reader:,enable,disable,adduser,syncusers,sync-multi-cluster-users,version,debug,help \
+    go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-datadir:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,include-slaves:,use-slave-as-writer:,use-existing-monitor-password,without-cluster-app-user,writer-is-reader:,enable,disable,adduser,syncusers,sync-multi-cluster-users,max-connections:,version,debug,help \
     --name="$(basename "$0")" -- "$@")"
     check_cmd $? $LINENO "Script error: getopt() failed with arguments: $@"
     eval set -- "$go_out"
@@ -1771,6 +1786,31 @@ function parse_args() {
         QUICK_DEMO=1
         ENABLE=1
         ;;
+      --max-connections )
+        MAX_CONNECTIONS="$2"
+        shift 2
+
+        # Verify that we have an integer >= 0
+        if [[ -n $MAX_CONNECTIONS ]]; then
+          if ! [ "$MAX_CONNECTIONS" -eq "$MAX_CONNECTIONS" ] 2>/dev/null
+          then
+            error "" "option '--max-connections' requires a number : $MAX_CONNECTIONS"
+            exit 1
+          fi
+
+          if [[ $MAX_CONNECTIONS -lt 0 ]]; then
+            error "" "option '--max-connections' requires a number >=0 : $MAX_CONNECTIONS"
+            exit 1
+          fi
+        else
+            error "" "option '--max-connections' requires an argument"
+            exit 1
+        fi
+
+        # If set by the command-line, use it in the arguments
+        # for proxysql_galera_checker (so that it overrides the config file)
+        MAX_CONNECTIONS_ARGS="--max-connections=$MAX_CONNECTIONS"
+        ;;
       -v | --version )
         # Detection of this setting is done before this
         shift
@@ -1967,6 +2007,9 @@ function parse_args() {
   readonly WITH_CHECK_MONITOR_USER
   readonly WITH_CLUSTER_APP_USER
   readonly WRITER_IS_READER
+
+  readonly MAX_CONNECTIONS
+  readonly MAX_CONNECTIONS_ARGS
 }
 
 # Main function

--- a/proxysql-admin.cnf
+++ b/proxysql-admin.cnf
@@ -28,3 +28,7 @@ export MODE="singlewrite"
 
 # Writer-is-reader configuration
 export WRITER_IS_READER="ondemand"
+
+# max_connections default (used only when INSERTing a new mysql_servers entry)
+export MAX_CONNECTIONS="1000"
+

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -18,7 +18,7 @@ set -o nounset    # no undefined variables
 # Script parameters/constants
 #
 declare  -i DEBUG=0
-readonly    PROXYSQL_ADMIN_VERSION="1.4.13"
+readonly    PROXYSQL_ADMIN_VERSION="1.4.13.1"
 
 #Timeout exists for instances where mysqld may be hung
 declare  -i TIMEOUT=10
@@ -71,6 +71,9 @@ declare     SLAVE_SECONDS_BEHIND=3600
 # Some extra text that will be logged
 # (useful for debugging)
 declare     LOG_TEXT=""
+
+# Default value for max_connections in mysql_servers
+declare     MAX_CONNECTIONS=1000
 
 
 #-------------------------------------------------------------------------------
@@ -203,6 +206,10 @@ Options:
                                       be added to the write hostgroup if all other
                                       cluster nodes are down.
                                       (default: 'yes')
+  --max-connections=<NUMBER>          Value for max_connections in the mysql_servers table.
+                                      This is the maximum number of connections that
+                                      ProxySQL will open to the backend servers.
+                                      (default: 1000)
   --debug                             Enables additional debug logging.
   -h, --help                          Display script usage information
   -v, --version                       Print version info
@@ -621,8 +628,8 @@ function change_server_status() {
   # to upgrade, but we do have a READER entry, so upgrade that
   if [[ $reader_status == "PRIORITY_NODE" ]]; then
     proxysql_exec $lineno -Ns "INSERT INTO mysql_servers
-          (hostname,hostgroup_id,port,weight,status,comment)
-          VALUES ('$server',$hostgroup,$port,1000000,'$status','WRITE');"
+          (hostname,hostgroup_id,port,weight,status,comment,max_connections)
+          VALUES ('$server',$hostgroup,$port,1000000,'$status','WRITE',$MAX_CONNECTIONS);"
     check_cmd_and_exit $LINENO $? "Could not create new mysql_servers row (query failed). Exiting."
     log "$lineno" "Adding server $hostgroup:$address with status $status. Reason: $comment"
   else
@@ -643,7 +650,7 @@ function parse_args() {
   # TODO: kennt, what happens if we don't have a functional getopt()?
   # Check if we have a functional getopt(1)
   if ! getopt --test; then
-    go_out="$(getopt --options=w:r:c:l:n:m:p:vh --longoptions=write-hg:,read-hg:,config-file:,log:,node-monitor-log:,writer-count:,mode:,priority:,writer-is-reader:,use-slave-as-writer:,log-text:,version,debug,help \
+    go_out="$(getopt --options=w:r:c:l:n:m:p:vh --longoptions=write-hg:,read-hg:,config-file:,log:,node-monitor-log:,writer-count:,mode:,priority:,writer-is-reader:,use-slave-as-writer:,log-text:,max-connections:,version,debug,help \
     --name="$(basename "$0")" -- "$@")"
     if [[ $? -ne 0 ]]; then
       # no place to send output
@@ -774,6 +781,10 @@ function parse_args() {
         SLAVE_IS_WRITER="$2"
         shift 2
       ;;
+      --max-connections )
+        MAX_CONNECTIONS="$2"
+        shift 2
+      ;;
       --debug )
         # Not handled here, see above
         shift
@@ -850,6 +861,16 @@ function parse_args() {
   unset READ_HOSTGROUP_ID
   unset SLAVEREAD_HOSTGROUP_ID
 
+
+  # Verify that we have an integer
+  if [[ -n $MAX_CONNECTIONS ]]; then
+    if ! [ "$MAX_CONNECTIONS" -eq "$MAX_CONNECTIONS" ] 2>/dev/null
+    then
+      error "" "option '--max-connections' parameter (must be a number) : $MAX_CONNECTIONS"
+      exit 1
+    fi
+  fi
+
   readonly ERR_FILE
   readonly CONFIG_FILE
   readonly DEBUG_ERR_FILE
@@ -865,6 +886,7 @@ function parse_args() {
   readonly P_PRIORITY
   readonly P_MODE
 
+  readonly MAX_CONNECTIONS
 }
 
 
@@ -998,7 +1020,7 @@ function writer_is_reader_check() {
         else
           comment="OFFLINE_SOFT"
         fi
-        proxysql_exec $LINENO -Ns "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,status,comment) VALUES ('$server',$HOSTGROUP_READER_ID,$port,1000,'$comment','READ');"
+        proxysql_exec $LINENO -Ns "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,status,comment,max_connections) VALUES ('$server',$HOSTGROUP_READER_ID,$port,1000,'$comment','READ',$MAX_CONNECTIONS);"
         check_cmd_and_exit $LINENO $? "writer-is-reader($WRITER_IS_READER): Failed to add $HOSTGROUP_READER_ID:$address (query failed). Exiting."
         log_if_success $LINENO $? "writer-is-reader($WRITER_IS_READER): Adding reader $HOSTGROUP_READER_ID:$address with status OFFLINE_SOFT"
         echo "1" > ${reload_check_file}
@@ -1151,8 +1173,8 @@ function ensure_one_writer_node() {
       if [[ -z $write_stat || $write_stat == "NULL" ]]; then
         # Writer does not exist, add an ONLINE writer
         proxysql_exec $LINENO -Ns \
-          "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,status,comment)
-           VALUES ('$host',$HOSTGROUP_WRITER_ID,$port,1000000,'ONLINE','WRITE');"
+          "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,status,comment,max_connections)
+           VALUES ('$host',$HOSTGROUP_WRITER_ID,$port,1000000,'ONLINE','WRITE',$MAX_CONNECTIONS);"
         check_cmd_and_exit $LINENO $? "Cannot add a PXC writer node to ProxySQL (query failed). Exiting."
         log_if_success $LINENO $? "Added $HOSTGROUP_WRITER_ID:$address as a writer."
       else
@@ -1844,8 +1866,8 @@ function search_for_desynced_writers() {
 
           if [[ $writer_count -eq 0 ]]; then
             proxysql_exec $LINENO -Ns \
-              "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment)
-                  VALUES ('$server',$HOSTGROUP_WRITER_ID,$port,1000000,'WRITE');"
+              "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment,max_connections)
+                  VALUES ('$server',$HOSTGROUP_WRITER_ID,$port,1000000,'WRITE',$MAX_CONNECTIONS);"
             check_cmd_and_exit $LINENO $? "Could not add writer node (query failed). Exiting."
             log $LINENO "Adding server $HOSTGROUP_WRITER_ID:$address with status ONLINE. Reason: WSREP status is DESYNC/DONOR, as this is the only node we will put this one online"
           else
@@ -2115,8 +2137,8 @@ function add_slave_to_write_hostgroup() {
       local address=$(combine_ip_port_into_address "$host" "$port")
 
       proxysql_exec $LINENO -Ns "INSERT INTO mysql_servers
-            (hostname,hostgroup_id,port,weight,status,comment)
-            VALUES ('$host',$HOSTGROUP_WRITER_ID,$port,1000000,'ONLINE','SLAVEREAD');"
+            (hostname,hostgroup_id,port,weight,status,comment,max_connections)
+            VALUES ('$host',$HOSTGROUP_WRITER_ID,$port,1000000,'ONLINE','SLAVEREAD',$MAX_CONNECTIONS);"
       check_cmd_and_exit $LINENO $? "Cannot add Percona XtraDB Cluster node $address to ProxySQL (query failed). Exiting."
       log_if_success $LINENO $? "slave server ${HOSTGROUP_WRITER_ID}:$address set to ONLINE status in ProxySQL."
       echo 1 > "${reload_check_file}"
@@ -2308,6 +2330,7 @@ function main() {
                                      --mode=$mode \
                                      --reload-check-file="$reload_check_file" \
                                      --log-text="$LOG_TEXT" \
+                                     --max-connections="$MAX_CONNECTIONS" \
                                      --log="$proxysql_monitor_log" $more_monitor_options
 
   # print information prior to a run if ${ERR_FILE} is defined

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -21,7 +21,7 @@ declare NRED=""
 #
 
 declare -i  DEBUG=0
-readonly    PROXYSQL_ADMIN_VERSION="1.4.13"
+readonly    PROXYSQL_ADMIN_VERSION="1.4.13.1"
 
 declare     CONFIG_FILE="/etc/proxysql-admin.cnf"
 declare     ERR_FILE="/dev/null"
@@ -51,6 +51,9 @@ declare -i  CLUSTER_TIMEOUT=3
 # Extra text that will be logged with the output
 # (useful for debugging/testing)
 declare     LOG_TEXT=""
+
+# Default value for max_connections in mysql_servers
+declare     MAX_CONNECTIONS="1000"
 
 
 #-------------------------------------------------------------------------------
@@ -126,6 +129,10 @@ Options:
                                       whenever this script is run (useful for debugging).
   --reload-check-file=PATH            Specify file used to notify proysql_galera_checker
                                       of a change in server configuration
+  --max-connections=<NUMBER>          Value for max_connections in the mysql_servers table.
+                                      This is the maximum number of connections that
+                                      ProxySQL will open to the backend servers.
+                                      (default: 1000)
   --debug                             Enables additional debug logging.
   -h, --help                          Display script usage information
   -v, --version                       Print version info
@@ -566,7 +573,7 @@ function update_cluster() {
       log_if_success $LINENO $? "Updated ${hostgroup}:${i} node in the ProxySQL database."
     else
       # Insert a reader if new PXC node not in ProxySQL
-      proxysql_exec $LINENO "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment) VALUES ('$ws_ip',$DEFAULT_HOSTGROUP_ID,$ws_port,1000,'$MODE_COMMENT');"
+      proxysql_exec $LINENO "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,comment,max_connections) VALUES ('$ws_ip',$DEFAULT_HOSTGROUP_ID,$ws_port,1000,'$MODE_COMMENT',$MAX_CONNECTIONS);"
       check_cmd $LINENO $? "Cannot add Percona XtraDB Cluster node $ws_address (hostgroup $DEFAULT_HOSTGROUP_ID) to ProxySQL database, Please check ProxySQL login credentials"
       log_if_success $LINENO $? "Added ${DEFAULT_HOSTGROUP_ID}:${i} node into ProxySQL database."
     fi
@@ -629,7 +636,7 @@ function update_cluster() {
     fi
 
     node_status=$(proxysql_exec $LINENO "SELECT status from mysql_servers WHERE hostname='$ws_ip' and port=$ws_port ORDER BY status LIMIT 1")
-    log $LINENO "Non-PXC node (${i}) current status '$node_status' in ProxySQL database!"
+    log $LINENO "Non-PXC node (${i}) current status '$node_status' in ProxySQL."
   done
 
   # Update the ProxySQL status for the new nodes
@@ -760,7 +767,7 @@ function mode_change_check(){
 function parse_args() {
   # Check if we have a functional getopt(1)
   if ! getopt --test; then
-    go_out="$(getopt --options=w:r:c:l:m:p:vh --longoptions=write-hg:,read-hg:,mode:,priority:,config-file:,log:,reload-check-file:,log-text:,debug,version,help \
+    go_out="$(getopt --options=w:r:c:l:m:p:vh --longoptions=write-hg:,read-hg:,mode:,priority:,config-file:,log:,reload-check-file:,log-text:,max-connections:,debug,version,help \
     --name="$(basename "$0")" -- "$@")"
     if [[ $? -ne 0 ]]; then
       # no place to send output
@@ -882,6 +889,10 @@ function parse_args() {
         LOG_TEXT="$2"
         shift 2
       ;;
+      --max-connections )
+        MAX_CONNECTIONS="$2"
+        shift 2
+      ;;
       --debug )
         shift;
       ;;
@@ -951,6 +962,13 @@ function parse_args() {
   fi
   check_permission -r $LINENO "$RELOAD_CHECK_FILE"
 
+  # Verify that we have an integer
+  if ! [ "$MAX_CONNECTIONS" -eq "$MAX_CONNECTIONS" ] 2>/dev/null
+  then
+    error $LINENO "Invalid --max-connections value (must be a number) : $MAX_CONNECTIONS"
+    exit 1
+  fi
+
   readonly WRITE_HOSTGROUP_ID
   readonly READ_HOSTGROUP_ID
   readonly SLAVEREAD_HOSTGROUP_ID
@@ -959,6 +977,7 @@ function parse_args() {
   readonly WRITE_WEIGHT
   readonly CLUSTER_NAME
   readonly RELOAD_CHECK_FILE
+  readonly MAX_CONNECTIONS
 }
 
 # Returns the address of an available (online) cluster host

--- a/tests/async-slave-testsuite.bats
+++ b/tests/async-slave-testsuite.bats
@@ -24,6 +24,7 @@ declare STATUS=()
 declare HOSTGROUPS=()
 declare COMMENTS=()
 declare WEIGHTS=()
+declare MAX_CONNECTIONS=()
 declare slave_host
 declare slave_port
 declare slave_status

--- a/tests/desynced-host-testsuite.bats
+++ b/tests/desynced-host-testsuite.bats
@@ -25,6 +25,7 @@ declare STATUS=()
 declare HOSTGROUPS=()
 declare COMMENTS=()
 declare WEIGHTS=()
+declare MAX_CONNECTIONS=()
 
 load test-common
 

--- a/tests/generic-test.bats
+++ b/tests/generic-test.bats
@@ -136,6 +136,30 @@ echo "$output"
         [ "$status" -eq 1 ]
 }
 
+@test 'run proxysql-admin --max-connections without parameters' {
+run sudo $WORKDIR/proxysql-admin --max-connections
+echo "$output"
+        [ "$status" -eq 1 ]
+}
+
+@test 'run proxysql-admin --max-connections without parameters' {
+run sudo $WORKDIR/proxysql-admin --max-connections=
+echo "$output"
+        [ "$status" -eq 1 ]
+}
+
+@test 'run proxysql-admin --max-connections with non-number parameter' {
+run sudo $WORKDIR/proxysql-admin --max-connections=abc
+echo "$output"
+        [ "$status" -eq 1 ]
+}
+
+@test 'run proxysql-admin --max-connections with negative values' {
+run sudo $WORKDIR/proxysql-admin --max-connections=-1
+echo "$output"
+        [ "$status" -eq 1 ]
+}
+
 @test "run proxysql-admin --version check" {
   admin_version=$(sudo $WORKDIR/proxysql-admin -v | grep --extended-regexp -oe '[1-9]\.[0-9]\.[0-9]+')
   proxysql_version=$(sudo $PROXYSQL_BASE/usr/bin/proxysql --help | grep --extended-regexp -oe '[1-9]\.[0-9]\.[0-9]+')

--- a/tests/loadbal-testsuite.bats
+++ b/tests/loadbal-testsuite.bats
@@ -24,6 +24,7 @@ declare STATUS=()
 declare HOSTGROUPS=()
 declare COMMENTS=()
 declare WEIGHTS=()
+declare MAX_CONNECTIONS=()
 
 load test-common
 

--- a/tests/node-monitor-testsuite.bats
+++ b/tests/node-monitor-testsuite.bats
@@ -1,0 +1,329 @@
+## proxysql_node_monitor tests
+#
+# This is to specifically test parts of the node monitor code that
+# are not tested in the other tests.
+#
+# Testing Hints:
+# If there is a problem in the test, it's useful to enable the "debug"
+# flag to see the proxysql_GALERA_CHECKER and galera_node_monitor
+# debug output.  The "--debug" flag must go INSIDE the duoble quotes.
+#
+#      run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --debug")
+#
+
+
+#
+# Variable initialization
+#
+source /etc/proxysql-admin.cnf
+PXC_BASEDIR=$WORKDIR/pxc-bin
+PROXYSQL_BASEDIR=$WORKDIR/proxysql-bin
+
+# Declare some GLOBALS
+# These are used to return data from get_node_data()
+declare HOSTS=()
+declare PORTS=()
+declare STATUS=()
+declare HOSTGROUPS=()
+declare COMMENTS=()
+declare WEIGHTS=()
+declare MAX_CONNECTIONS=()
+
+load test-common
+
+WSREP_CLUSTER_NAME=$(cluster_exec "select @@wsrep_cluster_name" 2> /dev/null)
+MYSQL_VERSION=$(cluster_exec "select @@version")
+
+if [[ $WSREP_CLUSTER_NAME == "cluster_one" ]]; then
+  PORT_1=4110
+  PORT_2=4120
+  PORT_3=4130
+else
+  PORT_1=4210
+  PORT_2=4220
+  PORT_3=4230
+fi
+
+if [[ $USE_IPVERSION == "v4" ]]; then
+  LOCALHOST_IP="127.0.0.1"
+else
+  LOCALHOST_IP="[::1]"
+fi
+
+
+# Sets up the general priority tests
+#   (1) Deactivates the scheduler
+#   (2) Syncs up with the RUNTIME (for a consistent start state)
+#   (3) Initializes some global variables for use
+#
+# Globals:
+#   SCHEDULER_ID
+#   GALERA_CHECKER
+#   GALERA_CHECKER_ARGS
+#   NODE_MONITOR
+#   NODE_MONITOR_ARGS
+#   WSREP_CLUSTER_NAME
+#   RELOAD_CHECK_FILE
+#
+function test_preparation() {
+  # SYNC up with the runtime
+  # (For a consistent starting point)
+  # ========================================================
+  proxysql_exec "SAVE mysql servers FROM RUNTIME"
+
+  # SETUP (determine some of the parameters)
+  # ========================================================
+  SCHEDULER_ID=$(proxysql_exec "SELECT id FROM scheduler WHERE arg1 like '% --write-hg=$WRITE_HOSTGROUP_ID %'")
+  GALERA_CHECKER=$(proxysql_exec "SELECT filename FROM scheduler WHERE id=$SCHEDULER_ID")
+  GALERA_CHECKER_ARGS=$(proxysql_exec "SELECT arg1 FROM scheduler WHERE id=$SCHEDULER_ID")
+  GALERA_CHECKER_ARGS=$(echo "$GALERA_CHECKER_ARGS" | sed "s/never/ondemand/g")
+
+  # Pull the options out of GALERA_CHECKER_ARGS
+  local config_file write_hg read_hg mode log reload_check_file
+  local datadir reload_file
+  local temp
+  config_file=$(echo "$GALERA_CHECKER_ARGS" | grep -oe "--config-file=[^ ]*")
+  write_hg=$(echo "$GALERA_CHECKER_ARGS" | grep -oe "--write-hg=[^ ]*")
+  read_hg=$(echo "$GALERA_CHECKER_ARGS" | grep -oe "--read-hg=[^ ]*")
+  mode=$(echo "$GALERA_CHECKER_ARGS" | grep -oe "--mode=[^ ]*")
+
+  temp=$(echo $GALERA_CHECKER_ARGS | grep -oe "--log=[^ ]*")
+  temp=${temp#--log=}
+  datadir="$(dirname $temp)"
+  log="--log=$datadir/${WSREP_CLUSTER_NAME}_proxysql_node_monitor.log"
+
+  RELOAD_CHECK_FILE="${datadir}/node_monitor_reload_check.test"
+  reload_file="--reload-check-file=$RELOAD_CHECK_FILE"
+  echo "0" > "$RELOAD_CHECK_FILE"
+
+  NODE_MONITOR="$(dirname $GALERA_CHECKER)/proxysql_node_monitor"
+  NODE_MONITOR_ARGS="$config_file $write_hg $read_hg $mode $log $reload_file"
+}
+
+# Runs the galera_checker and verifies the initial state
+#
+# Globals:
+#   GALERA_CHECKER
+#   GALERA_CHECKER_ARGS
+#   PORT_1  PORT_2  PORT_NOPRIO
+#
+#  Arguments:
+#   None
+#
+function verify_initial_state() {
+  # run twice to initialize (depends on the priority list in the scheduler)
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='node-monitor $LINENO'")
+  echo "$GALERA_CHECKER_ARGS" >&2
+  [ "$status" -eq 0 ]
+
+  run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='node-monitor $LINENO'")
+  echo "$GALERA_CHECKER_ARGS" >&2
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+
+  # Check the initial setup (3 rows in the table, all ONLINE)
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_port[0]}" -eq "${read_port[0]}" ]
+
+  [ "${write_comment[0]}" = "WRITE" ]
+  [ "${read_comment[0]}" = "READ" ]
+  [ "${read_comment[1]}" = "READ" ]
+  [ "${read_comment[2]}" = "READ" ]
+
+  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${read_weight[0]}" -eq 1000 ]
+  [ "${read_weight[1]}" -eq 1000 ]
+  [ "${read_weight[2]}" -eq 1000 ]
+}
+
+
+@test "run proxysql-admin -d ($WSREP_CLUSTER_NAME)" {
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  echo "$output" >&2
+  [ "$status" -eq  0 ]
+}
+
+@test "run proxysql-admin -e ($WSREP_CLUSTER_NAME)" {
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --writer-is-reader=ondemand <<< 'n'
+  [ "$status" -eq  0 ]
+
+  #
+  # DEACTIVATE the scheduler line (call proxysql_GALERA_CHECKER manually)
+  # For ALL of the tests
+  # ========================================================
+  local sched_id
+  sched_id=$(proxysql_exec "SELECT id FROM scheduler WHERE arg1 like '% --write-hg=$WRITE_HOSTGROUP_ID %'")
+  run proxysql_exec "UPDATE scheduler SET active=0 WHERE id=$sched_id; LOAD scheduler TO RUNTIME"
+  [ "$status" -eq  0 ]
+}
+
+@test "run node-monitor node in PXC and NOT in ProxySQL ($WSREP_CLUSTER_NAME)" {
+  #skip
+  # PREPARE for the test
+  # ========================================================
+  test_preparation
+  verify_initial_state
+
+  # Run the node monitor
+  # (Nothing should have changed)
+  run $(${NODE_MONITOR} ${NODE_MONITOR_ARGS} --log-text="node-monitor $LINENO")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_max_connections[0]}" -eq 1111 ]
+  [ "${read_max_connections[0]}" -eq 1111 ]
+  [ "${read_max_connections[1]}" -eq 1111 ]
+  [ "${read_max_connections[2]}" -eq 1111 ]
+
+  # Remove the node from ProxySQL
+  # Remove the first read node
+  proxysql_exec "DELETE FROM mysql_servers WHERE hostname='${read_host[1]}' AND port=${read_port[1]} AND hostgroup_id=${read_hostgroup[1]}"
+  [ "$?" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+
+  [ "${#read_host[@]}" -eq 2 ]
+  [ "${#write_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+
+  [ "${write_max_connections[0]}" -eq 1111 ]
+  [ "${read_max_connections[0]}" -eq 1111 ]
+  [ "${read_max_connections[1]}" -eq 1111 ]
+
+  # Run the node monitor
+  # The ndde should have been reinserted into ProxySQL
+  run $(${NODE_MONITOR} ${NODE_MONITOR_ARGS} --log-text="node-monitor $LINENO")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_max_connections[0]}" -eq 1111 ]
+  [ "${read_max_connections[0]}" -eq 1111 ]
+  [ "${read_max_connections[1]}" -eq 1111 ]
+  [ "${read_max_connections[2]}" -eq 1111 ]
+}
+
+@test "run proxysql-admin -d ($WSREP_CLUSTER_NAME)" {
+  #skip
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  echo "$output" >&2
+  [ "$status" -eq  0 ]
+}
+
+@test "run proxysql-admin -e with max-connections ($WSREP_CLUSTER_NAME)" {
+  #skip
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --writer-is-reader=ondemand --max-connections=2222 <<< 'n'
+  [ "$status" -eq  0 ]
+
+  #
+  # DEACTIVATE the scheduler line (call proxysql_GALERA_CHECKER manually)
+  # For ALL of the tests
+  # ========================================================
+  local sched_id
+  sched_id=$(proxysql_exec "SELECT id FROM scheduler WHERE arg1 like '% --write-hg=$WRITE_HOSTGROUP_ID %'")
+  run proxysql_exec "UPDATE scheduler SET active=0 WHERE id=$sched_id; LOAD scheduler TO RUNTIME"
+  [ "$status" -eq  0 ]
+}
+
+
+@test "run node-monitor node in PXC and NOT in ProxySQL with max-connections ($WSREP_CLUSTER_NAME)" {
+  #skip
+  # PREPARE for the test
+  # ========================================================
+  test_preparation
+  verify_initial_state
+
+  # Run the node monitor
+  # (Nothing should have changed)
+  run $(${NODE_MONITOR} ${NODE_MONITOR_ARGS} --log-text="node-monitor $LINENO")
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_max_connections[0]}" -eq 2222 ]
+  [ "${read_max_connections[0]}" -eq 2222 ]
+  [ "${read_max_connections[1]}" -eq 2222 ]
+  [ "${read_max_connections[2]}" -eq 2222 ]
+
+  # Remove the node from ProxySQL
+  # Remove the first read node
+  proxysql_exec "DELETE FROM mysql_servers WHERE hostname='${read_host[1]}' AND port=${read_port[1]} AND hostgroup_id=${read_hostgroup[1]}"
+  [ "$?" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+
+  [ "${#read_host[@]}" -eq 2 ]
+  [ "${#write_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+
+  [ "${write_max_connections[0]}" -eq 2222 ]
+  [ "${read_max_connections[0]}" -eq 2222 ]
+  [ "${read_max_connections[1]}" -eq 2222 ]
+
+  # Run the node monitor
+  # The ndde should have been reinserted into ProxySQL
+  run $(${NODE_MONITOR} ${NODE_MONITOR_ARGS} --log-text="node-monitor $LINENO" --max-connections=2222 --debug)
+  [ "$status" -eq 0 ]
+
+  retrieve_reader_info
+  retrieve_writer_info
+
+  [ "${#read_host[@]}" -eq 3 ]
+  [ "${#write_host[@]}" -eq 1 ]
+
+  [ "${write_status[0]}" = "ONLINE" ]
+  [ "${read_status[0]}" = "OFFLINE_SOFT" ]
+  [ "${read_status[1]}" = "ONLINE" ]
+  [ "${read_status[2]}" = "ONLINE" ]
+
+  [ "${write_max_connections[0]}" -eq 2222 ]
+  [ "${read_max_connections[0]}" -eq 2222 ]
+  [ "${read_max_connections[1]}" -eq 2222 ]
+  [ "${read_max_connections[2]}" -eq 2222 ]
+}
+

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -17,6 +17,7 @@ declare STATUS=()
 declare HOSTGROUPS=()
 declare COMMENTS=()
 declare WEIGHTS=()
+declare MAX_CONNECTIONS=()
 
 load test-common
 
@@ -110,11 +111,12 @@ echo "$output"
 
   # This value is highly dependent on the PXC shutdown period
   #   --pxc_maint_transition_period
-  wait_for_server_shutdown
+  wait_for_server_shutdown $pxc_socket 2
+  [[ $? -eq 0 ]]
 
   # Wait a little extra time to ensure that the proxysql_galera_checker
   # was invoked
-  sleep 5
+  sleep 15
   nr_nodes=$(proxysql_exec "select count(*) from mysql_servers where status='ONLINE' and hostgroup_id in ($WRITE_HOSTGROUP_ID,$READ_HOSTGROUP_ID);")
   [ "$nr_nodes" -eq 2 ]
 

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -14,6 +14,7 @@ TEST_SUITES+=("host-priority-testsuite.bats")
 TEST_SUITES+=("desynced-host-testsuite.bats")
 TEST_SUITES+=("async-slave-testsuite.bats")
 TEST_SUITES+=("loadbal-testsuite.bats")
+TEST_SUITES+=("node-monitor-testsuite.bats")
 
 
 #
@@ -103,7 +104,7 @@ function parse_args() {
 
       # possible positional parameter
       if [[ ! $param =~ ^--[^[[:space:]]]* ]]; then
-        positional_params+="$param "
+        positional_params+="$1 "
         shift
         continue
       fi
@@ -590,6 +591,7 @@ sudo sed -i "0,/^[ \t]*export CLUSTER_HOSTNAME[ \t]*=.*$/s|^[ \t]*export CLUSTER
 sudo sed -i "0,/^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$/s|^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$|export CLUSTER_APP_USERNAME=\"cluster_one\"|" /etc/proxysql-admin.cnf
 sudo sed -i "0,/^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$|export WRITE_HOSTGROUP_ID=\"10\"|" /etc/proxysql-admin.cnf
 sudo sed -i "0,/^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$|export READ_HOSTGROUP_ID=\"11\"|" /etc/proxysql-admin.cnf
+sudo sed -i "0,/^[ \t]*export MAX_CONNECTIONS[ \t]*=.*$/s|^[ \t]*export MAX_CONNECTIONS[ \t]*=.*$|export MAX_CONNECTIONS=\"1111\"|" /etc/proxysql-admin.cnf
 
 if [[ $RUN_TEST -eq 1 ]]; then
   echo ""
@@ -617,7 +619,7 @@ if [[ $RUN_TEST -eq 1 ]]; then
 
     if [[ $rc -ne 0 ]]; then
       ${PXC_BASEDIR}/bin/mysql --user=admin --password=admin --host=$LOCALHOST_IP --port=6032 --protocol=tcp \
-        -e "select hostgroup_id,hostname,port,status,comment from mysql_servers order by hostgroup_id,status,hostname,port" 2>/dev/null
+        -e "select hostgroup_id,hostname,port,status,comment,max_connections from mysql_servers order by hostgroup_id,status,hostname,port" 2>/dev/null
       echo "********************************"
       echo "* $test_file failed, the servers (ProxySQL+PXC) will be left running"
       echo "* for debugging purposes."
@@ -687,6 +689,7 @@ sudo sed -i "0,/^[ \t]*export CLUSTER_PORT[ \t]*=.*$/s|^[ \t]*export CLUSTER_POR
 sudo sed -i "0,/^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$/s|^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$|export CLUSTER_APP_USERNAME=\"cluster_two\"|" /etc/proxysql-admin.cnf
 sudo sed -i "0,/^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export WRITE_HOSTGROUP_ID[ \t]*=.*$|export WRITE_HOSTGROUP_ID=\"20\"|" /etc/proxysql-admin.cnf
 sudo sed -i "0,/^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export READ_HOSTGROUP_ID[ \t]*=.*$|export READ_HOSTGROUP_ID=\"21\"|" /etc/proxysql-admin.cnf
+sudo sed -i "0,/^[ \t]*export MAX_CONNECTIONS[ \t]*=.*$/s|^[ \t]*export MAX_CONNECTIONS[ \t]*=.*$|export MAX_CONNECTIONS=\"1111\"|" /etc/proxysql-admin.cnf
 echo "================================================================"
 echo ""
 
@@ -709,11 +712,12 @@ if [[ $RUN_TEST -eq 1 ]]; then
 
     if [[ $rc -ne 0 ]]; then
       ${PXC_BASEDIR}/bin/mysql --user=admin --password=admin --host=$LOCALHOST_IP --port=6032 --protocol=tcp \
-        -e "select hostgroup_id,hostname,port,status,comment from mysql_servers order by hostgroup_id,status,hostname,port" 2>/dev/null
+        -e "select hostgroup_id,hostname,port,status,comment,max_connections from mysql_servers order by hostgroup_id,status,hostname,port" 2>/dev/null
       echo "********************************"
       echo "* $test_file failed, the servers (ProxySQL+PXC)will be left running"
       echo "* for debugging purposes."
       echo "********************************"
+      ALLOW_SHUTDOWN="No"
       exit 1
     fi
     echo "================================================================"

--- a/tools/enable_scheduler
+++ b/tools/enable_scheduler
@@ -76,7 +76,7 @@ function parse_args() {
       # Assume that all options start with a '-'
       # otherwise treat as a positional parameter
       if [[ ! $param =~ ^- ]]; then
-        positional_params+="$param "
+        positional_params+="$1 "
         shift
         continue
       fi

--- a/tools/mysql_exec
+++ b/tools/mysql_exec
@@ -91,7 +91,7 @@ function parse_args() {
       # Assume that all options start with a '-'
       # otherwise treat as a positional parameter
       if [[ ! $param =~ ^- ]]; then
-        positional_params+="$param "
+        positional_params+="$1 "
         shift
         continue
       fi

--- a/tools/proxysql_exec
+++ b/tools/proxysql_exec
@@ -73,7 +73,7 @@ function parse_args() {
       # Assume that all options start with a '-'
       # otherwise treat as a positional parameter
       if [[ ! $param =~ ^- ]]; then
-        positional_params+="$param "
+        positional_params+="$1 "
         shift
         continue
       fi
@@ -126,4 +126,5 @@ if [[ -z $QUERY ]]; then
   exit 1
 fi
 
+echo "Query : $QUERY"
 exec_sql "$QUERY_OPTIONS" "$QUERY"

--- a/tools/run_galera_checker
+++ b/tools/run_galera_checker
@@ -78,7 +78,7 @@ function parse_args() {
       # Assume that all options start with a '-'
       # otherwise treat as a positional parameter
       if [[ ! $param =~ ^- ]]; then
-        positional_params+="$param "
+        positional_params+="$1 "
         shift
         continue
       fi


### PR DESCRIPTION
…ustom max_connections setting

Issue
When inserting a row into the mysql_servers table, we would not set the
value for max_connections.  Thus the default value of 1000 would be used.
This causes problems with customers that need a higher default value.

Solution
Add an option to set the value of max_connections.  This can be
done on the command line and in the config file.

Also added another testsuite to test this settings (as much as
possible).

Also updated the version to 1.4.13.1