### PR TITLE
[PSQLADM-564] Preserve default_schema on user re-creation

### DIFF
--- a/proxysql-admin-common
+++ b/proxysql-admin-common
@@ -625,6 +625,7 @@ function syncusers() {
   # Declare associative arrays
   declare -A mysql_users_full_hash    # Hash of MySQL users
   declare -A proxysql_users_full_hash # Hash of ProxySQL users
+  declare -A proxysql_users_default_schema # Hash of ProxySQL users
   local username password
 
   # Populate MySQL users hash
@@ -649,9 +650,12 @@ function syncusers() {
     # Extract ProxySQL username
     username=$(echo "$proxysql_user" | cut -f1)
     password=$(echo "$proxysql_user" | cut -f2)
+    default_schema=$(echo "$proxysql_user" | cut -f3)
 
     # Add ProxySQL user to hash
     proxysql_users_full_hash["${username}"]="$password"
+    # Add ProxySQL user to default_schema
+    proxysql_users_default_schema["${username}"]="$default_schema"
 
   done < <(printf "%s\n" "${proxysql_users}")
 
@@ -712,9 +716,9 @@ function syncusers() {
         echo "Adding user to ProxySQL: ${username}"
         proxysql_exec "$LINENO" \
           "INSERT INTO mysql_users
-           (username, password, active, default_hostgroup)
+           (username, password, active, default_hostgroup, default_schema)
            VALUES
-            ('${username}', UNHEX('${password}'), 1, $WRITER_HOSTGROUP_ID)"
+            ('${username}', UNHEX('${password}'), 1, $WRITER_HOSTGROUP_ID, '${proxysql_users_default_schema[${username}]}')"
         check_cmd $? "$LINENO" "Failed to add the user (${username}) from PXC to ProxySQL database."\
                              "\n-- Please check the ProxySQL connection parameters and status."
         if [[ $ADD_QUERY_RULE -eq 1 ]];then
@@ -791,7 +795,7 @@ function syncusers() {
 function get_proxysql_users() {
   local proxysql_users
   proxysql_users=$(proxysql_exec "$LINENO" \
-                    "SELECT username,HEX(password)
+                    "SELECT username,HEX(password),default_schema
                       FROM mysql_users
                       WHERE password!='' AND default_hostgroup=$WRITER_HOSTGROUP_ID" "" "hide_output")
   check_cmd $? "$LINENO" "Failed to load user list from ProxySQL database."\


### PR DESCRIPTION
[PSQLADM-525](https://perconadev.atlassian.net/browse/PSQLADM-564)

The _syncusers_ function/command will delete any existing users before re-creating them if a password hash diff is detected. But the creation **does not preserve** the **default_schema** property. This property configuration must be preserved because it's not pulled from PXC.
This is especially critical for ProxySQL versions 2.6.3 and higher, due to an unrelated **bug in ProxySQL's core** that significantly impacts how default_schema is handled with caching_sha2_password (you may find my report [here](https://github.com/sysown/proxysql/issues/4936) - TD;LR: ProxySQL will break client applications if default_schema is not set).

[PSQLADM-525]: https://perconadev.atlassian.net/browse/PSQLADM-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ