### PR TITLE
PSQLADM-181 : 'proxysql-admin --update-cluster --write-node=<node>' command will terminate if the writer node is read-only

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -2163,6 +2163,24 @@ function update_cluster()
   local data
   local -i force_to_runtime=0
 
+  if [[ -n $WRITE_NODE ]]; then
+    local ws_address ws_ip ws_port
+    ws_address=$(separate_ip_port_from_address "$WRITE_NODE")
+    ws_ip=$(echo "$ws_address" | cut -d' ' -f1)
+    ws_port=$(echo "$ws_address" | cut -d' ' -f2)
+
+    local is_read_only
+    is_read_only=$(exec_sql "$LINENO" "$CLUSTER_USERNAME" "$CLUSTER_PASSWORD" "$ws_ip" "$ws_port" \
+      "select @@global.read_only")
+    if [[ $? -eq 0 && $is_read_only -eq 1 ]]; then
+      writer_ws_ip=$ws_ip
+      writer_ws_port=$ws_port
+      writer_ws_address=$(combine_ip_port_into_address "$writer_ws_ip" "$writer_ws_port")
+
+      error "$LINENO" "--write-node is a read-only node($writer_ws_address). Terminating."
+      exit 1
+    fi
+  fi
   all_hostgroups=$(get_all_hostgroups_from_writer_hostgroup $WRITER_HOSTGROUP_ID)
   if [[ -z $all_hostgroups ]]; then
     error "$LINENO" "Could not find a cluster (with writer_hostgroup:$WRITER_HOSTGROUP_ID) to update"

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -780,6 +780,27 @@ fi
 
 }
 
+@test "run --update-cluster with read-only --write-node server ($WSREP_CLUSTER_NAME)" {
+  # Run --update-cluster with read-only --write-node server
+  echo "$LINENO : changing node2 to read-only" >&2
+  mysql_exec "$HOST_IP" "$PORT_2" "SET global read_only=1"
+  [ "$?" -eq 0 ]
+  
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --update-cluster --write-node=$HOST_IP:$PORT_2
+  echo "$LINENO : proxysql-admin --update-cluster --write-node=$HOST_IP:$PORT_2 " >&2
+  echo "$output" >& 2
+  [ "$status" -eq 1 ]
+
+  # revert node2 to be a read/write node
+  echo "$LINENO : changing node2 back to read-only=0" >&2
+  mysql_exec "$HOST_IP" "$PORT_2" "SET global read_only=0"
+  [ "$?" -eq 0 ]
+  
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  echo "$output" >& 2
+  [ "$status" -eq 0 ]
+}
+
 # Test --enable --update-cluster
 @test "test --enable --update-cluster ($WSREP_CLUSTER_NAME)" {
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
@@ -856,4 +877,5 @@ fi
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $BACKUP_WRITER_HOSTGROUP_ID " | awk '{print $0}')
   echo "$LINENO : backup writer count:$proxysql_cluster_count expected:2"  >&2
   [ "$proxysql_cluster_count" -eq 2 ]
+  
 }


### PR DESCRIPTION
```
$ sudo proxysql-admin --update-cluster --write-node=127.0.0.1:25200
ERROR (line:2180) : --write-node is a read-only node(127.0.0.1:25200). Terminating.
$
```