### PR TITLE
PSQLADM-51 : Added --update-mysql-version option to update the mysql version in proxysql db. Updated test suite and README.md accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ One of the options below must be provided.
   --enable, -e                       Auto-configure Percona XtraDB Cluster nodes into ProxySQL
   --update-cluster                   Updates the cluster membership, adds new cluster nodes
                                      to the configuration.
+  --update-mysql-version             Updates the mysql-server_version variable in ProxySQL with the version
+                                     from a node in the cluster.
   --quick-demo                       Setup a quick demo with no authentication
   --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL
                                      May be used with --enable.
@@ -459,7 +461,7 @@ ERROR (line:2925) : The current configuration has not been enabled
   the given Galera cluster which uses that writer hostgroup.  Otherwise it will
   display information about all Galera hostgroups (and their servers) being
   supported by this ProxySQL instance.
-
+  
 ```bash
 
 $ sudo proxysql-admin --status --writer-hg=10
@@ -484,6 +486,19 @@ mysql_servers rows for this configuration
 
 ```
 
+  __10) --update-mysql-version__
+  
+  This option will updates mysql server version (specified by the writer hostgroup,
+  either from __--writer-hg__ or from the config file) in proxysql db based on 
+  online writer node.
+  
+```bash
+
+$  sudo proxysql-admin --update-mysql-version --writer-hg=10
+ProxySQL MySQL version changed to 5.7.26
+$
+
+```
 
 ___Extra options___
 -------------------

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -101,6 +101,7 @@ declare -i ADDUSER=0
 declare -i SYNCUSERS=0
 declare -i SYNCMULTICLUSTERUSERS=0
 declare -i UPDATE_CLUSTER=0
+declare -i UPDATE_MYSQL_VERSION=0
 declare -i CHECK_IF_ENABLED=0
 declare -i REPORT_STATUS=0
 
@@ -267,6 +268,8 @@ One of the options below must be provided.
   --enable, -e                       Auto-configure Percona XtraDB Cluster nodes into ProxySQL
   --update-cluster                   Updates the cluster membership, adds new cluster nodes
                                      to the configuration.
+  --update-mysql-version             Updates the mysql-server_version variable in ProxySQL with the version 
+                                     from a node in the cluster.
   --quick-demo                       Setup a quick demo with no authentication
   --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL
                                      May be used with --enable.
@@ -1021,6 +1024,48 @@ function get_all_hostgroups_from_writer_hostgroup()
   echo "$hg_list"
 }
 
+# Update mysql server version details in proxysql db 
+# Globals:
+#   WRITER_HOSTGROUP_ID
+#   CLUSTER_HOSTNAME (overwrites)
+#   CLUSTER_PORT (overwrites)
+#
+# Arguments:
+#   None
+function update_mysql_version()
+{
+  local cluster_node
+
+  cluster_in_proxysql_check $WRITER_HOSTGROUP_ID
+
+  # Find a cluster node that belongs to the cluster with $WRITER_HOSTGROUP_ID
+  cluster_node=$(find_cluster_node "$WRITER_HOSTGROUP_ID")
+  check_cmd $? "$LINENO" "Could not find a primary cluster node"
+
+  # Reset the central cluster node (so that calls to mysql_exec) will
+  # work with this new node, rather than the node in the config file
+  CLUSTER_HOSTNAME=$(echo -e "$cluster_node" | cut -f1)
+  CLUSTER_PORT=$(echo -e "$cluster_node" | cut -f2)
+  cluster_connection_check
+  
+  proxysql_mysql_version_string=$(proxysql_exec "$LINENO" "select variable_value from global_variables where variable_name like 'mysql-server_version'")
+  check_cmd $? "$LINENO"  "Failed to select the mysql-server_version variables from ProxySQL."\
+                          "\n-- Please check the ProxySQL connection parameters and status."
+  mysql_version_string=$(mysql_exec "$LINENO" "SELECT VERSION();" | tail -1 | cut -d'-' -f1 )
+  check_cmd $? "$LINENO"  "Failed to select the mysql version info from Cluster node."\
+                          "\n-- Please check the PXC connection parameters and status."
+  if [[ $proxysql_mysql_version_string != $mysql_version_string ]]; then
+    proxysql_exec "$LINENO" \
+    "UPDATE global_variables
+      SET variable_value='$mysql_version_string'
+      WHERE variable_name='mysql-server_version';"
+    check_cmd $? "$LINENO"  "Failed to set the mysql-server_version variables in ProxySQL."\
+                          "\n-- Please check the ProxySQL connection parameters and status."
+    echo "ProxySQL MySQL version changed to $mysql_version_string"
+    proxysql_load_to_runtime_save_to_disk "MYSQL VARIABLES" $LINENO
+  fi
+}
+
 # Adds the list of servers to ProxySQL
 # This will add all of the servers in the list to the WRITER hostgroup
 # ProxySQL is responsible for moving them to the correct hostgroup
@@ -1507,7 +1552,7 @@ function enable_proxysql() {
                            "\n-- Please check the ProxySQL connection parameters and status."
     fi
   fi
-
+  
   proxysql_exec "$LINENO" \
     "INSERT INTO mysql_galera_hostgroups (writer_hostgroup,
                                          backup_writer_hostgroup,
@@ -2062,7 +2107,7 @@ function update_cluster()
     error "$LINENO" "Could not find a cluster (with writer_hostgroup:$WRITER_HOSTGROUP_ID) to update"
     exit 1
   fi
-
+  
   # First, reset the list of servers if desired (this will force us to use
   # the CLUSTER_HOSTNAME to find the cluster)
   if [[ $REMOVE_ALL_SERVERS -eq 1 ]]; then
@@ -2493,7 +2538,7 @@ function parse_args() {
   # TODO: kennt, what happens if we don't have a functional getopt()?
   # Check if we have a functional getopt(1)
   if ! getopt --test; then
-    go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-datadir:,writer-hg:,backup-writer-hg:,reader-hg:,offline-hg:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,use-existing-monitor-password,without-cluster-app-user,enable,disable,update-cluster,is-enabled,adduser,syncusers,sync-multi-cluster-users,status,max-connections:,max-transactions-behind:,use-ssl:,writers-are-readers:,remove-all-servers,version,debug,help \
+    go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-datadir:,writer-hg:,backup-writer-hg:,reader-hg:,offline-hg:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,use-existing-monitor-password,without-cluster-app-user,enable,disable,update-cluster,update-mysql-version,is-enabled,adduser,syncusers,sync-multi-cluster-users,status,max-connections:,max-transactions-behind:,use-ssl:,writers-are-readers:,remove-all-servers,version,debug,help \
     --name="$(basename "$0")" -- "$@")"
     check_cmd $? "$LINENO" "Script error: getopt() failed with arguments: $*"
     eval set -- "$go_out"
@@ -2704,6 +2749,10 @@ function parse_args() {
         shift
         UPDATE_CLUSTER=1
         NEEDS_WRITER_HOSTGROUP=1
+        ;;
+      --update-mysql-version )
+        shift
+        UPDATE_MYSQL_VERSION=1
         ;;
       --is-enabled )
         shift
@@ -3013,6 +3062,7 @@ function parse_args() {
   readonly SYNCMULTICLUSTERUSERS
   readonly QUICK_DEMO
   readonly UPDATE_CLUSTER
+  readonly UPDATE_MYSQL_VERSION
   readonly CHECK_IF_ENABLED
   readonly REPORT_STATUS
   readonly REMOVE_ALL_SERVERS
@@ -3034,6 +3084,7 @@ function parse_args() {
 #   SYNCMULTICLUSTERUSERS
 #   QUICK_DEMO
 #   UPDATE_CLUSTER
+#   UPDATE_MYSQL_VERSION
 #   CHECK_IF_ENABLED
 #   REPORT_STATUS
 #   MODE
@@ -3152,6 +3203,10 @@ function main() {
   elif [[ $REPORT_STATUS -eq 1 ]]; then
 
     report_status $WRITER_HOSTGROUP_ID
+
+  elif [[ $UPDATE_MYSQL_VERSION -eq 1 ]]; then
+
+    update_mysql_version
 
   else
 

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -121,12 +121,24 @@ fi
 }
 
 
+@test "run proxysql-admin --update-mysql-version ($WSREP_CLUSTER_NAME)" {
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --update-mysql-version
+  echo "$output" >&2
+  [ "$status" -eq  0 ]
+}
+
+@test "run the check for --update-mysql-version ($WSREP_CLUSTER_NAME)" {
+  local mysql_version=$(mysql_exec "$HOST_IP" "$PORT_3" "SELECT VERSION();" | tail -1 | cut -d'-' -f1)
+  local proxysql_mysql_version=$(proxysql_exec "select variable_value from global_variables where variable_name like 'mysql-server_version'" | awk '{print $0}')
+  echo "mysql_version:$mysql_version  proxysql_mysql_version:$proxysql_mysql_version" >&2
+  [ "$mysql_version" = "$proxysql_mysql_version" ]
+}
+
 @test "run the check for --adduser ($WSREP_CLUSTER_NAME)" {
   run_add_command=$(printf "proxysql_test_user1\ntest_user\ny" | sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --adduser)
   run_check_user_command=$(proxysql_exec "select 1 from mysql_users where username='proxysql_test_user1'" | awk '{print $0}')
   [ "$run_check_user_command" -eq 1 ]
 }
-
 
 @test "run proxysql-admin --syncusers ($WSREP_CLUSTER_NAME)" {
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --syncusers


### PR DESCRIPTION
Modified `proxysql-admin` script to update `mysql-server_version` variables in proxysql db based on MySQL server version. `proxysql-admin` will update `mysql-server_version` with following options

```
proxysql-admin --enable
proxysql-admin --update-cluster
```