### PR TITLE
PSQLADM-315 : proxysql-admin test suite was failing with PXC-8.0 when…

### DIFF
--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -303,6 +303,10 @@ function start_pxc_node(){
   echo "[sst]" >> my.cnf
   echo "wsrep_debug=1" >> my.cnf
 
+  if [[ $USE_IPVERSION == "v6" ]]; then
+    echo "sockopt=\"pf=ip6\"" >> my.cnf
+  fi
+
   # Assume that node1 is the bootstrapped node
   bootstrap_node="${PXC_BASEDIR}/${cluster_name}1"
 


### PR DESCRIPTION
… ipv6 is enabled

Issue:
wsrep_xtrabackup_v2 script does not automatically detect ipv6 connections

Workaround:
Modified the test script to accept ipv6 connections

Author: Mohit Joshi <mohit.joshi@percona.com>
Reviewed by: Kenn Takara <kenn.takara@percona.com>