### PR TITLE
K8SPXC-278 Update proxysql-admin

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -443,18 +443,20 @@ function exec_sql() {
     default_auth="default-auth=mysql_native_password"
   fi
 
-  retoutput=$(mysql --defaults-file=/dev/stdin --protocol=tcp \
-           --unbuffered --batch --silent ${args} -e "$query" <<EOF
-[client]
-user=${user//%/%%}
-password="${password//%/%%}"
-host=${hostname//%/%%}
-port=${port//%/%%}
-connect-timeout=${TIMEOUT}
-${default_auth}
+  cat <<-EOF >/tmp/my.cnf
+    [client]
+    user=${user//%/%%}
+    password=${password//%/%%}
+    host=${hostname//%/%%}
+    port=${port//%/%%}
+    connect-timeout=${TIMEOUT}
+    ${default_auth}
 EOF
-)
+
+  retoutput=$(mysql --defaults-file=/tmp/my.cnf --protocol=tcp --unbuffered --batch --silent ${args} -e "$query")
   retvalue=$?
+  
+  rm /tmp/my.cnf
 
   if [[ $DEBUG -eq 1 ]]; then
     local number_of_newlines=0

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -454,8 +454,6 @@ function exec_sql() {
 
   retoutput=$(mysql --defaults-file=<(echo "${defaults}") --protocol=tcp --unbuffered --batch --silent ${args} -e "$query")
   retvalue=$?
-  
-  rm /tmp/my.cnf
 
   if [[ $DEBUG -eq 1 ]]; then
     local number_of_newlines=0

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -443,17 +443,16 @@ function exec_sql() {
     default_auth="default-auth=mysql_native_password"
   fi
 
-  cat <<-EOF >/tmp/my.cnf
-    [client]
-    user=${user//%/%%}
-    password=${password//%/%%}
-    host=${hostname//%/%%}
-    port=${port//%/%%}
-    connect-timeout=${TIMEOUT}
-    ${default_auth}
-EOF
+  defaults=$(printf '[client]\nuser=%s\npassword="%s"\nhost=%s\nport=%s\nconnect-timeout=%s\n%s' \
+    "${user//%/%%}" \
+    "${password//%/%%}" \
+    "${hostname//%/%%}" \
+    "${port//%/%%}" \
+    "${TIMEOUT}" \
+    "${default_auth}"
+  )
 
-  retoutput=$(mysql --defaults-file=/tmp/my.cnf --protocol=tcp --unbuffered --batch --silent ${args} -e "$query")
+  retoutput=$(mysql --defaults-file=<(echo "${defaults}") --protocol=tcp --unbuffered --batch --silent ${args} -e "$query")
   retvalue=$?
   
   rm /tmp/my.cnf


### PR DESCRIPTION
Write mysql client config to a temporary file instead of using `/dev/stdin` to avoid an error that occurs under some environments.