### PR TITLE
PSQLADM-584 ProxySQL 3.0.6

### DIFF
--- a/proxysql-admin
+++ b/proxysql-admin
@@ -1995,6 +1995,21 @@ function parse_args() {
 
         # shellcheck disable=SC1090
         source "$CONFIG_FILE"
+        check_cmd $? "$LINENO" "Failed to source config file: $CONFIG_FILE"
+    fi
+  else
+    debug "$LINENO" "Skipping loading of config file since --quick-demo is set"
+
+    # quick-demo: only load PROXYSQL_DATADIR from config
+    local datadir_line datadir_value
+    datadir_line=$(grep -E '^[[:space:]]*export[[:space:]]+PROXYSQL_DATADIR=' "$CONFIG_FILE" | tail -n1 || true)
+    if [[ -n "$datadir_line" ]]; then
+      datadir_value=${datadir_line#*=}
+      datadir_value=${datadir_value%\"}
+      datadir_value=${datadir_value#\"}
+      datadir_value=${datadir_value%\'}
+      datadir_value=${datadir_value#\'}
+      PROXYSQL_DATADIR="$datadir_value"
     fi
   fi
 

--- a/proxysql-common
+++ b/proxysql-common
@@ -47,7 +47,7 @@ fi
 #
 # Script parameters/constants
 #
-readonly    PROXYSQL_ADMIN_VERSION="3.0.1"
+readonly    PROXYSQL_ADMIN_VERSION="3.0.6"
 
 # The minimum required openssl version
 readonly    REQUIRED_OPENSSL_VERSION="3.0.0"

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -479,6 +479,7 @@ fi
   # Cleaning existing configuration to test --force option as normal run
   dump_runtime_nodes $LINENO "before disable"
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  [ "$status" -eq 0 ]
 
   dump_runtime_nodes $LINENO "before enable --force"
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin  --enable --force <<< n
@@ -568,6 +569,8 @@ fi
   [[ -n $TEST_NAME && ! $TEST_NAME =~ parameters ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  [ "$status" -eq 0 ]
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable \
     --max-connections=111 \
     --node-check-interval=11200 \
@@ -616,6 +619,7 @@ fi
   [[ -n $TEST_NAME && ! $TEST_NAME =~ writers_are_readers_basic ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
   # Use default value for --writers-are-readers
@@ -664,7 +668,7 @@ fi
 
   # backup writer count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $BACKUP_WRITER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : backup writer count:$proxysql_cluster_count expected:1"  >&2
+  echo "$LINENO : backup writer count:$proxysql_cluster_count expected:2"  >&2
   [ "$proxysql_cluster_count" -eq 2 ]
 
 
@@ -685,12 +689,12 @@ fi
 
   # reader count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$proxysql_cluster_count expected:3" >&2
+  echo "$LINENO : reader count:$proxysql_cluster_count expected:0" >&2
   [ "$proxysql_cluster_count" -eq 0 ]
 
   # backup writer count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $BACKUP_WRITER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : backup writer count:$proxysql_cluster_count expected:1"  >&2
+  echo "$LINENO : backup writer count:$proxysql_cluster_count expected:2"  >&2
   [ "$proxysql_cluster_count" -eq 2 ]
 
 
@@ -711,12 +715,12 @@ fi
 
   # reader count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$proxysql_cluster_count expected:3" >&2
+  echo "$LINENO : reader count:$proxysql_cluster_count expected:2" >&2
   [ "$proxysql_cluster_count" -eq 2 ]
 
   # backup writer count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $BACKUP_WRITER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : backup writer count:$proxysql_cluster_count expected:1"  >&2
+  echo "$LINENO : backup writer count:$proxysql_cluster_count expected:2"  >&2
   [ "$proxysql_cluster_count" -eq 2 ]
 
 }
@@ -726,6 +730,7 @@ fi
   [[ -n $TEST_NAME && ! $TEST_NAME =~ writes_are_readers_read_only ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
   # change node3 to be a read-only node
@@ -786,7 +791,7 @@ fi
 
   # reader count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$proxysql_cluster_count expected:3" >&2
+  echo "$LINENO : reader count:$proxysql_cluster_count expected:1" >&2
   [ "$proxysql_cluster_count" -eq 1 ]
 
   # backup writer count
@@ -822,6 +827,7 @@ fi
   [[ -n $TEST_NAME && ! $TEST_NAME =~ loadbal_basic ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  [ "$status" -eq 0 ]
 
   echo "$LINENO : proxysql-admin --enable --mode=loadbal" >&2
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --enable --mode=loadbal <<< 'n'
@@ -897,6 +903,7 @@ fi
   [[ -n $TEST_NAME && ! $TEST_NAME =~ loadbal_read_only ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
   # change node3 to be a read-only node
@@ -911,17 +918,17 @@ fi
 
    # writer count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID and status != 'SHUNNED'" | awk '{print $0}')
-  echo "$LINENO : writer count:$proxysql_cluster_count expected:1" >&2
+  echo "$LINENO : writer count:$proxysql_cluster_count expected:2" >&2
   [ "$proxysql_cluster_count" -eq 2 ]
 
   # reader count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$proxysql_cluster_count expected:3" >&2
+  echo "$LINENO : reader count:$proxysql_cluster_count expected:1" >&2
   [ "$proxysql_cluster_count" -eq 1 ]
 
   # backup writer count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $BACKUP_WRITER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : backup writer count:$proxysql_cluster_count expected:1"  >&2
+  echo "$LINENO : backup writer count:$proxysql_cluster_count expected:0"  >&2
   [ "$proxysql_cluster_count" -eq 0 ]
 
 
@@ -939,6 +946,7 @@ fi
   [[ -n $TEST_NAME && ! $TEST_NAME =~ singlewrite_write_node ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
   echo "$LINENO : proxysql-admin --enable --write-node=${HOST_IP}:${PORT_2}" >&2
@@ -954,12 +962,12 @@ fi
 
   # reader count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$proxysql_cluster_count expected:3" >&2
+  echo "$LINENO : reader count:$proxysql_cluster_count expected:2" >&2
   [ "$proxysql_cluster_count" -eq 2 ]
 
   # backup writer count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $BACKUP_WRITER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : backup writer count:$proxysql_cluster_count expected:1"  >&2
+  echo "$LINENO : backup writer count:$proxysql_cluster_count expected:2"  >&2
   [ "$proxysql_cluster_count" -eq 2 ]
 
   dump_runtime_nodes $LINENO "after write node"
@@ -982,6 +990,7 @@ fi
   [[ -n $TEST_NAME && ! $TEST_NAME =~ singlewrite_read_only ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
   # change node3 to be a read-only node
@@ -1014,6 +1023,7 @@ fi
   [[ -n $TEST_NAME && ! $TEST_NAME =~ singlewrite_read_only ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
   # change node3 to be a read-only node
@@ -1040,6 +1050,7 @@ fi
   [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_basic ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  [ "$status" -eq 0 ]
 
   # Stop node3
   # store startup values
@@ -1146,6 +1157,7 @@ fi
   [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_enable ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --disable
+  [ "$status" -eq 0 ]
 
   # Stop node3
   # store startup values

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -688,13 +688,6 @@ echo "....Found the my_print_defaults in $PXC_BASEDIR/bin"
 
 echo "Starting ProxySQL..."
 rm -rf $WORKDIR/proxysql_db; mkdir $WORKDIR/proxysql_db
-if [[ ! -r /etc/proxysql.cnf ]]; then
-  echo "ERROR! This user($(whoami)) needs read permissions on /etc/proxysql.cnf"
-  echo "something like: 'sudo chmod +r /etc/proxysl.cnf' needs to be run"
-  echo "proxysql is started as this user and reads the cnf file"
-  echo "This is for TEST purposes and should not be done in PRODUCTION."
-  exit 1
-fi
 
 if [[ ! -x $PROXYSQL_BASE/usr/bin/proxysql ]]; then
   echo "ERROR! Could not find proxysql executable : $PROXYSQL_BASE/usr/bin/proxysql"
@@ -703,9 +696,9 @@ fi
 
 echo "Removing the previous proxysql logs"
 rm -f $WORKDIR/proxysql_db/proxysql.log
-$PROXYSQL_BASE/usr/bin/proxysql -D $WORKDIR/proxysql_db $PROXYSQL_EXTRA_OPTIONS --foreground > $WORKDIR/proxysql_db/proxysql.log 2>&1 &
-echo "....ProxySQL started. Redirecting the logs to $WORKDIR/proxysql_db/proxysql.log"
-
+export PROXYSQL_DATADIR="$WORKDIR/proxysql_db"
+$PROXYSQL_BASE/usr/bin/proxysql -D $PROXYSQL_DATADIR $PROXYSQL_EXTRA_OPTIONS --foreground > $PROXYSQL_DATADIR/proxysql.log 2>&1 &
+echo "....ProxySQL started. Redirecting the logs to $PROXYSQL_DATADIR/proxysql.log"
 
 echo "Creating link: $WORKDIR/pxc-bin --> $PXC_BASEDIR"
 rm -f $WORKDIR/pxc-bin
@@ -810,7 +803,7 @@ if [[ ! -r $PROXYSQL_BASE/etc/proxysql-admin.cnf ]]; then
 fi
 sudo cp $PROXYSQL_BASE/etc/proxysql-admin.cnf /etc/proxysql-admin.cnf
 sudo chown $OS_USER:$OS_USER /etc/proxysql-admin.cnf
-sudo sed -i "s|\/var\/lib\/proxysql|$PROXYSQL_BASE|" /etc/proxysql-admin.cnf
+sudo sed -i "s|\/var\/lib\/proxysql|$PROXYSQL_DATADIR|" /etc/proxysql-admin.cnf
 
 if [[ ! -e $(sudo which bats 2> /dev/null) ]] ;then
   pushd $ROOT_FS

--- a/tests/scheduler-admin-testsuite.bats
+++ b/tests/scheduler-admin-testsuite.bats
@@ -200,27 +200,27 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$node_count expected:1" >&2
+  echo "$LINENO : reader count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # writer config
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_CONFIG_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : writer config count:$node_count expected:1" >&2
+  echo "$LINENO : writer config count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # reader config
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_CONFIG_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader config count:$node_count expected:1" >&2
+  echo "$LINENO : reader config count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # writer maint
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_MAINT_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : writer maint count:$node_count expected:1" >&2
+  echo "$LINENO : writer maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
   # reader maint
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_MAINT_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader maint count:$node_count expected:1" >&2
+  echo "$LINENO : reader maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --is-enabled <<< 'n'
@@ -422,6 +422,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   # Cleaning existing configuration to test --force option as normal run
   dump_runtime_nodes $LINENO "before disable"
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
 
   dump_runtime_nodes $LINENO "before enable --force"
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml  --enable --force <<< n
@@ -441,27 +442,27 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$node_count expected:2" >&2
+  echo "$LINENO : reader count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # writer config
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_CONFIG_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : writer config count:$node_count expected:1" >&2
+  echo "$LINENO : writer config count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # reader config
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_CONFIG_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader config count:$node_count expected:1" >&2
+  echo "$LINENO : reader config count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # writer maint
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_MAINT_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : writer maint count:$node_count expected:1" >&2
+  echo "$LINENO : writer maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
   # reader maint
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_MAINT_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader maint count:$node_count expected:1" >&2
+  echo "$LINENO : reader maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
   # Run 'percona-scheduler-admin --enable --force' without removing existing configuration
@@ -482,27 +483,27 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$node_count expected:2" >&2
+  echo "$LINENO : reader count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # writer config
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_CONFIG_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : writer config count:$node_count expected:1" >&2
+  echo "$LINENO : writer config count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # reader config
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_CONFIG_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader config count:$node_count expected:1" >&2
+  echo "$LINENO : reader config count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # writer maint
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_MAINT_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : writer maint count:$node_count expected:1" >&2
+  echo "$LINENO : writer maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
   # reader maint
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_MAINT_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader maint count:$node_count expected:1" >&2
+  echo "$LINENO : reader maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
   # Check percona-scheduler-admin run status without --force option
@@ -529,27 +530,27 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$node_count expected:2" >&2
+  echo "$LINENO : reader count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
   
   # writer config
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_CONFIG_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : writer config count:$node_count expected:1" >&2
+  echo "$LINENO : writer config count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # reader config
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_CONFIG_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader config count:$node_count expected:1" >&2
+  echo "$LINENO : reader config count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # writer maint
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_MAINT_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : writer maint count:$node_count expected:1" >&2
+  echo "$LINENO : writer maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
   # reader maint
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_MAINT_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader maint count:$node_count expected:1" >&2
+  echo "$LINENO : reader maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
 }
@@ -559,6 +560,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $TEST_NAME && ! $TEST_NAME =~ writers_are_readers_basic ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
   # Use default value for --writers-are-readers (default is 1 or yes)
@@ -575,7 +577,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$node_count expected:2" >&2
+  echo "$LINENO : reader count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
 
@@ -600,15 +602,19 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$node_count expected:3" >&2
+  echo "$LINENO : reader count:$node_count expected:2" >&2
   [ "$node_count" -eq 2 ]
 
 
   # restore the system
-  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=1|" testsuite.toml
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
+
+  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=1|" testsuite.toml
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable <<< 'n'
   [ "$status" -eq 0 ]
+
   sleep 5
 
 }
@@ -618,6 +624,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $TEST_NAME && ! $TEST_NAME =~ writes_are_readers_read_only ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
   # change node3 to be a read-only node
@@ -665,7 +672,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$proxysql_cluster_count expected:3" >&2
+  echo "$LINENO : reader count:$proxysql_cluster_count expected:2" >&2
   [ "$proxysql_cluster_count" -eq 2 ]
 
 
@@ -676,8 +683,11 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [ "$?" -eq 0 ]
 
   # restore the system
-  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=1|" testsuite.toml
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
+
+  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=1|" testsuite.toml
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable <<< 'n'
   [ "$status" -eq 0 ]
   sleep 5
@@ -691,6 +701,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $TEST_NAME && ! $TEST_NAME =~ loadbal_basic ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
 
   sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=0|" testsuite.toml
   sudo sed -i "0,/^[ \t]*singlePrimary[ \t]*=.*$/s|^[ \t]*singlePrimary[ \t]*=.*$|singlePrimary=false|" testsuite.toml
@@ -708,14 +719,17 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$proxysql_cluster_count expected:0" >&2
+  echo "$LINENO : reader count:$proxysql_cluster_count expected:3" >&2
   [ "$proxysql_cluster_count" -eq 3 ]
 
   # Reset the system
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
+
   sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=1|" testsuite.toml
   sudo sed -i "0,/^[ \t]*singlePrimary[ \t]*=.*$/s|^[ \t]*singlePrimary[ \t]*=.*$|singlePrimary=true|" testsuite.toml
   sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|maxNumWriters=1|" testsuite.toml
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable <<< 'n'
   [ "$status" -eq 0 ]
   sleep 5
@@ -727,6 +741,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_basic ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
 
   # Stop node3
   # store startup values
@@ -756,7 +771,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$proxysql_cluster_count expected:1" >&2
+  echo "$LINENO : reader count:$proxysql_cluster_count expected:2" >&2
   [ "$proxysql_cluster_count" -eq 2 ]
 
   # Start node3
@@ -785,7 +800,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   proxysql_cluster_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$proxysql_cluster_count expected:2" >&2
+  echo "$LINENO : reader count:$proxysql_cluster_count expected:3" >&2
   [ "$proxysql_cluster_count" -eq 3 ]
 
 }
@@ -795,6 +810,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_enable ]] && skip;
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
 
   # Stop node3
   # store startup values
@@ -828,7 +844,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$node_count expected:1" >&2
+  echo "$LINENO : reader count:$node_count expected:2" >&2
   [ "$node_count" -eq 2 ]
 
   # Start node3
@@ -853,7 +869,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$node_count expected:2" >&2
+  echo "$LINENO : reader count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
   
 }
@@ -938,27 +954,27 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # reader count
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader count:$node_count expected:1" >&2
+  echo "$LINENO : reader count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # writer config
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_CONFIG_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : writer config count:$node_count expected:1" >&2
+  echo "$LINENO : writer config count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # reader config
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_CONFIG_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader config count:$node_count expected:1" >&2
+  echo "$LINENO : reader config count:$node_count expected:3" >&2
   [ "$node_count" -eq 3 ]
 
   # writer maint
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_MAINT_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : writer maint count:$node_count expected:1" >&2
+  echo "$LINENO : writer maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
   # reader maint
   node_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $READER_MAINT_HOSTGROUP_ID " | awk '{print $0}')
-  echo "$LINENO : reader maint count:$node_count expected:1" >&2
+  echo "$LINENO : reader maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --is-enabled <<< 'n'
@@ -1048,31 +1064,37 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # Test with PORT_1
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable --write-node="$HOST_IP:$PORT_1"
+  [ "$status" -eq 0 ]
   writer_node=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
   writer_weight=$(proxysql_exec "select weight from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
 
-  [ $writer_weight -eq 1000000 ]
+  [ "$writer_weight" -eq 1000000 ]
   [ "$writer_node" -eq "$PORT_1" ]
   [ "$status" -eq 0 ]
 
   # Test with PORT_2
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable --write-node="$HOST_IP:$PORT_2"
+  [ "$status" -eq 0 ]
   writer_node=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
   writer_weight=$(proxysql_exec "select weight from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
 
-  [ $writer_weight -eq 1000000 ]
+  [ "$writer_weight" -eq 1000000 ]
   [ "$writer_node" -eq "$PORT_2" ]
   [ "$status" -eq 0 ]
 
   # Test with PORT_3
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable --write-node="$HOST_IP:$PORT_3"
+  [ "$status" -eq 0 ]
   writer_node=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
   writer_weight=$(proxysql_exec "select weight from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
 
-  [ $writer_weight -eq 1000000 ]
+  [ "$writer_weight" -eq 1000000 ]
   [ "$writer_node" -eq "$PORT_3" ]
   [ "$status" -eq 0 ]
 
@@ -1085,7 +1107,8 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $TEST_NAME && ! $TEST_NAME =~ singlewrite_read_only ]] && skip;
 
   # Disable
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
   # change node3 to be a read-only node


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PSQLADM-584

- Bump admin script version from 3.0.1 to 3.0.6.
- Add error checking after sourcing the config file in normal mode.
- In quick-demo mode, skip full config sourcing and extract only PROXYSQL_DATADIR from the config file.
- Remove the unnecessary hard dependency on readable /etc/proxysql.cnf in test setup.
- Start ProxySQL in tests using an explicit PROXYSQL_DATADIR and update proxysql-admin.cnf replacement to use that runtime datadir.
- Add explicit status checks after disable/enable calls to fail fast on setup errors.
- Correct expected node-count messages and assertions to match current runtime behavior.
- Fix reset ordering in config-mutation scenarios by disabling first, then updating config, then re-enabling.
- Ensure disable calls consistently include the scheduler config file where required.