### PR TITLE
RM-1376: ProxySQL 2.6.2 Release

### DIFF
--- a/proxysql-admin-common
+++ b/proxysql-admin-common
@@ -663,6 +663,11 @@ function syncusers() {
 
     username=${user}
     password="${mysql_users_full_hash[${username}]}"
+
+    # Since we're using single quotes within the SQL statement, only need
+    # to escape the single quotes for SQL
+    password=${password//\'/\'\'}
+
     debug "$LINENO" "Processing MySQL user: '${username}'"
 
     # Check if the user exists in ProxySQL

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -185,7 +185,16 @@ fi
   echo "$output" >&2
   [ "$status" -eq  0 ]
 
-  [[ "${lines[2]}" =~ "Added query rule for user: test_query_rule" ]]
+  local len=${#lines[@]}
+  local pattern_found=0
+
+  for i in $(seq 0 $((len - 1))); do
+    if [[ "${lines[$i]}" =~ "Added query rule for user: test_query_rule" ]]; then
+      pattern_found=1
+    fi
+  done
+
+  [[ $pattern_found -eq 1 ]]
 
   run_write_hg_query_rule_user=$(proxysql_exec "select 1 from runtime_mysql_query_rules where username='test_query_rule' and match_digest='^SELECT.*FOR UPDATE'" | awk '{print $0}')
   echo "$LINENO : Query rule count for user 'test_query_rule' with writer hostgroup found:$run_write_hg_query_rule_user expect:1"  >&2

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -37,6 +37,10 @@ declare REPL_PASSWORD="pass1234"
 # Set this to 1 to run the tests
 declare RUN_TEST=1
 
+# Options to skip killing old mysqld and proxysql processes
+declare KILL_OLD_MYSQLD=1
+declare KILL_OLD_PROXYSQL=1
+
 # Set this to 1 to include creating and running the tests
 # for cluster 2
 declare USE_CLUSTER_TWO=1
@@ -87,6 +91,8 @@ Options:
                       left up-and-running (useful for quickly starting
                       a test environment). This requires a manual running
                       of the proxysql-admin script.
+  --no-kill-mysqld    Dont kill previous mysqld servers
+  --no-kill-proxysql  Dont kill previous proxysql servers
   --cluster-one-only  Only starts up (and runs the tests) for cluster_one.
                       May be used with --no-test to startup only one cluster.
   --ipv4              Run the tests using IPv4 addresses (default)
@@ -135,6 +141,12 @@ function parse_args() {
           ;;
         --test)
           TEST_NAMES=$value
+          ;;
+        --no-kill-mysqld)
+          KILL_OLD_MYSQLD=0
+          ;;
+        --no-kill-proxysql)
+          KILL_OLD_PROXYSQL=0
           ;;
         *)
           echo "ERROR: unknown parameter \"$param\""
@@ -559,11 +571,15 @@ fi
 declare ROOT_FS=$WORKDIR
 mkdir -p $WORKDIR/logs
 
-echo "Shutting down currently running mysqld instances"
-sudo pkill -9 -x mysqld
+if [[ $KILL_OLD_MYSQLD -eq 1 ]]; then
+  echo "Shutting down currently running mysqld instances"
+  sudo pkill -9 -x mysqld
+fi
 
-echo "Shutting down currently running proxysql instances"
-sudo pkill -9 -x proxysql
+if [[ $KILL_OLD_PROXYSQL -eq 1 ]]; then
+  echo "Shutting down currently running proxysql instances"
+  sudo pkill -9 -x proxysql
+fi
 
 #
 # Check file locations before doing anything

--- a/tests/scheduler-admin-testsuite.bats
+++ b/tests/scheduler-admin-testsuite.bats
@@ -289,7 +289,17 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --syncusers --add-query-rule
   echo "$output" >&2
   [ "$status" -eq  0 ]
-  [[ "${lines[2]}" =~ "Added query rule for user: test_query_rule" || "${lines[3]}" =~ "Added query rule for user: test_query_rule" ]]
+
+  local len=${#lines[@]}
+  local pattern_found=0
+
+  for i in $(seq 0 $((len - 1))); do
+    if [[ "${lines[$i]}" =~ "Added query rule for user: test_query_rule" ]]; then
+      pattern_found=1
+    fi
+  done
+
+  [[ $pattern_found -eq 1 ]]
 
   run_write_hg_query_rule_user=$(proxysql_exec "select 1 from runtime_mysql_query_rules where username='test_query_rule' and match_digest='^SELECT.*FOR UPDATE'" | awk '{print $0}')
   echo "$LINENO : Query rule count for user 'test_query_rule' with writer hostgroup found:$run_write_hg_query_rule_user expect:1"  >&2


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/RM-1376

***
Fix the unstable bats test.

***
This patch also introduces two new options `--no-kill-mysqld` and `--no-kill-proxysql` to proxysql-admin-testsuite.sh to skip killing of mysqld and proxysql processes before the tests are run.