### PR TITLE
bump: add MariaDB 10.11 version in pattern matching

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -1459,7 +1459,7 @@ function syncusers() {
     5.7 | 8.0)
       password_field="authentication_string"
       ;;
-    10.0 | 10.1 | 10.2 | 10.3 | 10.4 | 10.5 | 10.6)
+    10.0 | 10.1 | 10.2 | 10.3 | 10.4 | 10.5 | 10.6 | 10.11)
       password_field="Password"
       ;;
      *)

--- a/proxysql-admin-common
+++ b/proxysql-admin-common
@@ -547,7 +547,7 @@ function syncusers() {
     5.7 | 8.0)
       password_field="authentication_string"
       ;;
-    10.0 | 10.1 | 10.2 | 10.3 | 10.4 | 10.5 | 10.6)
+    10.0 | 10.1 | 10.2 | 10.3 | 10.4 | 10.5 | 10.6 | 10.11)
       password_field="Password"
       ;;
      *)

--- a/proxysql-common
+++ b/proxysql-common
@@ -410,6 +410,8 @@ function get_mysql_version()
     echo "10.5"
   elif echo "$version_string" | grep -qe "[[:space:]]10\.6\."; then
     echo "10.6"
+  elif echo "$version_string" | grep -qe "[[:space:]]10\.11\."; then
+    echo "10.11"
   else
     echo "$version_string"
     return 1

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -186,6 +186,8 @@ function get_mysql_version() {
     echo "10.5"
   elif echo "$version_string" | grep -qe "[[:space:]]10\.6\."; then
     echo "10.6"
+  elif echo "$version_string" | grep -qe "[[:space:]]10\.11\."; then
+    echo "10.11"
   else
     echo "Line $LINENO: Cannot determine the MySQL version: $mysqld_version"
     echo "This script needs to be updated."


### PR DESCRIPTION
## Feature description

This adds the possibility to run proxysql-admin when the downstream database is running MariaDB 10.11. I have tested this on a non-production 10.11 instance; however, I have not conducted serious regression tests.