### PR TITLE
Some improvements

### DIFF
--- a/build_scheduler.sh
+++ b/build_scheduler.sh
@@ -17,6 +17,8 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
 
+source ./proxysql-common
+
 if [ ! -d percona-scheduler ]; then
     git submodule update --init
 fi
@@ -24,17 +26,21 @@ fi
 cd percona-scheduler
 
 if [[ ! -e $(command -v go 2> /dev/null)  ]]; then
-  echo "go packages not found. Please install golang package."
+  error "" "go packages not found. Please install golang package."
   exit 1
 fi
 
-go build -a -ldflags "-X main.pxcSchedulerHandlerVersion=${PROXYSQL_ADMIN_VERSION}" -o pxc_scheduler_handler
+go mod tidy
+go build -v -a -ldflags "-X main.pxcSchedulerHandlerVersion=${PROXYSQL_ADMIN_VERSION}" -o pxc_scheduler_handler
 
 if [ $? -ne 0 ]; then
-  echo "go build process failed with errors. Exiting.."
+  error "" "go build process failed with errors. Exiting.."
   exit 1
 fi
 
 cd ..
 cp percona-scheduler/pxc_scheduler_handler .
-echo "Build was successful. The binary can be found in ./pxc_scheduler_handler"
+echo -e "Build was successful. The binary can be found in ./pxc_scheduler_handler"
+
+echo -e
+./pxc_scheduler_handler --version

--- a/percona-scheduler-admin
+++ b/percona-scheduler-admin
@@ -2647,6 +2647,7 @@ function parse_args() {
 
   readonly MAX_CONNECTIONS
 
+  readonly LOCK_FILE_PATH
   readonly AUTO_ASSIGN_WEIGHTS
   readonly UPDATE_READ_WEIGHT
   readonly UPDATE_WRITE_WEIGHT
@@ -3111,9 +3112,9 @@ function wait_for_scheduler_processing ()
 
       done
 
-      if [[ $i -eq $timeout ]]; then
-        echo -e "Warning: Timeout $timeout seconds exceeded when waiting for scheduler to process the nodes."
-        echo -e "Please check the error logs for more information."
+      if [[ $i -ge $timeout ]]; then
+          error "" "Error: Timeout exceeded ($timeout seconds) while waiting for the scheduler to process the nodes."
+          echo -e "Please check proxysql error logs for more information. Log will usually be found in /var/lib/proxysql/proxysql.log"
         exit 1
       fi
     fi


### PR DESCRIPTION
1. Improve the error message when scheduler fails to process the nodes.
2. build_scheduler.sh now runs go mod tidy before go build.