### PR TITLE
PSQLADM-384: proxysql-admin: --write-node fails if cluster is read-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,67 +839,80 @@ percona-scheduler-admin usage info
 
 ```bash
 Usage: percona-scheduler-admin [ options ]
-Options:
+
+
+You must include at least one option. Independent options do not require another
+option to run successfully. Dependent options require another option to run
+successfully. If you run a dependent option without the required option you see
+an error message and the option does not run.
+
+
+These options can be run without another option:
+
+  --adduser                          Adds the Percona XtraDB Cluster application user to the ProxySQL database
   --config-file=<config-file>        Read login credentials from a configuration file
                                      (command line options override any configuration file values)
-
-  --write-node=<IPADDRESS>:<PORT>    Specifies the node that is to be used for
-                                     writes for singlewrite mode.  If left unspecified,
-                                     the cluster node is then used as the write node.
-                                     This only applies when 'mode=singlewrite' is used.
-  --auto-assign-weights              When used with --update-cluster, this option shall auto assign
-                                     the weights if in 'singlewrite' mode.
-  --update-read-weight=<IP:PORT,WT>  When used with --update-cluster, this option shall assign the
-                                     specified read weight to the given node.
-  --update-write-weight=<IP:PORT,WT> When used with --update-cluster, this option shall assign the
-                                     specified write weight to the given node.
-  --remove-all-servers               When used with --update-cluster, this will remove all
-                                     servers belonging to the current cluster before
-                                     updating the list.
-  --server=<IPADDRESS>:<PORT>        Specifies the IP address and port for a single server. This can
-                                     be used with --syncusers or --sync-multi-cluster-users
-                                     to sync a single non-cluster server node.
-  --add-query-rule                   Create query rules for synced mysql user. This is applicable only
-                                     for singlewrite mode and works only with --syncusers
-                                     and --sync-multi-cluster-users options.
-  --force                            This option will skip existing configuration checks in mysql_servers,
-                                     mysql_users and mysql_galera_hostgroups tables. This option will
-                                     work with '--enable' and '--update-cluster'.
-                                     This will also cause certain checks to issue warnings instead
-                                     of an error.
+  --debug                            Enables additional debug logging.
+  --disable, -d                      Removes any Percona XtraDB Cluster configurations from ProxySQL
   --disable-updates                  Disable admin updates for ProxySQL cluster for the
                                      current operation. The default is to not change the
                                      admin variable settings.  If this option is specifed,
                                      these options will be set to false.
                                      (default: updates are not disabled)
-  --use-stdin-for-credentials        If set, then the MySQL client will use stdin to send credentials
-                                     to the client (instead of process substition).
-                                     (default: process subsitution is used)
-  --trace                            Enables shell-level tracing for this shell script
-  --debug                            Enables additional debug logging.
-  --help                             Displays this help text.
-
-These options are the possible operations for percona-scheduler-admin.
-One of the options below must be provided.
-  --adduser                          Adds the Percona XtraDB Cluster application user to the ProxySQL database
-  --disable, -d                      Remove any Percona XtraDB Cluster configurations from ProxySQL
   --enable, -e                       Auto-configure Percona XtraDB Cluster nodes into ProxySQL
-  --update-cluster                   Updates the cluster membership, adds new cluster nodes
-                                     to the configuration.
-  --update-mysql-version             Updates the mysql-server_version variable in ProxySQL with the version
-                                     from a node in the cluster.
-  --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL
-                                     May be used with --enable.  --server may be used with this
-                                     to specify a single server to sync.
-                                     (deletes ProxySQL users not in MySQL)
-  --sync-multi-cluster-users         Sync user accounts currently configured in MySQL to ProxySQL
-                                     May be used with --enable.
-                                     May be used with --enable.  --server may be used with this
-                                     to specify a single server to sync.
-                                     (doesn't delete ProxySQL users not in MySQL)
+  --help                             Displays this help text.
   --is-enabled                       Checks if the current configuration is enabled in ProxySQL.
   --status                           Returns a status report on the current configuration.
+  --trace                            Enables shell-level tracing for this shell script
+  --update-cluster                   Updates the cluster membership, adds new cluster nodes
+                                     to the configuration.
+
+  --update-mysql-version             Updates the mysql-server_version variable in ProxySQL with the version
+                                     from a node in the cluster.
+  --use-stdin-for-credentials        If set, then the MySQL client uses stdin to send credentials
+                                     to the client (instead of process substition).
+                                     (default: process subsitution is used)
   --version, -v                      Prints the version info
+
+The following options require another option or a specific mode. Running these
+options by themselves or with an incorrect option causes an error.
+
+  --add-query-rule                   Creates query rules for synced mysql user. This is applicable only
+                                     for singlewrite mode and works only with '--syncusers'
+                                     and '--sync-multi-cluster-users' options.
+  --auto-assign-weights              When used with '--update-cluster', this option will auto assign
+                                     the weights if in 'singlewrite' mode.
+  --force                            Skips existing configuration checks in mysql_servers,
+                                     mysql_users and mysql_galera_hostgroups tables. This option will
+                                     work with '--enable' and '--update-cluster'.
+                                     This will also cause certain checks to issue warnings instead
+                                     of an error.
+  --remove-all-servers               When used with '--update-cluster', this will remove all
+                                     servers belonging to the current cluster before
+                                     updating the list.
+  --server=<IPADDRESS>:<PORT>        This option can be used with --syncusers or
+                                     --sync-multi-cluster-users to sync a single non-cluster server
+                                     node.
+  --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL
+                                     May be used with '--enable'.  '--server' may be used with this
+                                     to specify a single server to sync.
+                                     NOTE: This option deletes the ProxySQL users not present in MySQL.
+
+  --sync-multi-cluster-users         Sync user accounts currently configured in MySQL to ProxySQL
+                                     May be used with '--enable'.  '--server' may be used with this
+                                     to specify a single server to sync.
+                                     NOTE: This option works in the same way as --syncusers but does not
+                                     delete ProxySQL users not present in MySQL. It's indicated to be
+                                     used when syncing proxysql instances that manage multiple clusters.
+
+  --update-read-weight=<IP:PORT,WT>  When used with '--update-cluster', this option will assign the
+                                     specified read weight to the given node.
+  --update-write-weight=<IP:PORT,WT> When used with '--update-cluster', this option will assign the
+                                     specified write weight to the given node.
+  --write-node=<IPADDRESS>:<PORT>    Specifies the node that is to be used for writes for singlewrite mode.
+                                     If left unspecified, the cluster node is then used as the write node.
+                                     This only applies when 'mode=singlewrite' is used.
+
 ```
 
 ### Prerequisites
@@ -1064,7 +1077,7 @@ It is recommended that you use --config-file to run the _percona-scheduler-admin
 
   Example:
   ```sql
-  CREATE USER `admin`@`192.%` IDENTIFIED WITH 'mysql_native_password' BY 'admin';
+  CREATE USER 'admin'@'192.%' IDENTIFIED WITH 'mysql_native_password' BY 'admin';
 
   GRANT ALL PRIVILEGES ON *.* TO 'admin'@'192.%' WITH GRANT OPTION;
   ```

--- a/config.toml
+++ b/config.toml
@@ -1,9 +1,11 @@
+# For the detailed manual, see
+# https://github.com/percona/pxc_scheduler_handler#how-to-configure-pxc-scheduler-handler
+#
 
 [pxccluster]
 activeFailover = 1
 failBack = false
 checkTimeOut = 2000
-# debug = 1 //Deprecated: this is redundant and not in use
 mainSegment = 0
 sslClient = "client-cert.pem"
 sslKey = "client-key.pem"
@@ -13,8 +15,6 @@ hgW = 100
 hgR = 101
 configHgRange =8000
 maintenanceHgRange =9000
-#bckHgW = 8100 #deprecated
-#bckHgR = 8101 #deprecated
 
 # --------------------------------
 # Set to true if there is a single writer node.  If this is set,
@@ -42,13 +42,22 @@ singlePrimary = true
 # Default: (none)
 #
 maxNumWriters = 1
-
 writerIsAlsoReader = 1
-
 retryUp = 0
 retryDown = 2
 clusterId = 10
-persistPrimarySettings=0 #0 disable| 1 only persist Write settings | 2 persist Reand and Write settings
+
+# Controls the primary settings during failover.
+# More details at https://github.com/percona/pxc_scheduler_handler#persist-primary-values
+#
+# Allowed values:
+#
+#       0 Disable
+#       1 Persist only write settings
+#       2 Persist both read and write settings
+persistPrimarySettings=0
+
+
 
 # == proxysql ===================================================
 # The proxysql section is for ProxySQL-specific information.
@@ -65,6 +74,7 @@ lockfilepath ="/var/run/pxc_scheduler_handler"
 respectManualOfflineSoft=false
 
 
+
 #== global ======================================================
 # The global section are for variables that are not ProxySQL or
 # cluster specific.
@@ -74,22 +84,31 @@ respectManualOfflineSoft=false
 [global]
 debug = true
 
-#?? Should we just have logFile, what advantage does logTarget have?
+# stdout: output is redirected to proxysql logs
+# file: output is written to the file pointed by logFile
+logTarget = "file" #stdout | file
+
+# Defines the log level to be used.
+# Allowed options are [error,warning,info,debug]
 logLevel = "info"
-logTarget = "stdout" #stdout | file
 logFile = "/var/log/pxc_scheduler_handler/pscheduler.log"
 
-#?? Should we use the development for these two
+# Should be set to false if we are pxc_scheduler_handler through percona-scheduler-admin.
 daemonize = false
 daemonInterval = 2000
+
+# boolean variable which enables reporting of statistics.
 performance = true
 
-#?? What does this do?
+# Not used currently
 OS = "na"
 
-#?? Make common lockfileTimeout -> lockFileTimeout
-lockfiletimeout = 60 #seconds
-lockclustertimeout = 600 #120 # seconds
+# Time in seconds after which the file lock is considered expired [local instance lock]
+lockFileTimeout = 60 #seconds
+
+# Time in seconds after which the cluster lock is considered expired
+lockClusterTimeout = 600 #seconds
+
 
 
 #== setup =======================================================

--- a/percona-scheduler-admin
+++ b/percona-scheduler-admin
@@ -181,67 +181,79 @@ function usage() {
   local path=$0
   cat << EOF
 Usage: ${path##*/} [ options ]
-Options:
+
+
+You must include at least one option. Independent options do not require another
+option to run successfully. Dependent options require another option to run
+successfully. If you run a dependent option without the required option you see
+an error message and the option does not run.
+
+
+These options can be run without another option:
+
+  --adduser                          Adds the Percona XtraDB Cluster application user to the ProxySQL database
   --config-file=<config-file>        Read login credentials from a configuration file
                                      (command line options override any configuration file values)
-
-  --write-node=<IPADDRESS>:<PORT>    Specifies the node that is to be used for
-                                     writes for singlewrite mode.  If left unspecified,
-                                     the cluster node is then used as the write node.
-                                     This only applies when 'mode=singlewrite' is used.
-  --auto-assign-weights              When used with --update-cluster, this option shall auto assign
-                                     the weights if in 'singlewrite' mode.
-  --update-read-weight=<IP:PORT,WT>  When used with --update-cluster, this option shall assign the
-                                     specified read weight to the given node.
-  --update-write-weight=<IP:PORT,WT> When used with --update-cluster, this option shall assign the
-                                     specified write weight to the given node.
-  --remove-all-servers               When used with --update-cluster, this will remove all
-                                     servers belonging to the current cluster before
-                                     updating the list.
-  --server=<IPADDRESS>:<PORT>        Specifies the IP address and port for a single server. This can
-                                     be used with --syncusers or --sync-multi-cluster-users
-                                     to sync a single non-cluster server node.
-  --add-query-rule                   Create query rules for synced mysql user. This is applicable only
-                                     for singlewrite mode and works only with --syncusers
-                                     and --sync-multi-cluster-users options.
-  --force                            This option will skip existing configuration checks in mysql_servers,
-                                     mysql_users and mysql_galera_hostgroups tables. This option will
-                                     work with '--enable' and '--update-cluster'.
-                                     This will also cause certain checks to issue warnings instead
-                                     of an error.
+  --debug                            Enables additional debug logging.
+  --disable, -d                      Removes any Percona XtraDB Cluster configurations from ProxySQL
   --disable-updates                  Disable admin updates for ProxySQL cluster for the
                                      current operation. The default is to not change the
                                      admin variable settings.  If this option is specifed,
                                      these options will be set to false.
                                      (default: updates are not disabled)
-  --use-stdin-for-credentials        If set, then the MySQL client will use stdin to send credentials
-                                     to the client (instead of process substition).
-                                     (default: process subsitution is used)
-  --trace                            Enables shell-level tracing for this shell script
-  --debug                            Enables additional debug logging.
-  --help                             Displays this help text.
-
-These options are the possible operations for percona-scheduler-admin.
-One of the options below must be provided.
-  --adduser                          Adds the Percona XtraDB Cluster application user to the ProxySQL database
-  --disable, -d                      Remove any Percona XtraDB Cluster configurations from ProxySQL
   --enable, -e                       Auto-configure Percona XtraDB Cluster nodes into ProxySQL
-  --update-cluster                   Updates the cluster membership, adds new cluster nodes
-                                     to the configuration.
-  --update-mysql-version             Updates the mysql-server_version variable in ProxySQL with the version
-                                     from a node in the cluster.
-  --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL
-                                     May be used with --enable.  --server may be used with this
-                                     to specify a single server to sync.
-                                     (deletes ProxySQL users not in MySQL)
-  --sync-multi-cluster-users         Sync user accounts currently configured in MySQL to ProxySQL
-                                     May be used with --enable.
-                                     May be used with --enable.  --server may be used with this
-                                     to specify a single server to sync.
-                                     (doesn't delete ProxySQL users not in MySQL)
+  --help                             Displays this help text.
   --is-enabled                       Checks if the current configuration is enabled in ProxySQL.
   --status                           Returns a status report on the current configuration.
+  --trace                            Enables shell-level tracing for this shell script
+  --update-cluster                   Updates the cluster membership, adds new cluster nodes
+                                     to the configuration.
+
+  --update-mysql-version             Updates the mysql-server_version variable in ProxySQL with the version
+                                     from a node in the cluster.
+  --use-stdin-for-credentials        If set, then the MySQL client uses stdin to send credentials
+                                     to the client (instead of process substition).
+                                     (default: process subsitution is used)
   --version, -v                      Prints the version info
+
+The following options require another option or a specific mode. Running these
+options by themselves or with an incorrect option causes an error.
+
+  --add-query-rule                   Creates query rules for synced mysql user. This is applicable only
+                                     for singlewrite mode and works only with '--syncusers'
+                                     and '--sync-multi-cluster-users' options.
+  --auto-assign-weights              When used with '--update-cluster', this option will auto assign
+                                     the weights if in 'singlewrite' mode.
+  --force                            Skips existing configuration checks in mysql_servers,
+                                     mysql_users and mysql_galera_hostgroups tables. This option will
+                                     work with '--enable' and '--update-cluster'.
+                                     This will also cause certain checks to issue warnings instead
+                                     of an error.
+  --remove-all-servers               When used with '--update-cluster', this will remove all
+                                     servers belonging to the current cluster before
+                                     updating the list.
+  --server=<IPADDRESS>:<PORT>        This option can be used with --syncusers or
+                                     --sync-multi-cluster-users to sync a single non-cluster server
+                                     node.
+  --syncusers                        Sync user accounts currently configured in MySQL to ProxySQL
+                                     May be used with '--enable'.  '--server' may be used with this
+                                     to specify a single server to sync.
+                                     NOTE: This option deletes the ProxySQL users not present in MySQL.
+
+  --sync-multi-cluster-users         Sync user accounts currently configured in MySQL to ProxySQL
+                                     May be used with '--enable'.  '--server' may be used with this
+                                     to specify a single server to sync.
+                                     NOTE: This option works in the same way as --syncusers but does not
+                                     delete ProxySQL users not present in MySQL. It's indicated to be
+                                     used when syncing proxysql instances that manage multiple clusters.
+
+  --update-read-weight=<IP:PORT,WT>  When used with '--update-cluster', this option will assign the
+                                     specified read weight to the given node.
+  --update-write-weight=<IP:PORT,WT> When used with '--update-cluster', this option will assign the
+                                     specified write weight to the given node.
+  --write-node=<IPADDRESS>:<PORT>    Specifies the node that is to be used for writes for singlewrite mode.
+                                     If left unspecified, the cluster node is then used as the write node.
+                                     This only applies when 'mode=singlewrite' is used.
 
 EOF
 }
@@ -2207,7 +2219,7 @@ function parse_args() {
   LOCK_FILE_PATH=$(read_from_config_file "$LINENO" "$CONFIG_FILE" "proxysql" "lockfilepath" "" 1)
   [[ $? -ne 0 ]] && exit 1
 
-  if [[ ! -d $(cd "$(dirname ${LOCK_FILE_PATH})" && pwd)/${LOCK_FILE_PATH} ]]; then
+  if [[ ! -d $(cd "$(dirname ${LOCK_FILE_PATH})" && pwd)/$(basename ${LOCK_FILE_PATH}) ]]; then
     error "" "lockfilepath is set to an invalid location ${LOCK_FILE_PATH}. Make sure the directory exists."
     exit 1
   fi

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -838,9 +838,13 @@ function enable_proxysql() {
         exit 1
       fi
       if [[ $is_read_only -eq 1 ]]; then
-        error "$LINENO" "The specified write node ($WRITE_NODE) is read-only" \
-                      "\n-- and cannot be used as a writer node."
-        exit 1
+        if [[ $FORCE -eq 1 ]]; then
+            warning "$LINENO" "The specified write node ($WRITE_NODE) is read-only"
+        else
+            error "$LINENO" "The specified write node ($WRITE_NODE) is read-only" \
+                          "\n-- and cannot be used as a writer node."
+            exit 1
+        fi
       fi
     else
       # If there is no WRITE_NODE specified, check that we have at least

--- a/tests/scheduler-args.bats
+++ b/tests/scheduler-args.bats
@@ -150,7 +150,6 @@ PROXYSQL_BASEDIR=$WORKDIR/proxysql-bin
     run sudo $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-write-weight="[::1]:4130av,20s00"
     echo "$output" >&2
     [ "$status" -eq 1 ]
-    echo ${lines[0]}
     [[ "${lines[0]}" =~ ERROR.*expected.address.in.format.* ]]
 
     run sudo $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-write-weight="[::1]:4130,20s00"

--- a/tests/testsuite.toml
+++ b/tests/testsuite.toml
@@ -84,7 +84,7 @@ daemonize = false
 daemonInterval = 2000
 performance = true
 
-#?? What does this do?
+# Not used currently
 OS = "na"
 
 #?? Make common lockfileTimeout -> lockFileTimeout


### PR DESCRIPTION
https://jira.percona.com/browse/PSQLADM-384

Problem
-------
When running --write-node option along with --enable, prevented the
setting up proxysql due to read-only node checks even when --force was
specified. This affected operators.

Solution
--------
If --write-node is used with the --force flag, then we log a warning instead of an error
if the write-node is a read-only node.

In addition to the above problem, the following things have also been
changes.
1. Reordered options in help section
2. Corrected the logic for checking lockFilePath in
   percona-scheduler-admin.