### PR TITLE
PSQLADM-272 : Use .my.cnf for proxysql-status

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,12 +270,18 @@ ___ProxySQL Admin Login File Usage___
  # Method (1) : Encrypt this data with --password
  $ proxysql-login-file --in data.cnf --out login-file.cnf --password=${passwd}
 
- # Method (2) : Encrypt the data with --password-file
- #              Sending the password via the command-line is insecure,
- #              it's better to use --password-file so that the
- #              password doesn't show up in the command-line
+ # Method (2a) : Encrypt the data with --password-file
+ #               Sending the password via the command-line is insecure,
+ #               it's better to use --password-file so that the
+ #               password doesn't show up in the command-line
  $ proxysql-login-file --in data.cnf --out login-file.cnf \
       --password-file=<(echo "${passwd}")
+
+ # Method (2b) : Running the command using sudo will not work with
+ #               bash's process substition.  In this case, sending the
+ #               password via stdin is another option.
+ $ sudo echo "${passwd}" | proxysql-login-file --in data.cnf --out login-file.cnf \
+                            --password-file=/dev/stdin
 
  # Method (3) : The script will prompt for the password
  #              if no password is provided via the command-line options.

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -27,7 +27,7 @@ set -o nounset    # no undefined variables
 set -o pipefail   # internal pipe failures cause an exit
 
 # Include the common functions
-. $(dirname $0)/proxysql-admin-common
+. $(dirname ${BASH_SOURCE[0]})/proxysql-admin-common
 
 
 #-------------------------------------------------------------------------------

--- a/proxysql-login-file
+++ b/proxysql-login-file
@@ -18,7 +18,7 @@
 # 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 
 # Include the common functions
-. $(dirname $0)/proxysql-admin-common
+. $(dirname ${BASH_SOURCE[0]})/proxysql-admin-common
 
 # The file used as input (unencrypted)
 declare INFILE="/dev/stdin"

--- a/proxysql-status
+++ b/proxysql-status
@@ -19,13 +19,13 @@
 # 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 
 # Include the common functions
-. $(dirname $0)/proxysql-admin-common
+. $(dirname ${BASH_SOURCE[0]})/proxysql-admin-common
 
 # Global variables
-declare USER
-declare PASSWORD
-declare HOST
-declare PORT
+declare USER=""
+declare PASSWORD=""
+declare HOST=""
+declare PORT=""
 declare RUNTIME_OPTION=""
 declare DUMP_ALL=1
 declare DUMP_MAIN=0
@@ -44,8 +44,8 @@ declare    LOGIN_PASSWORD_FILE=""
 
 # Set this to 1 if the default user credentials from my.cnf
 # are being used, set to 0 if the default my.cnf user credentials
-# are not being used, and set to -1 if unknown
-declare CREDENTIALS_FROM_CLIENT_CONFIG=-1
+# are not being used (default)
+declare CREDENTIALS_FROM_CLIENT_CONFIG=0
 
 function usage() {
     local path=$0
@@ -80,8 +80,13 @@ Usage example:
 
   The default is to display all tables and files.
 
-  If no credentials are specified the credentials in /etc/proxysql-admin.cnf
-  are used.
+  If no credentials are specified (on the command line or via a login-file) then:
+    1. The default MySQL client credentials are used (usually found
+       in ~/.my.cnf), if they connect to a ProxySQL instance).
+    2. If the default MySQL client credentials do not exist, or do not connect
+       to a ProxySQL instance, then the credentials in /etc/proxysql-admin.cnf
+       are used.
+
 EOF
 }
 
@@ -238,80 +243,86 @@ function parse_args() {
         esac
     done
 
-    # Load the data if the login-file has been set
-    # Run this before the command-line parsing, so that the command-line
-    # options can override the login path settings
-    if [[ -n $LOGIN_FILE ]]; then
-
-        # Check for key
-        if [[ -n $LOGIN_PASSWORD_FILE ]]; then
-            if [[ ! -r $LOGIN_PASSWORD_FILE ]]; then
-                error "$LINENO" "Cannot read from the login-password file: $LOGIN_PASSWORD_FILE"
-                exit 1
-            fi
-            LOGIN_PASSWORD=$(cat "$LOGIN_PASSWORD_FILE")
-            if [[ -z $LOGIN_PASSWORD ]]; then
-                error "$LINENO" "Did not find any data in the login-password file: $LOGIN_PASSWORD_FILE"
-                exit 1
-            fi
-        fi
-        if [[ -z $LOGIN_PASSWORD ]]; then
-            read -r -s -p  "Enter the login-file password:" LOGIN_PASSWORD
-            echo
-        fi
-
-        # Extract the information
-        load_login_file "$LINENO" "$LOGIN_FILE" "$LOGIN_PASSWORD"
-        if [[ $? -ne 0 ]]; then
-            error "$LINENO" "Cannot read the credentials from the login-file"
-            exit 1
-        fi
-
-        [[ -n $PROXYSQL_USERNAME ]] && USER=$PROXYSQL_USERNAME;
-        [[ -n $PROXYSQL_PASSWORD ]] && PASSWORD=$PROXYSQL_PASSWORD;
-        [[ -n $PROXYSQL_HOSTNAME ]] && HOST=$PROXYSQL_HOSTNAME;
-        [[ -n $PROXYSQL_PORT ]] && PORT=$PROXYSQL_PORT;
-    fi
-
     # Reset the args
     eval set -- "$positional_args"
 
-    if [[ $# -eq 0 ]]; then
-        mysql_works_from_config=`mysql -e "SELECT 1" >/dev/null 2>/dev/null`
-        mysql_works_from_config_exit_code=$?
+    if [[ $# -eq 0 && -z $LOGIN_FILE ]]; then
+        # If no credentials have been provided, try the default
+        # mysql client credentials
 
-        if [[ $mysql_works_from_config_exit_code == 0 ]]; then
+        mysql -e "SHOW tables" 2>/dev/null | grep -q "runtime_proxysql_servers"
+        if [[ $? -eq 0 ]]; then
+            echo -e "Connecting to ProxySQL with the default MySQL client credentials"
+            echo -e "Usually found in ~/.my.cnf"
             CREDENTIALS_FROM_CLIENT_CONFIG=1
-            echo "ProxySQL admin configuration loaded from a configuration file (most likely /.my.cnf)"
-        elif [[ ! -r /etc/proxysql-admin.cnf ]]; then
+        fi
+    fi
+
+    if [[ $CREDENTIALS_FROM_CLIENT_CONFIG -eq 0 ]]; then
+        # If we can't use the default, get the credentials
+        # from proxysql-admin.cnf
+        if [[ ! -r /etc/proxysql-admin.cnf ]]; then
             echo "Cannot find /etc/proxysql-admin.cnf."
             exit 1
         else
-            CREDENTIALS_FROM_CLIENT_CONFIG=0
             source /etc/proxysql-admin.cnf
             USER=$PROXYSQL_USERNAME
             PASSWORD=$PROXYSQL_PASSWORD
             HOST=$PROXYSQL_HOSTNAME
             PORT=$PROXYSQL_PORT
         fi
-    elif [[ $# -eq 4 ]]; then
-        CREDENTIALS_FROM_CLIENT_CONFIG=0
-        [[ -n $1 ]] && USER=$1
-        [[ -n $2 ]] && PASSWORD=$2
-        [[ -n $3 ]] && HOST=$3
-        [[ -n $4 ]] && PORT=$4
-    elif [[ $# -ne 0 ]]; then
-        error "$LINENO" "Incomplete connection parameters"
-        echo -e "All four parameters (user,password,host,port) must be specified together."
-        exit 1
-    else
-        echo -e "ERROR: Incorrect usage\n"
-        usage
-    fi
 
-    if [[ -z $USER || -z $PASSWORD || -z $HOST || -z $PORT ]]; then
-        error "$LINENO" "One of the user, password, host, or port parameter is missing."
-        exit 1
+        # Load the data if the login-file has been set
+        # Run this before the command-line parsing, so that the command-line
+        # options can override the login path settings
+        if [[ -n $LOGIN_FILE ]]; then
+
+            # Check for key
+            if [[ -n $LOGIN_PASSWORD_FILE ]]; then
+                #if [[ ! -e $LOGIN_PASSWORD_FILE ]]; then
+                #    error "$LINENO" "Cannot read from the login-password file: $LOGIN_PASSWORD_FILE"
+                #    exit 1
+                #fi
+                LOGIN_PASSWORD=$(cat "$LOGIN_PASSWORD_FILE")
+                if [[ -z $LOGIN_PASSWORD ]]; then
+                    error "$LINENO" "Did not find any data in the login-password file: $LOGIN_PASSWORD_FILE"
+                    exit 1
+                fi
+            fi
+            if [[ -z $LOGIN_PASSWORD ]]; then
+                read -r -s -p  "Enter the login-file password:" LOGIN_PASSWORD
+                echo
+            fi
+
+            # Extract the information
+            load_login_file "$LINENO" "$LOGIN_FILE" "$LOGIN_PASSWORD"
+            if [[ $? -ne 0 ]]; then
+                error "$LINENO" "Cannot read the credentials from the login-file"
+                exit 1
+            fi
+
+            [[ -n $PROXYSQL_USERNAME ]] && USER=$PROXYSQL_USERNAME;
+            [[ -n $PROXYSQL_PASSWORD ]] && PASSWORD=$PROXYSQL_PASSWORD;
+            [[ -n $PROXYSQL_HOSTNAME ]] && HOST=$PROXYSQL_HOSTNAME;
+            [[ -n $PROXYSQL_PORT ]] && PORT=$PROXYSQL_PORT;
+        fi
+
+        # Now override any values with the command-line args
+        if [[ $# -gt 0 && $# -le 4 ]]; then
+            [[ -n ${1+} ]] && USER=$1
+            [[ -n ${2+} ]] && PASSWORD=$2
+            [[ -n ${3+} ]] && HOST=$3
+            [[ -n ${4+} ]] && PORT=$4
+        elif [[ $# -ge 5 ]]; then
+            error "$LINENO" "Incorrect usage"
+            usage
+            exit 1
+        fi
+
+        if [[ -z $USER || -z $PASSWORD || -z $HOST || -z $PORT ]]; then
+            error "$LINENO" "One of the user, password, host, or port parameterd is missing."
+            exit 1
+        fi
     fi
 
 }


### PR DESCRIPTION
Have proxysql-status use the default mysql credentials to access
the proxysql server.

Also clarified some issues in the README.md