### PR TITLE
PSQLADM-567 ProxySQL 3.0.1

### DIFF
--- a/proxysql-admin-common
+++ b/proxysql-admin-common
@@ -625,6 +625,7 @@ function syncusers() {
   # Declare associative arrays
   declare -A mysql_users_full_hash    # Hash of MySQL users
   declare -A proxysql_users_full_hash # Hash of ProxySQL users
+  declare -A proxysql_users_default_schema # Hash of ProxySQL users
   local username password
 
   # Populate MySQL users hash
@@ -649,9 +650,12 @@ function syncusers() {
     # Extract ProxySQL username
     username=$(echo "$proxysql_user" | cut -f1)
     password=$(echo "$proxysql_user" | cut -f2)
+    default_schema=$(echo "$proxysql_user" | cut -f3)
 
     # Add ProxySQL user to hash
     proxysql_users_full_hash["${username}"]="$password"
+    # Add ProxySQL user to default_schema
+    proxysql_users_default_schema["${username}"]="$default_schema"
 
   done < <(printf "%s\n" "${proxysql_users}")
 
@@ -712,9 +716,9 @@ function syncusers() {
         echo "Adding user to ProxySQL: ${username}"
         proxysql_exec "$LINENO" \
           "INSERT INTO mysql_users
-           (username, password, active, default_hostgroup)
+           (username, password, active, default_hostgroup, default_schema)
            VALUES
-            ('${username}', UNHEX('${password}'), 1, $WRITER_HOSTGROUP_ID)"
+            ('${username}', UNHEX('${password}'), 1, $WRITER_HOSTGROUP_ID, '${proxysql_users_default_schema[${username}]}')"
         check_cmd $? "$LINENO" "Failed to add the user (${username}) from PXC to ProxySQL database."\
                              "\n-- Please check the ProxySQL connection parameters and status."
         if [[ $ADD_QUERY_RULE -eq 1 ]];then
@@ -791,7 +795,7 @@ function syncusers() {
 function get_proxysql_users() {
   local proxysql_users
   proxysql_users=$(proxysql_exec "$LINENO" \
-                    "SELECT username,HEX(password)
+                    "SELECT username,HEX(password),default_schema
                       FROM mysql_users
                       WHERE password!='' AND default_hostgroup=$WRITER_HOSTGROUP_ID" "" "hide_output")
   check_cmd $? "$LINENO" "Failed to load user list from ProxySQL database."\

--- a/proxysql-common
+++ b/proxysql-common
@@ -47,10 +47,10 @@ fi
 #
 # Script parameters/constants
 #
-readonly    PROXYSQL_ADMIN_VERSION="2.7.3"
+readonly    PROXYSQL_ADMIN_VERSION="3.0.1"
 
 # The minimum required openssl version
-readonly    REQUIRED_OPENSSL_VERSION="1.1.1"
+readonly    REQUIRED_OPENSSL_VERSION="3.0.0"
 
 # The name of the openssl binary packaged with proxysql-admin
 readonly    PROXYSQL_ADMIN_OPENSSL_NAME="proxysql-admin-openssl"

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -249,6 +249,66 @@ fi
   [ "$cluster_user_count" -eq "$proxysql_user_count" ]
 }
 
+@test "test if default schema is preserved when password update is synced using syncusers ($WSREP_CLUSTER_NAME)" {
+  [[ -n $TEST_NAME && ! $TEST_NAME =~ user_sync_password_update ]] && skip;
+
+  local user="test_user"
+  local initial_password="InitialPass1!"
+  local updated_password="UpdatedPass2!"
+  local default_schema="test_schema"
+
+  # Step 1: Create the user in MySQL
+  echo "$LINENO: Creating user '$user' in MySQL" >&2
+  mysql_exec "$HOST_IP" "$PORT_3" "CREATE USER '$user'@'%' IDENTIFIED WITH mysql_native_password BY '$initial_password';"
+  mysql_exec "$HOST_IP" "$PORT_3" "GRANT ALL PRIVILEGES ON *.* TO '$user'@'%';"
+  sleep 3  # Allow replication
+
+  # Verify the user exists in MySQL
+  mysql_user_count=$(mysql_exec "$HOST_IP" "$PORT_1" "SELECT COUNT(*) FROM mysql.user WHERE user='$user';")
+  echo "$LINENO: MySQL user count for '$user': $mysql_user_count" >&2
+  [[ $mysql_user_count -eq 1 ]]
+
+  # Step 2: Sync the user to ProxySQL
+  echo "$LINENO: Syncing user '$user' to ProxySQL" >&2
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --syncusers
+  echo "$output" >&2
+  [ "$status" -eq 0 ]
+
+  # Verify the user exists in ProxySQL (runtime_mysql_users table)
+  proxysql_user_count=$(proxysql_exec "SELECT COUNT(*) FROM runtime_mysql_users WHERE username='$user'" | awk '{print $0}')
+  echo "$LINENO: ProxySQL user count for '$user': $proxysql_user_count" >&2
+  [[ $proxysql_user_count -ne 0 ]]
+
+  # Step 3: Add a default schema in ProxySQL
+  echo "$LINENO: Adding default schema '$default_schema' for user '$user' in ProxySQL" >&2
+  proxysql_exec "UPDATE mysql_users SET default_schema='$default_schema' WHERE username='$user'; LOAD MYSQL USERS TO RUNTIME;"
+  proxysql_schema=$(proxysql_exec "SELECT default_schema FROM runtime_mysql_users WHERE username='$user'" | awk 'NR==1 {print $1}')
+  echo "$LINENO: ProxySQL default schema for '$user': $proxysql_schema and actual $default_schema: $default_schema" >&2
+  [[ "$proxysql_schema" == "$default_schema" ]]
+
+  # Step 4: Update the user's password in MySQL
+  echo "$LINENO: Updating password for user '$user' in MySQL" >&2
+  mysql_exec "$HOST_IP" "$PORT_3" "ALTER USER '$user'@'%' IDENTIFIED BY '$updated_password';"
+  sleep 3  # Allow replication
+
+  # Step 5: Sync the updated password to ProxySQL
+  echo "$LINENO: Syncing updated password for user '$user' to ProxySQL" >&2
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --syncusers
+  echo "$output" >&2
+  [ "$status" -eq 0 ]
+
+  # Verify the default schema property remains unchanged
+  proxysql_exec "LOAD MYSQL USERS TO RUNTIME;"
+  proxysql_schema_after_update=$(proxysql_exec "SELECT default_schema FROM mysql_users WHERE username='$user'" | awk 'NR==1 {print $1}')
+  echo "$LINENO: ProxySQL default schema for '$user' after password update: $proxysql_schema_after_update" >&2
+  [[ "$proxysql_schema_after_update" == "$default_schema" ]]
+
+  # Cleanup: Remove the user from MySQL and ProxySQL
+  echo "$LINENO: Cleaning up user '$user'" >&2
+  mysql_exec "$HOST_IP" "$PORT_3" "DROP USER '$user'@'%';"
+  proxysql_exec "DELETE FROM mysql_users WHERE username='$user'; LOAD MYSQL USERS TO RUNTIME;"
+}
+
 @test "run proxysql-admin --syncusers --server ($WSREP_CLUSTER_NAME) (many users)" {
   [[ -n $TEST_NAME && ! $TEST_NAME =~ syncusers_big ]] && skip;
 

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -392,8 +392,8 @@ fi
   time_taken=$((end_time - start_time))
 
   # Expected time to process 1000 users is about 25 seconds.
-  # For this test, lets assume that it takes less than a minute.
-  [[ $time_taken -le 60 ]]
+  # For this test, lets assume that it takes less than 3 minutes.
+  [[ $time_taken -le 150 ]]
 
   # Verify that the user has been removed from ProxySQL
   proxysql_count=$(proxysql_exec "select count(distinct username) from mysql_users where username like 'a - %'")


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PSQLADM-567

- Bump the admin scripts version to '3.0.1'
- Bump the minimum required openssl version to '3.0.0'
- Increase the testcase timeout for sync users from 60 to 150 seconds.
- PSQLADM-564 Preserves default_schema on user re-creation with --syncusers.