### PR TITLE
ProxySQL version check bug fix with generic tarball

### DIFF
--- a/proxysql-admin.cnf
+++ b/proxysql-admin.cnf
@@ -12,8 +12,8 @@ export CLUSTER_HOSTNAME='localhost'
 export CLUSTER_PORT='3306'
 
 # proxysql monitoring user. proxysql admin script will create this user in pxc to monitor pxc-nodes.
-export MONITOR_USERNAME='monitor2'
-export MONITOR_PASSWORD='m%onitor'
+export MONITOR_USERNAME='monitor'
+export MONITOR_PASSWORD='monitor'
 
 # Application user to connect to pxc-node through proxysql
 export CLUSTER_APP_USERNAME='proxysql_user'

--- a/proxysql-admin.cnf
+++ b/proxysql-admin.cnf
@@ -12,8 +12,8 @@ export CLUSTER_HOSTNAME='localhost'
 export CLUSTER_PORT='3306'
 
 # proxysql monitoring user. proxysql admin script will create this user in pxc to monitor pxc-nodes.
-export MONITOR_USERNAME='monitor'
-export MONITOR_PASSWORD='monitor'
+export MONITOR_USERNAME='monitor2'
+export MONITOR_PASSWORD='m%onitor'
 
 # Application user to connect to pxc-node through proxysql
 export CLUSTER_APP_USERNAME='proxysql_user'

--- a/tests/generic-test.bats
+++ b/tests/generic-test.bats
@@ -156,7 +156,7 @@ PROXYSQL_BASEDIR=$WORKDIR/proxysql-bin
 
 @test "run proxysql-admin --version check" {
     admin_version=$(sudo $WORKDIR/proxysql-admin -v | grep --extended-regexp -oe '[1-9]\.[0-9]\.[0-9]+')
-    proxysql_version=$(sudo $PROXYSQL_BASE/usr/bin/proxysql --help | grep --extended-regexp -oe '[1-9]\.[0-9]\.[0-9]+')
+    proxysql_version=$(sudo $PROXYSQL_BASEDIR/usr/bin/proxysql --help | grep --extended-regexp -oe '[1-9]\.[0-9]\.[0-9]+')
     echo "proxysql_version:$proxysql_version  admin_version:$admin_version" >&2
     [ "${proxysql_version}" = "${admin_version}" ]
 }

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -421,7 +421,7 @@ elif [[ $USE_IPVERSION == "v6" ]]; then
 fi
 
 # Find the localhost alias in /etc/hosts
-LOCALHOST_NAME=$(cat /etc/hosts | grep "^${LOCALHOST_IP}" | awk '{ print $2 }')
+LOCALHOST_NAME=$(cat /etc/hosts | grep "^${LOCALHOST_IP}" | awk '{ print $2 }' | head -1)
 
 declare ROOT_FS=$WORKDIR
 mkdir -p $WORKDIR/logs
@@ -583,9 +583,6 @@ fi
 sudo cp $PROXYSQL_BASE/etc/proxysql-admin.cnf /etc/proxysql-admin.cnf
 sudo chown $OS_USER:$OS_USER /etc/proxysql-admin.cnf
 sudo sed -i "s|\/var\/lib\/proxysql|$PROXYSQL_BASE|" /etc/proxysql-admin.cnf
-
-echo "Copying over proxysql to /usr/bin"
-sudo cp $PROXYSQL_BASE/usr/bin/* /usr/bin/
 
 if [[ ! -e $(sudo which bats 2> /dev/null) ]] ;then
   pushd $ROOT_FS


### PR DESCRIPTION
Issue: ProxySQL version check is failing due to missing library
```
[vagrant@node1 ~]$ /usr/bin/proxysql --version
/usr/bin/proxysql: error while loading shared libraries: libgnutls.so.26.22.6: cannot open shared object file: No such file or directory
[vagrant@node1 ~]$
```

Solution: Skipped copying ProxySQL binary from the tarball to `/usr/bin` and updated ProxySQL BASEDIR location to check the ProxySQL version.

