### PR TITLE
allow to resync nodes via adding "--disable --enable" arguments

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -1099,8 +1099,8 @@ function enable_proxysql() {
   # Adding Percona XtraDB Cluster nodes to ProxySQL
   echo -e "\nAdding the Percona XtraDB Cluster server nodes to ProxySQL"
   if [[ $MODE == "loadbal" ]]; then
-    proxysql_exec "$LINENO" "DELETE FROM mysql_servers WHERE hostgroup_id=$WRITE_HOSTGROUP_ID"
-    check_cmd $? $LINENO "Failed to delete the existing servers with hostgroup: ${WRITE_HOSTGROUP_ID}"\
+    proxysql_exec "$LINENO" "DELETE FROM mysql_servers WHERE hostgroup_id in ($READ_HOSTGROUP_ID,$WRITE_HOSTGROUP_ID,$BACKUP_WRITE_HOSTGROUP_ID,$OFFLINE_HOSTGROUP_ID)"
+    check_cmd $? $LINENO "Failed to delete the existing servers with hostgroup: $READ_HOSTGROUP_ID,$WRITE_HOSTGROUP_ID,$BACKUP_WRITE_HOSTGROUP_ID,$OFFLINE_HOSTGROUP_ID"\
                          "\n-- Please check the ProxySQL connection parameters and status."
     for i in "${wsrep_address[@]}"; do  
       local ws_address=$(separate_ip_port_from_address "$i")
@@ -1290,10 +1290,11 @@ function disable_proxysql(){
   check_cmd $? $LINENO "Failed to delete the query rules from ProxySQL."\
                        "\n-- Please check the ProxySQL connection parameters amd status."
 
-
-  proxysql_load_to_runtime_save_to_disk "MYSQL USERS" $LINENO
-  proxysql_load_to_runtime_save_to_disk "MYSQL SERVERS" $LINENO
-  proxysql_load_to_runtime_save_to_disk "MYSQL QUERY RULES" $LINENO
+  if [[ $ENABLE -eq 0 ]]; then
+    proxysql_load_to_runtime_save_to_disk "MYSQL USERS" $LINENO
+    proxysql_load_to_runtime_save_to_disk "MYSQL SERVERS" $LINENO
+    proxysql_load_to_runtime_save_to_disk "MYSQL QUERY RULES" $LINENO
+  fi
 }
 
 # Adds an application user to ProxySQL
@@ -2054,6 +2055,10 @@ function main() {
       echo -e "with ProxySQL is supported)"
     fi
     echo -e "\nProxySQL read/write configuration mode is ${BD}$MODE${NBD}"
+
+    if [[ $DISABLE -eq 1 ]]; then
+      disable_proxysql
+    fi
 
     enable_proxysql
     echo -e "\nProxySQL configuration completed!\n"


### PR DESCRIPTION
issue: new Native Galera Clustering doesn't update servers list automatically, it is needed to update them manually.
in my environment, it is not a case, so I added functionality which allows me to resync servers by cron command `proxysql-admin ... --disable --enable --syncusers`