### PR TITLE
Permit syncusers on plain mysql-server

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -1840,17 +1840,25 @@ function find_cluster_node()
 function syncusers() {
   debug "$LINENO" "syncusers ()"
 
-  cluster_in_proxysql_check $WRITER_HOSTGROUP_ID
 
   local mysql_version
   local password_field
   local cluster_node
 
+  
   # Get current MySQL users, filter out header row and mysql.sys user
+  cluster_node=$(echo -e "${WRITE_NODE/:/\t}" | cut -f1)
+
+  if [ "$cluster_node" != "$CLUSTER_HOSTNAME" ]
+  then  
+  cluster_in_proxysql_check $WRITER_HOSTGROUP_ID
   # Find a cluster node that belongs to the cluster with $WRITER_HOSTGROUP_ID
   cluster_node=$(find_cluster_node "$WRITER_HOSTGROUP_ID")
   check_cmd $? "$LINENO" "Could not find a primary cluster node"
-
+  fi
+  
+  cluster_node=${WRITE_NODE/:/'\t'}
+  
   # Reset the central cluster node (so that calls to mysql_exec) will
   # work with this new node, rather than the node in the config file
   CLUSTER_HOSTNAME=$(echo -e "$cluster_node" | cut -f1)


### PR DESCRIPTION
This patch adds the posibility to sync users in a plain mysql server, It is a minimal patch that permits the use of the script without galera tables.

Use with: CLUSTER_HOSTNAME=mysql-server WRITER_NODE=mysql-server:3306 in config file