### PR TITLE
Updated --update-mysql-version testcase

### DIFF
--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -126,16 +126,21 @@ fi
   local mysql_version=$(mysql_exec "$HOST_IP" "$PORT_3" "SELECT VERSION();" | tail -1 | cut -d'-' -f1)
   local proxysql_mysql_version=$(proxysql_exec "select variable_value from global_variables where variable_name like 'mysql-server_version'" | awk '{print $0}')
   echo "$LINENO: mysql_version:$mysql_version  proxysql_mysql_version:$proxysql_mysql_version" >&2
-  [[ $mysql_version != $proxysql_mysql_version ]]
+  if [[ $mysql_version != $proxysql_mysql_version ]]; then
+  
+    run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --update-mysql-version
+    echo "$output" >&2
+    [ "$status" -eq  0 ]
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --update-mysql-version
-  echo "$output" >&2
-  [ "$status" -eq  0 ]
-
-  mysql_version=$(mysql_exec "$HOST_IP" "$PORT_3" "SELECT VERSION();" | tail -1 | cut -d'-' -f1)
-  proxysql_mysql_version=$(proxysql_exec "select variable_value from global_variables where variable_name like 'mysql-server_version'" | awk '{print $0}')
-  echo "$LINENO: mysql_version:$mysql_version  proxysql_mysql_version:$proxysql_mysql_version" >&2
-  [ "$mysql_version" = "$proxysql_mysql_version" ]
+    mysql_version=$(mysql_exec "$HOST_IP" "$PORT_3" "SELECT VERSION();" | tail -1 | cut -d'-' -f1)
+    proxysql_mysql_version=$(proxysql_exec "select variable_value from global_variables where variable_name like 'mysql-server_version'" | awk '{print $0}')
+    echo "$LINENO: mysql_version:$mysql_version  proxysql_mysql_version:$proxysql_mysql_version" >&2
+    [ "$mysql_version" = "$proxysql_mysql_version" ]
+  else
+    run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --update-mysql-version
+    echo "$output" >&2
+    [ "$status" -eq  0 ]
+  fi
 }
 
 @test "run the check for --adduser ($WSREP_CLUSTER_NAME)" {


### PR DESCRIPTION
Currently --update-mysql-version testcase is failing if the version is same.

Error Info
```
05:21:57 not ok 3 run proxysql-admin --update-mysql-version (cluster_two)
05:21:57 # (in test file proxysql-2.0.5-Linux-x86_64/tests/proxysql-admin-testsuite.bats, line 129)
05:21:57 #   `[[ $mysql_version != $proxysql_mysql_version ]]' failed
05:21:57 # 128: mysql_version:5.7.26  proxysql_mysql_version:5.7.26
05:21:58 ok 4 run the check for --adduser (cluster_two)
```