### PR TITLE
PSQLADM-327 : proxysql-admin --syncusers does not work for async repl…

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,9 @@ $
   with the ProxySQL database except password-less users and admin users.
   It also deletes ProxySQL users not in Percona XtraDB Cluster from the ProxySQL database.
 
+  The __--server__ option can be used with __--syncusers__ to specify a
+  specific server that will be synced (rather than a PXC cluster).
+
 ```bash
 $ /usr/bin/proxysql-admin --syncusers
 
@@ -482,12 +485,17 @@ mysql> select user,host from mysql.user where authentication_string!='' and user
 mysql>
 
 ```
+
   __5) --sync-multi-cluster-users__
 
   This option works in the same way as --syncusers but it does not delete ProxySQL users
   that are not present in the Percona XtraDB Cluster. It is to be used when syncing proxysql
   instances that manage multiple clusters.
   
+  The __--server__ option can be used with __--sync-multi-cluster-users__ to specify a
+  specific server that will be synced (rather than a PXC cluster).
+
+
   __6) --add-query-rule__
 
   Create query rules for synced mysql user. This is applicable only for singlewrite mode and
@@ -792,6 +800,11 @@ variable settings. If this option is specified, then the values of
 the admin-checksum_mysql_query_rules, admin-checksum_mysql_servers,
 and admin-checksum_mysql_users will be set to 'false'.
 
+__vi) --server__
+
+This option is used with __--syncusers__  or __--sync-multi-cluster-users__ to specify
+a single server to sync, rather than a PXC cluster. This server does not have to belong
+to a PXC cluster and can be a standalone MySQL node.
 
 ## ProxySQL Status
 

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -105,6 +105,11 @@ declare -i CHECK_IF_ENABLED=0
 declare -i FORCE=0
 declare -i REPORT_STATUS=0
 
+# This can be specifed by the "--server=IP:PORT" option for
+# a single address.  This is used by --syncusers to sync a
+# single node (that does not need to be part of a cluster)
+declare    SINGLE_SERVER=""
+
 declare -i USE_EXISTING_MONITOR_PASSWORD=0
 declare -i WITH_CLUSTER_APP_USER=1
 
@@ -247,6 +252,9 @@ Options:
   --remove-all-servers               When used with --update-cluster, this will remove all
                                      servers belonging to the current cluster before
                                      updating the list.
+  --server=<IPADDRESS>:<PORT>        Specifies the IP address and port for a single server. This can
+                                     be used with --syncusers or --sync-multi-cluster-users
+                                     to sync a single non-cluster server node.
   --add-query-rule                   Create query rules for synced mysql user. This is applicable only
                                      for singlewrite mode and works only with --syncusers
                                      and --sync-multi-cluster-users options.
@@ -277,10 +285,13 @@ One of the options below must be provided.
                                      from a node in the cluster.
   --quick-demo                       Setup a quick demo with no authentication
   --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL
-                                     May be used with --enable.
+                                     May be used with --enable.  --server may be used with this
+                                     to specify a single server to sync.
                                      (deletes ProxySQL users not in MySQL)
   --sync-multi-cluster-users         Sync user accounts currently configured in MySQL to ProxySQL
                                      May be used with --enable.
+                                     May be used with --enable.  --server may be used with this
+                                     to specify a single server to sync.
                                      (doesn't delete ProxySQL users not in MySQL)
   --is-enabled                       Checks if the current configuration is enabled in ProxySQL.
   --status                           Returns a status report on the current configuration.
@@ -587,10 +598,10 @@ function proxysql_connection_check() {
 #
 function cluster_connection_check() {
   mysql_exec "$LINENO" "SELECT @@PORT" >/dev/null
-  check_cmd $? "$LINENO" "PXC connection check failed."\
-                       "\n-- Could not connect to the PXC cluster at $CLUSTER_HOSTNAME:$CLUSTER_PORT"\
-                       "\n-- Please check the PXC connection parameters and status."
-  debug "$LINENO" "cluster connection check succeeded"
+  check_cmd $? "$LINENO" "Server connection check failed."\
+                       "\n-- Could not connect to the server at $CLUSTER_HOSTNAME:$CLUSTER_PORT"\
+                       "\n-- Please check the connection parameters and status."
+  debug "$LINENO" "server connection check succeeded"
 }
 
 
@@ -1876,6 +1887,7 @@ function add_query_rule()
 #   SYNCUSERS
 #   CLUSTER_HOSTNAME (overwrites)
 #   CLUSTER_PORT (overwrites)
+#   SINGLE_SERVER
 #
 # Arguments:
 #   None
@@ -1883,27 +1895,46 @@ function add_query_rule()
 function syncusers() {
   debug "$LINENO" "syncusers ()"
 
-  cluster_in_proxysql_check $WRITER_HOSTGROUP_ID
-
   local mysql_version
   local password_field
-  local cluster_node
   local changes_made=0
 
-  # Get current MySQL users, filter out header row and mysql.sys user
-  # Find a cluster node that belongs to the cluster with $WRITER_HOSTGROUP_ID
-  cluster_node=$(find_cluster_node "$WRITER_HOSTGROUP_ID")
-  check_cmd $? "$LINENO" "Could not find a primary cluster node"
+  # If a single server has been specified with --server, use that server
+  # and skip the cluster check (it may be a standalone node)
+  if [[ -n $SINGLE_SERVER ]]; then
+    local ws_address
 
-  # Reset the central cluster node (so that calls to mysql_exec) will
-  # work with this new node, rather than the node in the config file
-  CLUSTER_HOSTNAME=$(echo -e "$cluster_node" | cut -f1)
-  CLUSTER_PORT=$(echo -e "$cluster_node" | cut -f2)
+    ws_address=$(separate_ip_port_from_address "$SINGLE_SERVER")
+    CLUSTER_HOSTNAME=$(echo "$ws_address" | cut -d' ' -f1)
+    CLUSTER_PORT=$(echo "$ws_address" | cut -d' ' -f2)
+
+    echo -e "\nSyncing user accounts from server(${CLUSTER_HOSTNAME}:${CLUSTER_PORT}) to ProxySQL"
+
+  else
+    cluster_in_proxysql_check $WRITER_HOSTGROUP_ID
+
+    local cluster_node
+
+    # Get current MySQL users, filter out header row and mysql.sys user
+    # Find a cluster node that belongs to the cluster with $WRITER_HOSTGROUP_ID
+    cluster_node=$(find_cluster_node "$WRITER_HOSTGROUP_ID")
+    check_cmd $? "$LINENO" "Could not find a primary cluster node"
+
+    # Reset the central cluster node (so that calls to mysql_exec) will
+    # work with this new node, rather than the node in the config file
+    CLUSTER_HOSTNAME=$(echo -e "$cluster_node" | cut -f1)
+    CLUSTER_PORT=$(echo -e "$cluster_node" | cut -f2)
+
+    echo -e "\nSyncing user accounts from PXC(${CLUSTER_HOSTNAME}:${CLUSTER_PORT}) to ProxySQL"
+
+  fi
+
+  # Check that we can connect to CLUSTER_HOSTNAME:CLUSTER_PORT
   cluster_connection_check
 
   mysql_version=$(mysql_exec "$LINENO" "SELECT VERSION();" | tail -1 | cut -d'.' -f1,2 )
-  check_cmd $? "$LINENO" "Could not connect to the PXC node."\
-                       "\n-- Please check the PXC connection parameters and status."
+  check_cmd $? "$LINENO" "Could not connect to the server."\
+                       "\n-- Please check the server connection parameters and status."
 
   case $mysql_version in
     5.6)
@@ -1912,22 +1943,7 @@ function syncusers() {
     5.7 | 8.0)
       password_field="authentication_string"
       ;;
-    10.0)
-      password_field="Password"
-      ;;
-    10.1)
-      password_field="Password"
-      ;;
-    10.2)
-      password_field="Password"
-      ;;
-    10.3)
-      password_field="Password"
-      ;;
-    10.4)
-      password_field="Password"
-      ;;
-    10.5)
+    10.0 | 10.1 | 10.2 | 10.3 | 10.4 | 10.5)
       password_field="Password"
       ;;
      *)
@@ -1942,14 +1958,12 @@ function syncusers() {
                   grep -E -v "^(mysql.sys|mysql.session|mysql.infoschema|mysql.pxc)" |
                   sort |
                   uniq )
-  check_cmd $? "$LINENO" "Failed to load the user list from PXC."\
-                       "\n-- Please check the PXC connection parameters and status."
+  check_cmd $? "$LINENO" "Failed to load the user list from the server."\
+                       "\n-- Please check the server connection parameters and status."
 
   #Checking whether user is part of proxysql admin user list
   # Get current ProxySQL users and filter out header row
   proxysql_users=$(get_proxysql_users)
-
-  echo -e "\nSyncing user accounts from PXC to ProxySQL"
 
   # TEST FOR USERS THAT EXIST IN MYSQL BUT NOT IN PROXYSQL HERE AND ADD
 
@@ -2571,11 +2585,65 @@ function report_status()
 function parse_args() {
   local go_out=""
 
+  local argument_list=(
+    "config-file:"
+    "login-file:"
+    "login-password:"
+    "login-password-file:"
+    "proxysql-datadir:"
+    "writer-hg:"
+    "backup-writer-hg:"
+    "reader-hg:"
+    "offline-hg:"
+    "proxysql-username:"
+    "proxysql-password::"
+    "proxysql-hostname:"
+    "proxysql-port:"
+    "cluster-username:"
+    "cluster-password::"
+    "cluster-hostname:"
+    "cluster-port:"
+    "monitor-username:"
+    "monitor-password:"
+    "cluster-app-username:"
+    "cluster-app-password:"
+    "node-check-interval:"
+    "quick-demo"
+    "mode:"
+    "write-node:"
+    "use-existing-monitor-password"
+    "without-cluster-app-user"
+    "enable"
+    "disable"
+    "update-cluster"
+    "is-enabled"
+    "adduser"
+    "syncusers"
+    "sync-multi-cluster-users"
+    "update-mysql-version"
+    "add-query-rule"
+    "status"
+    "max-connections:"
+    "max-transactions-behind:"
+    "use-ssl:"
+    "writers-are-readers:"
+    "remove-all-servers"
+    "disable-updates"
+    "force"
+    "use-stdin-for-credentials"
+    "server:"
+    "version"
+    "debug"
+    "help"
+  )
+
   # TODO: kennt, what happens if we don't have a functional getopt()?
   # Check if we have a functional getopt(1)
   if ! getopt --test; then
-    go_out="$(getopt --options=edv --longoptions=config-file:,login-file:,login-password:,login-password-file:,proxysql-datadir:,writer-hg:,backup-writer-hg:,reader-hg:,offline-hg:,proxysql-username:,proxysql-password::,proxysql-hostname:,proxysql-port:,cluster-username:,cluster-password::,cluster-hostname:,cluster-port:,monitor-username:,monitor-password:,cluster-app-username:,cluster-app-password:,node-check-interval:,quick-demo,mode:,write-node:,use-existing-monitor-password,without-cluster-app-user,enable,disable,update-cluster,is-enabled,adduser,syncusers,sync-multi-cluster-users,update-mysql-version,add-query-rule,status,max-connections:,max-transactions-behind:,use-ssl:,writers-are-readers:,remove-all-servers,disable-updates,force,use-stdin-for-credentials,version,debug,help \
-    --name="$(basename "$0")" -- "$@")"
+    go_out="$(getopt \
+                --options=edv \
+                --longoptions "$(printf "%s," "${argument_list[@]}")" \
+                --name="$(basename "$0")" -- "$@")"
     check_cmd $? "$LINENO" "Script error: getopt() failed with arguments: $*"
     eval set -- "$go_out"
   fi
@@ -2973,6 +3041,10 @@ function parse_args() {
         USE_STDIN_FOR_CREDENTIALS=1
         shift
         ;;
+      --server )
+        SINGLE_SERVER=$2
+        shift 2
+        ;;
       -v | --version )
         # Detection of this setting is done before this
         shift
@@ -3010,6 +3082,35 @@ function parse_args() {
     fi
   fi
   readonly WRITE_NODE
+
+  # SINGLE_SERVER should only be used with syncusers
+  if [[ -n $SINGLE_SERVER && $SYNCUSERS -ne 1 && $SYNCMULTICLUSTERUSERS -ne 1 ]]; then
+    error "$LINENO" "The --server option can only be used with --syncusers" \
+                  "\nand --sync-multi-cluster-users."
+    exit 1
+  fi
+
+  # SINGLE_SERVER validity check (check to see if the port is included)
+  if [[ -n $SINGLE_SERVER ]]; then
+    if [[ $SINGLE_SERVER =~ , ]]; then
+      error "$LINENO" "The --server option expects to receive the address" \
+                    "\n-- of a single node, therefore commas ',' are not allowed."
+      exit 1
+    fi
+    local ws_address
+    local ws_port
+
+    ws_address=$(separate_ip_port_from_address "$SINGLE_SERVER")
+    ws_port=$(echo "$ws_address" | cut -d' ' -f2)
+
+    # Check that we have a port and that it only contains digits
+    if [[ -z $ws_port || ! $ws_port =~ ^[[:digit:]]*$ ]]; then
+      error "$LINENO" "--server : expected 'address:port' found '$SINGLE_SERVER'"
+      exit 1
+    fi
+  fi
+  readonly SINGLE_SERVER
+
 
 
   if [[ ! $MODE =~ ^(loadbal|singlewrite)$ ]]; then

--- a/tests/generic-test.bats
+++ b/tests/generic-test.bats
@@ -130,6 +130,37 @@ PROXYSQL_BASEDIR=$WORKDIR/proxysql-bin
     [[ "${lines[0]}" =~ ERROR.*--write-node.*expects.* ]]
 }
 
+@test "run proxysql-admin --server without parameters" {
+    run sudo $WORKDIR/proxysql-admin --server
+    echo "$output" >&2
+    [ "$status" -eq 1 ]
+    [[ "${lines[0]}" =~ .*--server.* ]]
+}
+
+@test "run proxysql-admin --server with missing port" {
+    run sudo $WORKDIR/proxysql-admin --server=1.1.1.1 --syncusers
+    echo "$output" >&2
+    [ "$status" -eq 1 ]
+    [[ "${lines[0]}" =~ ERROR.*--server.*expected.* ]]
+
+    run sudo $WORKDIR/proxysql-admin --server=[1:1:1:1] --syncusers
+    echo "$output" >&2
+    [ "$status" -eq 1 ]
+    [[ "${lines[0]}" =~ ERROR.*--server.*expected.* ]]
+}
+
+@test "run proxysql-admin --server with unsupported commands" {
+    run sudo $WORKDIR/proxysql-admin --server=1.1.1.1 --disable
+    echo "$output" >&2
+    [ "$status" -eq 1 ]
+    [[ "${lines[0]}" =~ ERROR.*--server.*can.only.be.used.* ]]
+
+    run sudo $WORKDIR/proxysql-admin --server=[1:1:1:1] --update-cluster
+    echo "$output" >&2
+    [ "$status" -eq 1 ]
+    [[ "${lines[0]}" =~ ERROR.*--server.*can.only.be.used.* ]]
+}
+
 @test 'run proxysql-admin --max-connections without parameters' {
     run sudo $WORKDIR/proxysql-admin --max-connections
     echo "$output" >&2

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -26,10 +26,12 @@ if [[ $WSREP_CLUSTER_NAME == "cluster_one" ]]; then
   PORT_1=4110
   PORT_2=4120
   PORT_3=4130
+  ASYNC_PORT=4190
 else
   PORT_1=4210
   PORT_2=4220
   PORT_3=4230
+  ASYNC_PORT=4290
 fi
 
 if [[ $USE_IPVERSION == "v6" ]]; then
@@ -121,7 +123,7 @@ fi
 
 
 @test "run proxysql-admin --update-mysql-version ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ update_mysql_version ]] && skip;
 
   DEBUG_SQL_QUERY=1
   local mysql_version=$(mysql_exec "$HOST_IP" "$PORT_3" "SELECT VERSION();" | tail -1 | cut -d'-' -f1)
@@ -148,7 +150,7 @@ fi
 }
 
 @test "run the check for --adduser ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ adduser ]] && skip;
   DEBUG_SQL_QUERY=1
 
   printf "proxysql_test_user1\ntest_user\ny" | sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --adduser --debug >&2
@@ -158,16 +160,8 @@ fi
   [ "$run_check_user_command" -eq 1 ]
 }
 
-@test "run proxysql-admin --syncusers ($WSREP_CLUSTER_NAME)" {
-  #skip
-
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --syncusers
-  echo "$output" >&2
-  [ "$status" -eq  0 ]
-}
-
 @test "run proxysql-admin --syncusers --add-query-rule ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ add_query_rule ]] && skip;
 
   # Check whether user and query rule exists in  ProxySQL DB
   DEBUG_SQL_QUERY=1
@@ -190,7 +184,7 @@ fi
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --syncusers --add-query-rule
   echo "$output" >&2
   [ "$status" -eq  0 ]
-  [[ "${lines[4]}" =~ "Added query rule for user: test_query_rule" ]]
+  [[ "${lines[6]}" =~ "Added query rule for user: test_query_rule" ]]
 
   run_write_hg_query_rule_user=$(proxysql_exec "select 1 from runtime_mysql_query_rules where username='test_query_rule' and match_digest='^SELECT.*FOR UPDATE'" | awk '{print $0}')
   echo "$LINENO : Query rule count for user 'test_query_rule' with writer hostgroup found:$run_write_hg_query_rule_user expect:1"  >&2
@@ -213,7 +207,7 @@ fi
 }
 
 @test "run the check for --syncusers ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ syncusers_basic ]] && skip;
 
   local mysql_version=$(cluster_exec "select @@version")
   local pass_field
@@ -246,8 +240,69 @@ fi
 }
 
 
+@test "run proxysql-admin --syncusers --server ($WSREP_CLUSTER_NAME)" {
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ syncusers_server ]] && skip;
+
+  local server_user
+  local proxysql_count
+  server_user="${WSREP_CLUSTER_NAME}_slave"
+
+  DEBUG_SQL_QUERY=1
+
+  # Verify that the user is not in ProxySQL
+  proxysql_count=$(proxysql_exec "select count(distinct username) from mysql_users where username='${server_user}'")
+  [[ $proxysql_count -eq 0 ]]
+
+  # Create a user on the async node
+  mysql_exec "$HOST_IP" "$ASYNC_PORT" "CREATE USER '${server_user}'@'%' IDENTIFIED WITH mysql_native_password BY 'passwd';"
+
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --syncusers --server=${HOST_IP}:${ASYNC_PORT}
+  echo "$output" >&2
+  [ "$status" -eq  0 ]
+
+  # Verify that the user has been added to ProxySQL
+  proxysql_count=$(proxysql_exec "select count(distinct username) from mysql_users where username='${server_user}'")
+  [[ $proxysql_count -eq 1 ]]
+
+  # Cleanup by removing the user on the async node
+  mysql_exec "$HOST_IP" "$ASYNC_PORT" "DROP USER '${WSREP_CLUSTER_NAME}_slave'@'%';"
+
+  # Remove the user from proxysql
+  proxysql_exec "delete from mysql_users where username='${server_user}'; load mysql users to runtime"
+}
+
+@test "run proxysql-admin --sync-multi-cluster-users --server ($WSREP_CLUSTER_NAME)" {
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ syncusers_multicluster_server ]] && skip;
+
+  local server_user
+  local proxysql_count
+  server_user="${WSREP_CLUSTER_NAME}_slave"
+
+  # Verify that the user is not in ProxySQL
+  proxysql_count=$(proxysql_exec "select count(distinct username) from mysql_users where username='${server_user}'")
+  [[ $proxysql_count -eq 0 ]]
+
+  # Create a user on the async node
+  mysql_exec "$HOST_IP" "$ASYNC_PORT" "CREATE USER '${server_user}'@'%' IDENTIFIED WITH mysql_native_password BY 'passwd';"
+
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --sync-multi-cluster-users --server=${HOST_IP}:${ASYNC_PORT}
+  echo "$output" >&2
+  [ "$status" -eq  0 ]
+
+  # Verify that the user has been added to ProxySQL
+  proxysql_count=$(proxysql_exec "select count(distinct username) from mysql_users where username='${server_user}'")
+  [[ $proxysql_count -eq 1 ]]
+
+  # Cleanup by removing the user on the async node
+  mysql_exec "$HOST_IP" "$ASYNC_PORT" "DROP USER '${WSREP_CLUSTER_NAME}_slave'@'%'"
+
+  # Remove the user from proxysql
+  proxysql_exec "delete from mysql_users where username='${server_user}'; load mysql users to runtime"
+}
+
+
 @test "run the check for --quick-demo ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ quick_demo ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin  --enable \
       --writer-hg=10 --reader-hg=11 --backup-writer-hg=12 \
@@ -258,7 +313,7 @@ fi
 }
 
 @test "run the check for --force ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ force ]] && skip;
 
   # Cleaning existing configuration to test --force option as normal run
   dump_runtime_nodes $LINENO "before disable"
@@ -349,7 +404,8 @@ fi
 
 
 @test "test for various parameter settings ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ parameters ]] && skip;
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable \
     --max-connections=111 \
@@ -396,7 +452,8 @@ fi
 
 
 @test "test for --writers-are-readers ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ writers_are_readers_basic ]] && skip;
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
 
   # -----------------------------------------------------------
@@ -505,7 +562,8 @@ fi
 
 
 @test "test for --writers-are-readers with a read-only node ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ writes_are_readers_read_only ]] && skip;
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
 
   # -----------------------------------------------------------
@@ -600,7 +658,8 @@ fi
 
 # Test loadbal
 @test "test for --mode=loadbal ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ loadbal_basic ]] && skip;
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
 
   echo "$LINENO : proxysql-admin --enable --mode=loadbal" >&2
@@ -674,7 +733,8 @@ fi
 
 # Test loadbal with a read-only node
 @test "test for --mode=loadbal with a read-only node ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ loadbal_read_only ]] && skip;
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
 
   # -----------------------------------------------------------
@@ -715,7 +775,8 @@ fi
 
 # Test singlewrite with --write-node
 @test "test for --write-node ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ singlewrite_write_node ]] && skip;
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
 
   # -----------------------------------------------------------
@@ -758,7 +819,8 @@ fi
 
 # Test singlewrite with --write-node is a read-only node
 @test "test for --write-node on a read-only node ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ singlewrite_read_only ]] && skip;
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
 
   # -----------------------------------------------------------
@@ -783,7 +845,8 @@ fi
 
 # Test --update-cluster
 @test "test --update-cluster ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_basic ]] && skip;
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
 
   # Stop node3
@@ -859,7 +922,8 @@ fi
 }
 
 @test "run --update-cluster with read-only --write-node server ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_read_only_writer ]] && skip;
+
   # Run --update-cluster with read-only --write-node server
   echo "$LINENO : changing node2 to read-only" >&2
   mysql_exec "$HOST_IP" "$PORT_2" "SET global read_only=1"
@@ -887,7 +951,8 @@ fi
 
 # Test --enable --update-cluster
 @test "test --enable --update-cluster ($WSREP_CLUSTER_NAME)" {
-  #skip
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_enable ]] && skip;
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
 
   # Stop node3
@@ -971,6 +1036,8 @@ fi
 
 # Test --enable with login-file
 @test "test --enable with login-file ($WSREP_CLUSTER_NAME)" {
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ enable_login_file ]] && skip;
+
   local openssl_binary
   openssl_binary=$(find_openssl_binary "$LINENO" || true)
   if [[ -z ${openssl_binary} ]]; then
@@ -1044,6 +1111,8 @@ fi
 
 # Test proxysql-login-file
 @test "test proxysql-login-file ($WSREP_CLUSTER_NAME)" {
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ proxysql_login_file ]] && skip;
+
   local openssl_binary
   openssl_binary=$(find_openssl_binary "$LINENO" || true)
   if [[ -z ${openssl_binary} ]]; then


### PR DESCRIPTION
…ication

Issue
Running --syncusers or --sync-multi-cluster-users does not work if
the node being synced is not a cluster node.  The code checks to
see if the node is part of the cluster and errors out otherwise.

Solution
Added the --server option. If this is specified with --syncusers or
--sync-multi-cluster-users, then the check for cluster membership
is skipped, thus allowing standalone nodes to be synced.