### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM centos:latest
 RUN yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
 RUN yum -y install Percona-XtraDB-Cluster-client
 
+RYN yum -y install which
+
 RUN mkdir -p /opt/proxysql-admin-tool/etc /opt/proxysql-admin-tool/var
 
 COPY . /opt/proxysql-admin-tool

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:latest
 RUN yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
 RUN yum -y install Percona-XtraDB-Cluster-client
 
-RYN yum -y install which
+RUN yum -y install which
 
 RUN mkdir -p /opt/proxysql-admin-tool/etc /opt/proxysql-admin-tool/var
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM centos:latest
 
+RUN mkdir -p /opt/proxysql-admin-tool/etc /opt/proxysql-admin-tool/var
+
 COPY . /opt/proxysql-admin-tool
 
 # CMD /bin/bash -c -- "while :; do sleep 60; done;"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# FROM centos:latest
-FROM ellerbrock/alpine-mysql-client
+FROM centos:latest
+
+RUN yum -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+RUN yum -y install Percona-XtraDB-Cluster-client
 
 RUN mkdir -p /opt/proxysql-admin-tool/etc /opt/proxysql-admin-tool/var
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:latest
 
-COPY . /proxysql-admin-tool
+COPY . /opt/proxysql-admin-tool
 
 CMD /bin/bash -c -- "while :; do sleep 60; done;"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:latest
+
+COPY . /proxysql-admin-tool
+
+RUN /bin/bash -c -- "while :; do sleep 60; done;"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM alpine:latest
+FROM centos:latest
 
 COPY . /proxysql-admin-tool
 
-CMD /bin/sh -c -- "while :; do sleep 60; done;"
+CMD /bin/bash -c -- "while :; do sleep 60; done;"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM centos:latest
+# FROM centos:latest
+FROM ellerbrock/alpine-mysql-client
 
 RUN mkdir -p /opt/proxysql-admin-tool/etc /opt/proxysql-admin-tool/var
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM centos:latest
 
 COPY . /opt/proxysql-admin-tool
 
-CMD /bin/bash -c -- "while :; do sleep 60; done;"
+# CMD /bin/bash -c -- "while :; do sleep 60; done;"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine:latest
 
 COPY . /proxysql-admin-tool
 
-RUN /bin/bash -c -- "while :; do sleep 60; done;"
+RUN /bin/sh -c -- "while :; do sleep 60; done;"

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM alpine:latest
 
 COPY . /proxysql-admin-tool
 
-RUN /bin/sh -c -- "while :; do sleep 60; done;"
+CMD /bin/sh -c -- "while :; do sleep 60; done;"


### PR DESCRIPTION
Hello,

I'd propose to add a dockerfile, so one could runproxysql-admin-tool in K8S and perform maintenance jobs like that:
```
apiVersion: batch/v1beta1
kind: CronJob
metadata:
  name: sync-users
  namespace: proxysql
spec:
  schedule: "*/10 * * * *"
  jobTemplate:
    spec:
      template:
        spec:
          containers:
          - args:
            - /opt/proxysql-admin-tool/proxysql-admin
            - --config-file=/opt/proxysql-admin-tool/etc/proxysql-admin.cnf
            - --syncusers
            image: volodymyrmelnyk/proxysql-admin-tool
            name: proxysql-admin
            stdin: true
            stdinOnce: true
            volumeMounts:
            - mountPath: /opt/proxysql-admin-tool/etc
              name: proxysql-admin-config
              readOnly: true
          restartPolicy: OnFailure
          volumes:
          - name: proxysql-admin-config
            secret:
              secretName: proxysql-admin-tool-configuration
```

What do you think, will it be useful for other people?