### PR TITLE
PSQLADM-402: proxysql-status - positional arguments not working anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -825,7 +825,49 @@ Simple script to dump ProxySQL config and stats
 __Usage:__
 
 ```
-proxysql-status admin admin 127.0.0.1 6032
+Usage example:
+  $ proxysql-status [options] [<USER> <PASSWORD> <HOST> <PORT>]
+
+  Options:
+    --files                 : display contents of proxysql-admin related files
+    --main                  : display main tables (both on-disk and runtime)
+    --monitor               : display monitor tables
+    --runtime               : display runtime-related data
+                              (implies --main)
+    --stats                 : display stats tables
+    --table=<table_name>    : display only tables that contain the table name
+                              (note: this is a case-sensitive match)
+    --with-stats-reset      : display _reset tables, by default _reset tables
+                              will not be queried.
+
+    --login-file=<login-file-path>
+                            : Read login credentials from an encrypted file.
+                              If the --login-password or --login-password-file
+                              options are not specified, then the user
+                              will be prompted for the password.
+                              (command line options override any login file values)
+    --login-password=<password>
+                            : The key used to decrypt the encrypted login-file.
+                              This cannot be used with --login-password-file.
+    --login-password-file=<path>
+                            : Read the key from a file using the <path>.
+                              This cannot be used with --login-password
+    --use-stdin-for-credentials
+                            : If set, then the MySQL client will use stdin to send
+                              credentials to the client (instead of process
+                              substitution).
+                              (default: process substitution is used)
+
+  The default is to display all tables and files.
+
+  If no credentials are specified (on the command line or via a login-file) then:
+    1. The default MySQL client credentials are used (usually found
+       in ~/.my.cnf), if they connect to a ProxySQL instance).
+    2. If the default MySQL client credentials do not exist, or do not connect
+       to a ProxySQL instance, then the credentials in /etc/proxysql-admin.cnf
+       are used.
+
+Example: proxysql-status admin admin 127.0.0.1 6032
 ```
 
 

--- a/proxysql-status
+++ b/proxysql-status
@@ -88,8 +88,8 @@ Usage example:
     --use-stdin-for-credentials
                             : If set, then the MySQL client will use stdin to send
                               credentials to the client (instead of process
-                              substition).
-                              (default: process subsitution is used)
+                              substitution).
+                              (default: process substitution is used)
 
   The default is to display all tables and files.
 
@@ -179,11 +179,7 @@ function parse_args() {
     if ! getopt --test; then
         go_out="$(getopt --options=hv --longoptions=runtime,main,stats,monitor,files,table:,with-stats-reset,login-file:,login-password:,login-password-file:,use-stdin-for-credentials,version,help \
         --name="$(basename "$0")" -- "$@")"
-        if [[ $? -ne 0 ]]; then
-            # no place to send output
-            echo "Script error: getopt() failed" >&2
-            exit 1
-        fi
+        check_cmd $? "$LINENO" "Script error: getopt() failed with arguments: $*"
         eval set -- "$go_out"
     fi
 
@@ -283,18 +279,6 @@ function parse_args() {
     fi
 
     if [[ $CREDENTIALS_FROM_CLIENT_CONFIG -eq 0 ]]; then
-        # If we can't use the default, get the credentials
-        # from proxysql-admin.cnf
-        if [[ ! -r /etc/proxysql-admin.cnf ]]; then
-            echo "Cannot find /etc/proxysql-admin.cnf."
-            exit 1
-        else
-            source /etc/proxysql-admin.cnf
-            USER=$PROXYSQL_USERNAME
-            PASSWORD=$PROXYSQL_PASSWORD
-            HOST=$PROXYSQL_HOSTNAME
-            PORT=$PROXYSQL_PORT
-        fi
 
         # Load the data if the login-file has been set
         # Run this before the command-line parsing, so that the command-line
@@ -329,21 +313,35 @@ function parse_args() {
             [[ -n $PROXYSQL_PASSWORD ]] && PASSWORD=$PROXYSQL_PASSWORD;
             [[ -n $PROXYSQL_HOSTNAME ]] && HOST=$PROXYSQL_HOSTNAME;
             [[ -n $PROXYSQL_PORT ]] && PORT=$PROXYSQL_PORT;
-        fi
 
-        # Now override any values with the command-line args
-        if [[ $# -gt 0 && $# -le 4 ]]; then
-            [[ -n ${1+} ]] && USER=$1
-            [[ -n ${2+} ]] && PASSWORD=$2
-            [[ -n ${3+} ]] && HOST=$3
-            [[ -n ${4+} ]] && PORT=$4
-        elif [[ $# -ge 5 ]]; then
-            error "$LINENO" "Incorrect usage"
+        elif [[ $# -eq 0 ]]; then
+            # When no arguments are passed try to read from /etc/proxysql-admin.cnf
+            if [[ ! -r /etc/proxysql-admin.cnf ]]; then
+                error $LINENO "Cannot find /etc/proxysql-admin.cnf to read the credentials." \
+                    "\nYou can either consider creating the cnf file or pass the credentials through command-line in the format <USER> <PASSWORD> <HOST> <PORT>"
+                exit 1
+            else
+                source /etc/proxysql-admin.cnf
+                USER=$PROXYSQL_USERNAME
+                PASSWORD=$PROXYSQL_PASSWORD
+                HOST=$PROXYSQL_HOSTNAME
+                PORT=$PROXYSQL_PORT
+            fi
+            
+        elif [[ $# -ne 4 ]]; then
+            error "$LINENO" "Incorrect usage: Please use the format <USER> <PASSWORD> <HOST> <PORT>"
             usage
             exit 1
+        else
+            [ -n ${1+} ] && USER=$1
+            [ -n ${2+} ] && PASSWORD=$2
+            [ -n ${3+} ] && HOST=$3
+            [ -n ${4+} ] && PORT=$4
         fi
 
+
         if [[ -z $USER || -z $PASSWORD || -z $HOST || -z $PORT ]]; then
+
             error "$LINENO" "One of the user, password, host, or port parameterd is missing."
             exit 1
         fi


### PR DESCRIPTION
https://jira.percona.com/browse/PSQLADM-402

Allow the proxysql-status script to be called without having a
requirement to pass the cnf file. With this change, the users shall be
able to query proxysql by just running

`$ proxysql-status USER PASSWORD HOST PORT`

As per the new logic, the following user visible changes have been done.

-  When none of the options are passed, the script will try to read the
   credentials in the order

   1. File pointed by --log-file, if passed
   2. /etc/proxysql-admin.cnf, error if not present
   3. Positional parameters passed through command-line

-  When credentials are passed in the command line in the format
   <USER> <PASSWORD> <HOST> <PORT>, then it uses the command line
   arguments to connect to proxysql server.