### PR TITLE
PSQLADM-501 - Fixing the --syncusers to filter all users from admin-admin_credentials

### DIFF
--- a/proxysql-admin-common
+++ b/proxysql-admin-common
@@ -745,6 +745,7 @@ function proxysql_admin_user_check(){
                             "select variable_value
                              from global_variables
                              where variable_name like 'admin-%_credentials'" |
+			      sed 's/;/\n/g'|
                               cut -d':' -f1 |
                               grep -v variable_value))
   if [[ " ${proxysql_admin_users[@]} " =~ [[:space:]]${userchk}[[:space:]] ]]; then


### PR DESCRIPTION
Fixing the bug reported at https://perconadev.atlassian.net/browse/PSQLADM-501.

The --syncusers flag was only considering the first user on the admin-admin_credentials, so when there is more than one, the remaining ones were added to the mysql_users table, which shouldn't happen due to the following: 

> users defined in admin-admin_credentials or admin-stats_credentials cannot be used also in mysql_users table.
[https://proxysql.com/documentation/global-variables/admin-variables](https://proxysql.com/documentation/global-variables/admin-variables/#admin-admin_credentials:~:text=users%20defined%20in%20admin%2Dadmin_credentials%20or%20admin%2Dstats_credentials%20cannot%20be%20used%20also%20in%20mysql_users%20table.)
