### PR TITLE
PSQLADM-219 : Scheduler is not respecting pxc_maint_transition_period

### DIFF
--- a/proxysql-admin.cnf
+++ b/proxysql-admin.cnf
@@ -13,7 +13,7 @@ export CLUSTER_PORT='3306'
 
 # proxysql monitoring user. proxysql admin script will create this user in pxc to monitor pxc-nodes.
 export MONITOR_USERNAME='monitor'
-export MONITOR_PASSWORD='monit0r'
+export MONITOR_PASSWORD='monitor'
 
 # Application user to connect to pxc-node through proxysql
 export CLUSTER_APP_USERNAME='proxysql_user'

--- a/proxysql_galera_checker
+++ b/proxysql_galera_checker
@@ -624,9 +624,13 @@ function change_server_status() {
 
   address=$(combine_ip_port_into_address "$server" "$port")
 
-  # If we have a PRIORITY_NODE, then we don't have a WRITER entry
-  # to upgrade, but we do have a READER entry, so upgrade that
-  if [[ $reader_status == "PRIORITY_NODE" ]]; then
+  # If we already have a row, upgrade the data
+  # Otherwise, create a new row
+  local row_count
+  row_count=$(proxysql_exec $LINENO -Ns "SELECT count(*) FROM mysql_servers WHERE hostgroup_id=$hostgroup AND hostname='$server' AND port=$port")
+  check_cmd_and_exit $LINENO $? "Could not check if row exists (query failed). Exiting."
+
+  if [[ $row_count -eq 0 ]]; then
     proxysql_exec $lineno -Ns "INSERT INTO mysql_servers
           (hostname,hostgroup_id,port,weight,status,comment,max_connections)
           VALUES ('$server',$hostgroup,$port,1000000,'$status','WRITE',$MAX_CONNECTIONS);"
@@ -1040,9 +1044,9 @@ function writer_is_reader_check() {
       fi
     elif [[ $WRITER_IS_READER == "never" ]]; then
       #
-      # Ensure that there is NO corresponding entry in mysql_servers
+      # Ensure that there is NO corresponding ONLINE entry in mysql_servers
       #
-      if [[ $servers =~ $regex ]]; then
+      if [[ $stat == 'ONLINE' && $servers =~ $regex ]]; then
         # Delete the corresponding READER entry
         proxysql_exec $LINENO -Ns "DELETE FROM mysql_servers WHERE hostgroup_id=$HOSTGROUP_READER_ID and hostname='$server' and port=$port"
         check_cmd_and_exit $LINENO $? "writer-is-reader(never): Failed to remove $HOSTGROUP_READER_ID:$address (query failed). Exiting."
@@ -1362,7 +1366,6 @@ function update_writers() {
       AND reader.hostname = writer.hostname
       AND reader.port = writer.port
     WHERE writer.hostgroup_id = $HOSTGROUP_WRITER_ID
-      AND writer.status <> 'OFFLINE_HARD'
     ORDER BY writer.status DESC"
 
   proxysql_list=$(proxysql_exec $LINENO -Ns "$writer_proxysql_query")
@@ -1475,7 +1478,21 @@ function update_writers() {
                                  "max write nodes reached (${NUMBER_WRITERS})"
             echo "1" > ${reload_check_file}
           elif [[ $rdstat != "PRIORITY_NODE" ]]; then
-             log $LINENO "server $hostgroup:$address is already OFFLINE_SOFT, max write nodes reached (${NUMBER_WRITERS})"
+            log $LINENO "server $hostgroup:$address is already OFFLINE_SOFT, max write nodes reached (${NUMBER_WRITERS})"
+
+            # If not there, add node as a reader
+            local reader_count=$(proxysql_exec $LINENO -Ns "SELECT count(*) FROM mysql_servers WHERE hostgroup_id=$HOSTGROUP_READER_ID AND hostname='$server' AND port=$port")
+            check_cmd_and_exit $LINENO $? "Could not get reader count (query failed). Exiting."
+            if [[ $reader_count -eq 0 ]]; then
+              proxysql_exec $LINENO -Ns \
+                "INSERT INTO mysql_servers (hostname,hostgroup_id,port,weight,status,comment,max_connections)
+                 VALUES ('$server',$HOSTGROUP_READER_ID,$port,1000,'ONLINE','READ',$MAX_CONNECTIONS);"
+              check_cmd_and_exit $LINENO $? "Cannot add a PXC reader node to ProxySQL (query failed). Exiting."
+              log_if_success $LINENO $? "Added $HOSTGROUP_READER_ID:$address as a reader."
+              echo "1" > ${reload_check_file}
+            else
+              log $LINENO "$hostgroup:$address already exists in $stat state"
+            fi
           fi
         fi
       # we do not have to limit
@@ -2495,11 +2512,15 @@ function main() {
     restore_reload_check "${reload_check_file}" $save_reload_state
   fi
 
-
   if [[ $(cat ${reload_check_file}) -ne 0 ]] ; then
       log "" "###### Loading mysql_servers config into runtime ######"
       proxysql_exec $LINENO -Ns "LOAD MYSQL SERVERS TO RUNTIME;" 2>>${ERR_FILE}
       check_cmd_and_exit $LINENO $? "Could not update the mysql_servers table in ProxySQL. Exiting."
+      if [[ $DEBUG -eq 1 ]]; then
+        debug "$LINENO" "#### Dumping mysql_servers table"
+        proxysql_exec $LINENO "" "SELECT * FROM mysql_servers;" >>${ERR_FILE} 2>&1
+        debug '' "####"
+      fi
   else
       log "" "###### Not loading mysql_servers, no change needed ######"
   fi

--- a/proxysql_node_monitor
+++ b/proxysql_node_monitor
@@ -619,6 +619,7 @@ function update_cluster() {
       #
       # If OFFLINE_SOFT, move to OFFLINE_HARD
       #
+
       log $LINENO "Cluster node ${ws_hg_id}:${i} does not exist in PXC! Changing status from OFFLINE_SOFT to OFFLINE_HARD"
       proxysql_exec $LINENO "UPDATE mysql_servers set status='OFFLINE_HARD' WHERE hostname='$ws_ip' and port=$ws_port"
       check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check ProxySQL login credentials"
@@ -668,7 +669,7 @@ function update_cluster() {
       if [ "$ws_status" == "OFFLINE_HARD" ]; then
         # The node was OFFLINE_HARD, but its now in the cluster list
         # so lets make it OFFLINE_SOFT
-        proxysql_exec $LINENO "UPDATE mysql_servers set status = 'OFFLINE_SOFT', weight=1000 WHERE hostname='$ws_ip' and port=$ws_port;"
+        proxysql_exec $LINENO "UPDATE mysql_servers set status = 'OFFLINE_SOFT' WHERE hostname='$ws_ip' and port=$ws_port;"
         check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster node $i in the ProxySQL database, Please check the ProxySQL login credentials"
         log_if_success $LINENO $? "${ws_hg_id}:${i} node set to OFFLINE_SOFT status to ProxySQL database."
         CHECK_STATUS=1
@@ -693,7 +694,7 @@ function move_writers_to_readers() {
   local offline_writers=$1
 
   debug $LINENO "$offline_writers"
-  printf "$offline_writers" | while read host port hostgroup || [ -n "$hostgroup" ]
+  printf "$offline_writers" | while read host port hostgroup status || [ -n "$hostgroup" ]
   do
     local read_count
 
@@ -702,17 +703,25 @@ function move_writers_to_readers() {
     read_count=$(proxysql_exec $LINENO "SELECT COUNT(*) FROM mysql_servers WHERE hostgroup_id=$READ_HOSTGROUP_ID AND hostname='$host' AND port=$port")
     if [[ $read_count -ne 0 ]]; then
       # If node is already a READER, update the READER
-      proxysql_exec $LINENO "UPDATE mysql_servers SET status='OFFLINE_SOFT',hostgroup_id=$READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostgroup_id=$READ_HOSTGROUP_ID AND hostname='$host' AND port=$port"
-      check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check ProxySQL login credentials"
-      log_if_success $LINENO $? "Changed OFFLINE_SOFT writer to a reader ($READ_HOSTGROUP_ID:$host:$port)"
-
-      # Delete the WRITER (so that we don't get here again)
-      proxysql_exec $LINENO "DELETE FROM mysql_servers WHERE hostgroup_id=$hostgroup AND hostname='$host' AND port=$port"
+      if [[ $status == 'ONLINE' ]]; then
+        proxysql_exec $LINENO "UPDATE mysql_servers SET status='OFFLINE_SOFT',hostgroup_id=$READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostgroup_id=$READ_HOSTGROUP_ID AND hostname='$host' AND port=$port"
+        check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check ProxySQL login credentials"
+        log_if_success $LINENO $? "Changed OFFLINE_SOFT writer to a reader ($READ_HOSTGROUP_ID:$host:$port)"
+      fi
     else
-      # If node is not a reader, change from WRITER to READER
-      proxysql_exec $LINENO "UPDATE mysql_servers SET status='OFFLINE_SOFT',hostgroup_id=$READ_HOSTGROUP_ID, comment='READ', weight=1000 WHERE hostgroup_id=$hostgroup AND hostname='$host' AND port=$port"
-      check_cmd $LINENO $? "Cannot update Percona XtraDB Cluster writer node in ProxySQL database, Please check ProxySQL login credentials"
-      log_if_success $LINENO $? "Changed OFFLINE_SOFT writer to a reader ($READ_HOSTGROUP_ID:$host:$port)"
+      if [[ $status == "ONLINE" ]]; then
+        local address
+        address=$(combine_ip_port_into_address "$host" "$port")
+
+        # If node is not a reader, add node as a reader
+        debug $LINENO "Node is not a reader, adding node as a reader"
+
+        proxysql_exec $LINENO \
+              "INSERT INTO mysql_servers (hostname,hostgroup_id,port,status,weight,comment,max_connections)
+                  VALUES ('$host',$READ_HOSTGROUP_ID,$port,'OFFLINE_SOFT',1000,'READ',$MAX_CONNECTIONS);"
+        check_cmd $LINENO $? "Cannot add Percona XtraDB Cluster reader node in ProxySQL database, Please check ProxySQL login credentials"
+        log $LINENO "Adding server $READ_HOSTGROUP_ID:$address with status OFFLINE_SOFT."
+      fi
     fi
   done
 }
@@ -734,7 +743,7 @@ function mode_change_check(){
 
   # Check if the current writer is in an OFFLINE_SOFT state
   local offline_writers
-  offline_writers=$(proxysql_exec $LINENO "SELECT hostname,port,hostgroup_id from mysql_servers where comment in ('WRITE', 'READWRITE') and status <> 'ONLINE' and hostgroup_id in ($WRITE_HOSTGROUP_ID)")
+  offline_writers=$(proxysql_exec $LINENO "SELECT hostname,port,hostgroup_id,status from mysql_servers where comment in ('WRITE', 'READWRITE') and status <> 'ONLINE' and hostgroup_id in ($WRITE_HOSTGROUP_ID)")
   if [[ -n $offline_writers ]]; then
     #
     # Found a writer node that was in 'OFFLINE_SOFT' state,

--- a/tests/loadbal-testsuite.bats
+++ b/tests/loadbal-testsuite.bats
@@ -88,6 +88,7 @@ function verify_initial_state() {
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   # Check the initial setup (3 rows in the table, all ONLINE)
   [ "${#read_host[@]}" -eq 0 ]
@@ -155,11 +156,13 @@ function verify_initial_state() {
   run $PXC_BASEDIR/bin/mysqladmin $pxc_socket1 -u root shutdown
   [ "$status" -eq 0 ]
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -184,11 +187,13 @@ function verify_initial_state() {
   [ "${write_weight[1]}" -eq 1000 ]
   [ "${write_weight[2]}" -eq 1000 ]
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -218,11 +223,13 @@ function verify_initial_state() {
   restart_server "$restart_cmd1" "$restart_user1"
   wait_for_server_start $pxc_socket1 3
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -264,11 +271,13 @@ function verify_initial_state() {
   run mysql_exec "$host" "$PORT_2" "SET global pxc_maint_mode='maintenance'"
   [ "$status" -eq 0 ]
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -293,11 +302,13 @@ function verify_initial_state() {
   [ "${write_weight[1]}" -eq 1000 ]
   [ "${write_weight[2]}" -eq 1000 ]
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -327,11 +338,13 @@ function verify_initial_state() {
   run mysql_exec "$host" "$PORT_2" "SET global pxc_maint_mode='disabled'"
   [ "$status" -eq 0 ]
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -397,11 +410,13 @@ function verify_initial_state() {
   run $PXC_BASEDIR/bin/mysqladmin $pxc_socket1 -u root shutdown
   [ "$status" -eq 0 ]
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -426,11 +441,13 @@ function verify_initial_state() {
   [ "${write_weight[1]}" -eq 1000 ]
   [ "${write_weight[2]}" -eq 1000 ]
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -460,11 +477,13 @@ function verify_initial_state() {
   restart_server "$restart_cmd3" "$restart_user3" "bootstrap"
   wait_for_server_start $pxc_socket3 1
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -499,11 +518,13 @@ function verify_initial_state() {
   restart_server "$restart_cmd2" "$restart_user2"
   wait_for_server_start $pxc_socket2 3
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -554,11 +575,13 @@ function verify_initial_state() {
   run mysql_exec "$host" "$PORT_3" "SET global pxc_maint_mode='maintenance'"
   [ "$status" -eq 0 ]
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -583,11 +606,13 @@ function verify_initial_state() {
   [ "${write_weight[1]}" -eq 1000 ]
   [ "${write_weight[2]}" -eq 1000 ]
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -617,11 +642,13 @@ function verify_initial_state() {
   run mysql_exec "$host" "$PORT_2" "SET global pxc_maint_mode='disabled'"
   [ "$status" -eq 0 ]
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]
@@ -656,11 +683,13 @@ function verify_initial_state() {
   run mysql_exec "$host" "$PORT_3" "SET global pxc_maint_mode='disabled'"
   [ "$status" -eq 0 ]
 
+  echo "$LINENO Running the galera checker" >&2
   run $(${GALERA_CHECKER} "${GALERA_CHECKER_ARGS} --log-text='loadbal $LINENO'")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "loadbal $LINENO"
 
   [ "${#read_host[@]}" -eq 0 ]
   [ "${#write_host[@]}" -eq 3 ]

--- a/tests/node-monitor-testsuite.bats
+++ b/tests/node-monitor-testsuite.bats
@@ -122,6 +122,7 @@ function verify_initial_state() {
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "node-monitor $LINENO"
 
   # Check the initial setup (3 rows in the table, all ONLINE)
   [ "${#read_host[@]}" -eq 3 ]
@@ -175,11 +176,13 @@ function verify_initial_state() {
 
   # Run the node monitor
   # (Nothing should have changed)
+  echo "$LINENO Running the node monitor" >&2
   run $(${NODE_MONITOR} ${NODE_MONITOR_ARGS} --log-text="node-monitor $LINENO")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "node-monitor $LINENO"
 
   [ "${#read_host[@]}" -eq 3 ]
   [ "${#write_host[@]}" -eq 1 ]
@@ -201,6 +204,7 @@ function verify_initial_state() {
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "node-monitor $LINENO"
 
   [ "${#read_host[@]}" -eq 2 ]
   [ "${#write_host[@]}" -eq 1 ]
@@ -215,11 +219,13 @@ function verify_initial_state() {
 
   # Run the node monitor
   # The ndde should have been reinserted into ProxySQL
+  echo "$LINENO Running the node monitor" >&2
   run $(${NODE_MONITOR} ${NODE_MONITOR_ARGS} --log-text="node-monitor $LINENO")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "node-monitor $LINENO"
 
   [ "${#read_host[@]}" -eq 3 ]
   [ "${#write_host[@]}" -eq 1 ]
@@ -267,11 +273,13 @@ function verify_initial_state() {
 
   # Run the node monitor
   # (Nothing should have changed)
+  echo "$LINENO Running the node monitor" >&2
   run $(${NODE_MONITOR} ${NODE_MONITOR_ARGS} --log-text="node-monitor $LINENO")
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "node-monitor $LINENO"
 
   [ "${#read_host[@]}" -eq 3 ]
   [ "${#write_host[@]}" -eq 1 ]
@@ -293,6 +301,7 @@ function verify_initial_state() {
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "node-monitor $LINENO"
 
   [ "${#read_host[@]}" -eq 2 ]
   [ "${#write_host[@]}" -eq 1 ]
@@ -307,11 +316,13 @@ function verify_initial_state() {
 
   # Run the node monitor
   # The ndde should have been reinserted into ProxySQL
+  echo "$LINENO Running the node monitor" >&2
   run $(${NODE_MONITOR} ${NODE_MONITOR_ARGS} --log-text="node-monitor $LINENO" --max-connections=2222 --debug)
   [ "$status" -eq 0 ]
 
   retrieve_reader_info
   retrieve_writer_info
+  dump_nodes "node-monitor $LINENO"
 
   [ "${#read_host[@]}" -eq 3 ]
   [ "${#write_host[@]}" -eq 1 ]

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -495,7 +495,7 @@ if [[ ! -x $PROXYSQL_BASE/usr/bin/proxysql ]]; then
   echo "ERROR! Could not find proxysql executable : $PROXYSQL_BASE/usr/bin/proxysql"
   exit 1
 fi
-$PROXYSQL_BASE/usr/bin/proxysql -D $WORKDIR/proxysql_db $PROXYSQL_EXTRA_OPTIONS $WORKDIR/proxysql_db/proxysql.log &
+$PROXYSQL_BASE/usr/bin/proxysql --initial -D $WORKDIR/proxysql_db $PROXYSQL_EXTRA_OPTIONS $WORKDIR/proxysql_db/proxysql.log &
 echo "....ProxySQL started"
 
 
@@ -618,8 +618,6 @@ if [[ $RUN_TEST -eq 1 ]]; then
     fi
 
     if [[ $rc -ne 0 ]]; then
-      ${PXC_BASEDIR}/bin/mysql --user=admin --password=admin --host=$LOCALHOST_IP --port=6032 --protocol=tcp \
-        -e "select hostgroup_id,hostname,port,status,comment,max_connections from mysql_servers order by hostgroup_id,status,hostname,port" 2>/dev/null
       echo "********************************"
       echo "* $test_file failed, the servers (ProxySQL+PXC) will be left running"
       echo "* for debugging purposes."
@@ -711,8 +709,6 @@ if [[ $RUN_TEST -eq 1 ]]; then
     fi
 
     if [[ $rc -ne 0 ]]; then
-      ${PXC_BASEDIR}/bin/mysql --user=admin --password=admin --host=$LOCALHOST_IP --port=6032 --protocol=tcp \
-        -e "select hostgroup_id,hostname,port,status,comment,max_connections from mysql_servers order by hostgroup_id,status,hostname,port" 2>/dev/null
       echo "********************************"
       echo "* $test_file failed, the servers (ProxySQL+PXC)will be left running"
       echo "* for debugging purposes."


### PR DESCRIPTION
Issue
If a node is being shutdown, it sets pxc_maint_mode to 'SHUTDOWN',
however proxysql_galera_checker will set the state to OFFLINE_SOFT
on the first run.  On the second run, it will then move the node
to OFFLINE_HARD (ignoring the pxc_maint_transition_period).

Solution
Only move the node to OFFLINE_HARD if we are unable to connect
to the node, otherwise leave in OFFLINE_SOFT.