### PR TITLE
Use hosts IP address as user group instead of a guessed wildcard.

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -1258,7 +1258,7 @@ function enable_proxysql() {
   # If we have only digits in $cluster_network, then we can assume
   # that we have an IPv4 address
   if [[ "$cluster_network" =~ ^[0-9]+$ ]]; then
-    USER_HOST_RANGE="$cluster_network.%"
+    USER_HOST_RANGE=$(ifconfig | grep -Eo 'inet (addr:)?([0-9]*\.){3}[0-9]*' | grep -Eo '([0-9]*\.){3}[0-9]*' | grep -v '127.0.0.1')
   else
     USER_HOST_RANGE="%"
   fi


### PR DESCRIPTION
The wildcard approach has the issue, that it allows monitor connections
to the MySQL nodes from a too big IP range. Having the first pxc nodes
IP something like 10.1.2.3, proxysql-admin would create the monitor user
with the host range of 10.%. This would contain the complete 10.0.0.0/8
network which most likely contain other systems that are not supposed to
be allowed to connect to MySQL, even if we are just talking about the
monitor user.

Another issue with the current solution pops up, when the IP address of
the pxc node does not share the same first octet with the ProxySQL IP.
Example:
  ProxySQL IP: 172.18.1.1
  PXC IP: 10.0.0.1
Then the ProxySQL-Admin script will anyways create the monitor user as
monitor@10.%, resulting in ProxySQL not being able to connect.

In this commit, we use ifconfig to get the actual IP of the ProxySQL
node and will therefore only allow the ProxySQL node to connect as
monitor user.

Co-authored-by: Isobel <isobelsmith00@gmail.com>