### PR TITLE
PSQLADM-339 : Dynamic proxysql configuration for pxc cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,6 +779,8 @@ __iv) --force__
 
   This will skip existing configuration checks with __--enable__ option in mysql_servers,
   mysql_users and mysql_galera_hostgroups tables
+  This will also cause certain checks to issue warnings instead of an error,
+  allowing the operation to proceed.
 
 
 __v) --disable_updates__

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -251,8 +251,10 @@ Options:
                                      for singlewrite mode and works only with --syncusers
                                      and --sync-multi-cluster-users options.
   --force                            This option will skip existing configuration checks in mysql_servers,
-                                     mysql_users and mysql_galera_hostgroups tables. This option will only
-                                     work with 'proxysql-admin --enable'.
+                                     mysql_users and mysql_galera_hostgroups tables. This option will
+                                     work with '--enable' and '--update-cluster'.
+                                     This will also cause certain checks to issue warnings instead
+                                     of an error.
   --disable-updates                  Disable admin updates for ProxySQL cluster for the
                                      current operation. The default is to not change the
                                      admin variable settings.  If this option is specifed,
@@ -2127,6 +2129,7 @@ function update_cluster()
   local data
   local -i force_to_runtime=0
 
+  # If we have a write node specified, check for read-only
   if [[ -n $WRITE_NODE ]]; then
     local ws_address ws_ip ws_port
     ws_address=$(separate_ip_port_from_address "$WRITE_NODE")
@@ -2141,8 +2144,12 @@ function update_cluster()
       writer_ws_port=$ws_port
       writer_ws_address=$(combine_ip_port_into_address "$writer_ws_ip" "$writer_ws_port")
 
-      error "$LINENO" "--write-node is a read-only node($writer_ws_address). Terminating."
-      exit 1
+      if [[ $FORCE -eq 1 ]]; then
+        warning "$LINENO" "--write-node is a read-only node($writer_ws_address)."
+      else
+        error "$LINENO" "--write-node is a read-only node($writer_ws_address). Terminating."
+        exit 1
+      fi
     fi
   fi
   all_hostgroups=$(get_all_hostgroups_from_writer_hostgroup $WRITER_HOSTGROUP_ID)

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -224,7 +224,7 @@ fi
   fi
   cluster_user_count=$(cluster_exec "select count(distinct user) from mysql.user where ${pass_field} != '' and user not in ('admin') and user not like 'mysql.%'" -Ns)
 
-  # HACK: this mismatch occurs because we're running the tests for cluster_two
+  # HACK: this mismatch occurs because we are running the tests for cluster_two
   # right after the test for cluster_one (multi-cluster scenario), so the
   # user counts will be off (because user cluster_one will still be in proxysql users).
   if [[ $WSREP_CLUSTER_NAME == "cluster_two" ]]; then
@@ -869,6 +869,11 @@ fi
   echo "$LINENO : proxysql-admin --update-cluster --write-node=$HOST_IP:$PORT_2 " >&2
   echo "$output" >& 2
   [ "$status" -eq 1 ]
+
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --update-cluster --force --write-node=$HOST_IP:$PORT_2
+  echo "$LINENO : proxysql-admin --update-cluster --write-node=$HOST_IP:$PORT_2 " >&2
+  echo "$output" >& 2
+  [ "$status" -eq 0 ]
 
   # revert node2 to be a read/write node
   echo "$LINENO : changing node2 back to read-only=0" >&2


### PR DESCRIPTION
Issue
When running --update-cluster, the write-node is not a read-only node
check is causing issues with the operator.

Solution
If --update-cluster is used with the --force flag, a warning will
be issued (instead of an error) if the write-node is a read-only node.