### PR TITLE
fix weight to 1001

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Write node info
 +-----------+--------------+--------+-----------+
 | hostname  | hostgroup_id | port   | weight    |
 +-----------+--------------+--------+-----------+
-| 127.0.0.1 | 10           | 25000  | 1000000   |
+| 127.0.0.1 | 10           | 25000  | 1001   |
 +-----------+--------------+--------+-----------+
 
 ProxySQL configuration completed!
@@ -655,7 +655,7 @@ mysql_servers rows for this configuration
 +---------------+-------+-----------+-------+--------+-----------+----------+---------+-----------+
 | hostgroup     | hg_id | hostname  | port  | status | weight    | max_conn | use_ssl | gtid_port |
 +---------------+-------+-----------+-------+--------+-----------+----------+---------+-----------+
-| writer        | 10    | 127.0.0.1 | 25000 | ONLINE | 1000000   | 1000     | 0       | 0         |
+| writer        | 10    | 127.0.0.1 | 25000 | ONLINE | 1001   | 1000     | 0       | 0         |
 | reader        | 11    | 127.0.0.1 | 25100 | ONLINE | 1000      | 1000     | 0       | 0         |
 | reader        | 11    | 127.0.0.1 | 25200 | ONLINE | 1000      | 1000     | 0       | 0         |
 | backup-writer | 12    | 127.0.0.1 | 25100 | ONLINE | 1000      | 1000     | 0       | 0         |
@@ -693,7 +693,7 @@ All other remaining nodes will be read-only and will only receive read statement
 
 With the --write-node option we can control which node ProxySQL will use as the
 writer node. The writer node is specified as an address:port - 10.0.0.51:3306
-If --write-node is used, the writer node is given a weight of 1000000 (the default
+If --write-node is used, the writer node is given a weight of 1001 (the default
 weight is 1000).
 
 The mode _loadbal_ on the other hand is a load balanced set of evenly weighted

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -1377,7 +1377,7 @@ function enable_proxysql() {
     # writer-is-also-reader=0, since we only have writers
 
     # Setup parameters for loadbal
-    MAX_WRITERS=1000000
+    MAX_WRITERS=1001
 
     # Force this for loadbal, since in loadbal, everyone is a writer
     WRITERS_ARE_READERS_OPTION=0
@@ -1394,7 +1394,7 @@ function enable_proxysql() {
       # Update the write_node to have a higher priority
       proxysql_exec "$LINENO" \
         "UPDATE mysql_servers
-          SET weight = 1000000
+          SET weight = 1001
           WHERE
             hostname = '$writer_ws_ip' AND
             port = $writer_ws_port AND
@@ -2323,14 +2323,14 @@ function update_cluster()
             SET weight = 1000
             WHERE
               hostgroup_id IN ($all_hostgroups) AND
-              weight = 1000000"
+              weight = 1001"
         check_cmd $? "$LINENO" "Failed to update the write-node" \
                              "\n-- Please check the ProxySQL connection parameters and status."
 
         # Update the write_node to have a higher priority
         proxysql_exec "$LINENO" \
           "UPDATE mysql_servers
-            SET weight = 1000000
+            SET weight = 1001
             WHERE
               hostname = '$writer_ws_ip' AND
               port = $writer_ws_port AND

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -649,11 +649,11 @@ fi
   max_transactions_behind=$(echo "$data" | cut -f8)
 
   echo "active:$active expected:1" >&2
-  echo "max_writers:$active expected:1000000" >&2
+  echo "max_writers:$active expected:1001" >&2
   echo "writer_is_also_reader:$active expected:0" >&2
   echo "max_transactions_behind:$active expected:100" >&2
   [[ $active -eq 1 ]]
-  [[ $max_writers -eq 1000000 ]]
+  [[ $max_writers -eq 1001 ]]
   [[ $writer_is_also_reader -eq 0 ]]
   [[ $max_transactions_behind -eq 100 ]]
 
@@ -733,7 +733,7 @@ fi
   retrieve_writer_info $WRITER_HOSTGROUP_ID
   echo "write_weight[0]:${write_weight[0]}" >&2
   [ "${write_status[0]}" = 'ONLINE' ]
-  [ "${write_weight[0]}" -eq 1000000 ]
+  [ "${write_weight[0]}" -eq 1001 ]
   [ "${write_port[0]}" -eq $PORT_2 ]
 
   retrieve_writer_info $BACKUP_WRITER_HOSTGROUP_ID


### PR DESCRIPTION
With the single write and writers_are_readers mode set to yes, the write node will  have a weight of 100000 and be added to the reader group. As a result, the reader request will all direct to the writer node(writers_are_readers) because othe readers have a weight of 1000. So, fix the weight to 1001 will  distinguish the writer node and has a little effect to the read balance