### PR TITLE
PSQLADM-380: scheduler-admin: update README with examples

### DIFF
--- a/build_scheduler.sh
+++ b/build_scheduler.sh
@@ -17,7 +17,9 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 
-source ./proxysql-common
+if [ ! -d percona-scheduler ]; then
+    git submodule update --init
+fi
 
 cd percona-scheduler
 

--- a/config.toml
+++ b/config.toml
@@ -119,8 +119,8 @@ monitorUserPassword="monitor"
 # The clusterXXX information is used to setup the cluster for
 # use by ProxySQL.
 #
-clusterHost="localhost"
-clusterPort=4110
+clusterHost="<IP_ADDRESS>"
+clusterPort=3306
 clusterUser="admin"
 clusterUserPassword="admin"
 

--- a/percona-scheduler-admin
+++ b/percona-scheduler-admin
@@ -187,7 +187,8 @@ Options:
                                      writes for singlewrite mode.  If left unspecified,
                                      the cluster node is then used as the write node.
                                      This only applies when 'mode=singlewrite' is used.
-  --auto-assign-weights              Auto assigns weights in a 'singlewrite' mode.
+  --auto-assign-weights              When used with --update-cluster, this option shall auto assign
+                                     the weights if in 'singlewrite' mode.
   --update-read-weight=<IP:PORT,WT>  When used with --update-cluster, this option shall assign the
                                      specified read weight to the given node.
   --update-write-weight=<IP:PORT,WT> When used with --update-cluster, this option shall assign the
@@ -238,10 +239,6 @@ One of the options below must be provided.
                                      (doesn't delete ProxySQL users not in MySQL)
   --is-enabled                       Checks if the current configuration is enabled in ProxySQL.
   --status                           Returns a status report on the current configuration.
-                                     If "--writer-hg=<NUM>" is specified, then the
-                                     data corresponding to the galera cluster with that
-                                     writer hostgroup is displayed. Otherwise, information
-                                     for all clusters will be displayed.
   --version, -v                      Prints the version info
 
 EOF
@@ -2620,7 +2617,7 @@ function validate_update_weights() {
 
   # The update option requires exact 2 arguments
   arg_count=$(echo $new_weight_info | tr ',' '\n' | wc -l)
-  if [[ $arg_count -le 2 || $arg_count -ge 2 ]]; then
+  if [[ $arg_count -lt 2 || $arg_count -gt 2 ]]; then
     error "" "$update_operation option requires exactly two arguments in format \"<IP_ADDR:PORT>,NEW_WEIGHT\". Found $new_weight_info"
     exit 1
   fi


### PR DESCRIPTION
https://jira.percona.com/browse/PSQLADM-380

Updated README.md with examples for each every supported options, and
also instructions about the admin user for communicating with proxysql.

In addition to the above, this commit also fixes the problem in parsing
the arguments of `--update-write-weight` and `--update-read-weight`.