### PR TITLE
PSQLADM-385: Support MySQL / PXC 5.5 with proxysql-admin

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -1449,7 +1449,7 @@ function syncusers() {
                        "\n-- Please check the server connection parameters and status."
 
   case $mysql_version in
-    5.6)
+    5.5 | 5.6)
       password_field="Password"
       ;;
     5.7 | 8.0)


### PR DESCRIPTION
https://jira.percona.com/browse/PSQLADM-385

Currently the tool supports 5.6+, we should extend it to 5.5 as we help customers with migrations using ProxySQL in front of older versions :+1: 