### PR TITLE
Actually progress in parameter-check loop

### DIFF
--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -2545,6 +2545,7 @@ else
       # Assume that all options start with a '-'
       # otherwise treat as a positional parameter
       if [[ ! $param =~ ^- ]]; then
+        shift
         continue
       fi
       case $param in


### PR DESCRIPTION
When called in "classic" mode with 5 predefined parameters, the parser fails to handle the parameters as it entered a endless loop. Fixed by adding a 'shift'.