### PR TITLE
PSQLADM-49 : Created query rules for synced mysql users

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ One of the options below must be provided.
   --sync-multi-cluster-users         Sync user accounts currently configured in MySQL to ProxySQL
                                      May be used with --enable.
                                      (doesn't delete ProxySQL users not in MySQL)
+  --add-query-rule                   Create query rules for synced mysql user. This is applicable only
+                                     for singlewrite mode and works only with --syncusers
+                                     and --sync-multi-cluster-users options.
   --is-enabled                       Checks if the current configuration is enabled in ProxySQL.
   --status                           Returns a status report on the current configuration.
                                      If "--writer-hg=<NUM>" is specified, than the
@@ -328,8 +331,27 @@ mysql>
   This option works in the same way as --syncusers but it does not delete ProxySQL users
   that are not present in the Percona XtraDB Cluster. It is to be used when syncing proxysql
   instances that manage multiple clusters.
+  
+  __6) --add-query-rule__
 
-  __6) --quick-demo__
+  Create query rules for synced mysql user. This is applicable only for singlewrite mode and
+  works only with --syncusers and --sync-multi-cluster-users options.
+
+```bash
+$ sudo proxysql-admin  --syncusers --add-query-rule
+
+Syncing user accounts from PXC to ProxySQL
+
+Note : 'admin' is in proxysql admin user list, this user cannot be addded to ProxySQL
+-- (For more info, see https://github.com/sysown/proxysql/issues/709)
+Adding user to ProxySQL: test_query_rule
+  Added query rule for user: test_query_rule
+
+Synced PXC users to the ProxySQL database!
+$
+```
+
+  __7) --quick-demo__
 
   This option is used to setup a dummy proxysql configuration.
 
@@ -391,7 +413,7 @@ mysql>
  
 ```
 
-  __7) --update-cluster__
+  __8) --update-cluster__
 
   This option will check the Percona XtraDB Cluster to see if any new nodes
   have joined the cluster.  If so, the new nodes are added to ProxySQL.
@@ -432,7 +454,7 @@ Cluster membership updated in the ProxySQL database!
 
 ```
 
-  __8) --is-enabled__
+  __9) --is-enabled__
 
   This option will check if a galera cluster (specified by the writer hostgroup,
   either from __--writer-hg__ or from the config file) has any active entries
@@ -455,7 +477,7 @@ ERROR (line:2925) : The current configuration has not been enabled
 
 ```
 
-  __9) --status__
+  __10) --status__
 
   If used with the __--writer-hg__ option, this will display information about
   the given Galera cluster which uses that writer hostgroup.  Otherwise it will
@@ -486,7 +508,7 @@ mysql_servers rows for this configuration
 
 ```
 
-  __10) --update-mysql-version__
+  __11) --update-mysql-version__
   
   This option will updates mysql server version (specified by the writer hostgroup,
   either from __--writer-hg__ or from the config file) in proxysql db based on 

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -100,6 +100,7 @@ declare -i DISABLE=0
 declare -i ADDUSER=0
 declare -i SYNCUSERS=0
 declare -i SYNCMULTICLUSTERUSERS=0
+declare -i ADD_QUERY_RULE=0
 declare -i UPDATE_CLUSTER=0
 declare -i UPDATE_MYSQL_VERSION=0
 declare -i CHECK_IF_ENABLED=0
@@ -277,6 +278,9 @@ One of the options below must be provided.
   --sync-multi-cluster-users         Sync user accounts currently configured in MySQL to ProxySQL
                                      May be used with --enable.
                                      (doesn't delete ProxySQL users not in MySQL)
+  --add-query-rule                   Create query rules for synced mysql user. This is applicable only 
+                                     for singlewrite mode and works only with --syncusers 
+                                     and --sync-multi-cluster-users options.
   --is-enabled                       Checks if the current configuration is enabled in ProxySQL.
   --status                           Returns a status report on the current configuration.
                                      If "--writer-hg=<NUM>" is specified, than the
@@ -1857,6 +1861,32 @@ function find_cluster_node()
   return 1
 }
 
+# Create query rules for given user. This is applicable only for singlewrite mode  
+# Globals:
+#   WRITER_HOSTGROUP_ID
+#
+# Arguments:
+#   Parameter 1: the username
+function add_query_rule()
+{
+  local username=$1
+  if ! is_mode_singlewrite "$WRITER_HOSTGROUP_ID"; then
+      warning "$LINENO" "Ignoring query rule for $username, since this is not using" \
+        "singlewrite mode (max-writers is not 1)"
+  else
+    proxysql_exec "$LINENO" \
+      "INSERT INTO mysql_query_rules
+        (username,destination_hostgroup,active,match_digest,apply)
+       VALUES
+        ('$username',$WRITER_HOSTGROUP_ID,1,'^SELECT.*FOR UPDATE',1),
+        ('$username',$READER_HOSTGROUP_ID,1,'^SELECT ',1);"
+    
+    check_cmd $? "$LINENO" "Failed to add the read query rule to ProxySQL."\
+                         "\n-- Please check the ProxySQL connection parameters and status."
+	echo -e "  Added query rule for user: $username"
+  fi
+}
+
 # Synchronizes the users between ProxySQL and PXC
 #
 # This function was created to auto sync all the existing users already
@@ -1986,6 +2016,9 @@ function syncusers() {
           proxysql_exec "$LINENO" "DELETE FROM mysql_users WHERE username='${user}' and default_hostgroup=$WRITER_HOSTGROUP_ID"
           check_cmd $? "$LINENO" "Failed to delete the user ($user) from ProxySQL database."\
                                "\n-- Please check the ProxySQL connection parameters and status."
+          proxysql_exec "$LINENO" "DELETE FROM mysql_query_rules WHERE username='${user}' and destination_hostgroup in($WRITER_HOSTGROUP_ID,$READER_HOSTGROUP_ID)"
+          check_cmd $? "$LINENO" "Failed to delete the query rule for user ($user) from ProxySQL database."\
+                               "\n-- Please check the ProxySQL connection parameters and status."          
           break
         fi
       done< <(printf "%s\n" "${proxysql_users}")
@@ -2006,6 +2039,9 @@ function syncusers() {
               ('${user}', '${password}', 1, $WRITER_HOSTGROUP_ID)"
           check_cmd $? "$LINENO" "Failed to add the user ($user) from PXC to ProxySQL database."\
                                "\n-- Please check the ProxySQL connection parameters and status."
+          if [[ $ADD_QUERY_RULE -eq 1 ]];then
+            add_query_rule ${user}
+          fi
         else
           echo "Cannot add the user (${user}). The user (${user}) already exists in ProxySQL database with different hostgroup."
           check_user=""
@@ -2044,6 +2080,9 @@ function syncusers() {
         proxysql_exec "$LINENO" "DELETE FROM mysql_users WHERE username='${user}' and default_hostgroup=$WRITER_HOSTGROUP_ID"
         check_cmd $? "$LINENO" "Failed to delete the user ($user) from ProxySQL database."\
                              "\n-- Please check the ProxySQL connection parameters and status."
+        proxysql_exec "$LINENO" "DELETE FROM mysql_query_rules WHERE username='${user}' and destination_hostgroup in($WRITER_HOSTGROUP_ID,$READER_HOSTGROUP_ID)"
+        check_cmd $? "$LINENO" "Failed to delete the query rule for user ($user) from ProxySQL database."\
+                               "\n-- Please check the ProxySQL connection parameters and status."   
       fi
     done< <(printf "%s\n" "$proxysql_users")
   fi
@@ -2538,7 +2577,7 @@ function parse_args() {
   # TODO: kennt, what happens if we don't have a functional getopt()?
   # Check if we have a functional getopt(1)
   if ! getopt --test; then
-    go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-datadir:,writer-hg:,backup-writer-hg:,reader-hg:,offline-hg:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,use-existing-monitor-password,without-cluster-app-user,enable,disable,update-cluster,update-mysql-version,is-enabled,adduser,syncusers,sync-multi-cluster-users,status,max-connections:,max-transactions-behind:,use-ssl:,writers-are-readers:,remove-all-servers,version,debug,help \
+    go_out="$(getopt --options=edv --longoptions=config-file:,proxysql-datadir:,writer-hg:,backup-writer-hg:,reader-hg:,offline-hg:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,use-existing-monitor-password,without-cluster-app-user,enable,disable,update-cluster,update-mysql-version,is-enabled,adduser,syncusers,sync-multi-cluster-users,add-query-rule,status,max-connections:,max-transactions-behind:,use-ssl:,writers-are-readers:,remove-all-servers,version,debug,help \
     --name="$(basename "$0")" -- "$@")"
     check_cmd $? "$LINENO" "Script error: getopt() failed with arguments: $*"
     eval set -- "$go_out"
@@ -2735,6 +2774,11 @@ function parse_args() {
       --sync-multi-cluster-users )
         shift
         SYNCMULTICLUSTERUSERS=1
+        NEEDS_WRITER_HOSTGROUP=1
+        ;;
+      --add-query-rule )
+        shift
+        ADD_QUERY_RULE=1
         NEEDS_WRITER_HOSTGROUP=1
         ;;
       -d | --disable )
@@ -3060,6 +3104,7 @@ function parse_args() {
   readonly ADDUSER
   readonly SYNCUSERS
   readonly SYNCMULTICLUSTERUSERS
+  readonly ADD_QUERY_RULE
   readonly QUICK_DEMO
   readonly UPDATE_CLUSTER
   readonly UPDATE_MYSQL_VERSION
@@ -3184,6 +3229,10 @@ function main() {
     syncusers
     echo -e "\nSynced PXC users to the ProxySQL database!"
 
+  elif [[ $ADD_QUERY_RULE -eq 1 ]]; then
+
+    add_query_rule
+	
   elif [[ $CHECK_IF_ENABLED -eq 1 ]]; then
     local errcode
 
@@ -3203,7 +3252,7 @@ function main() {
   elif [[ $REPORT_STATUS -eq 1 ]]; then
 
     report_status $WRITER_HOSTGROUP_ID
-
+	
   elif [[ $UPDATE_MYSQL_VERSION -eq 1 ]]; then
 
     update_mysql_version


### PR DESCRIPTION
Created query rules for synced mysql user. This is applicable only for singlewrite mode and works only with --syncusers and --sync-multi-cluster-users options. 

Added test to verify the query rules are present in ProxySQL DB.