### PR TITLE
PSQLADM-598: ProxySQL v3.0.9 release

### DIFF
--- a/percona-scheduler-admin
+++ b/percona-scheduler-admin
@@ -358,7 +358,7 @@ function exec_sql() {
   local more_options=""
   local retvalue
   local retoutput
-  local default_auth=""
+  local auth_option=""
   local defaults=""
 
   if [[ $# -ge 7 ]]; then
@@ -370,10 +370,7 @@ function exec_sql() {
   fi
 
   debug "$lineno" "exec_sql : $user@$hostname:$port ==> $query"
-
-  if [[ $MYSQL_CLIENT_VERSION == "8.0" ]]; then
-    default_auth="default-auth=mysql_native_password"
-  fi
+  auth_option="default-auth=${AUTH_PLUGIN}"
 
   defaults=$(printf '[client]\nuser=%s\npassword="%s"\nhost=%s\nport=%s\nconnect-timeout=%s\n%s' \
     "${user}" \
@@ -381,7 +378,7 @@ function exec_sql() {
     "${hostname}" \
     "${port}" \
     "${TIMEOUT}" \
-    "${default_auth}"
+    "${auth_option}"
   )
 
   if [[ $USE_STDIN_FOR_CREDENTIALS -eq 1 ]]; then
@@ -692,7 +689,7 @@ function user_input_check() {
                            "\n-- Please check the ProxySQL connection parameters and status."
 
       if [[ -z "$precheck_user" ]]; then
-        mysql_exec "$LINENO" "CREATE USER '$safe_username'@'$USER_HOST_RANGE' IDENTIFIED WITH mysql_native_password BY '$safe_password';"
+        mysql_exec "$LINENO" "CREATE USER '$safe_username'@'$USER_HOST_RANGE' IDENTIFIED WITH ${AUTH_PLUGIN} BY '$safe_password';"
         check_cmd $? "$LINENO" "Failed to add the PXC application user to PXC: $username" \
                              "\n-- Please check if '$CLUSTER_USERNAME'@'$CLUSTER_HOSTNAME' has the proper permissions to create the montioring user"
 
@@ -1174,7 +1171,7 @@ function enable_proxysql() {
                        "\n-- Please check the PXC cluster connection parameters and status."
   if [[ -z "$check_user" ]]; then
     # No monitor user found in MySQL, create the monitor user
-    mysql_exec "$LINENO" "CREATE USER '$SAFE_MONITOR_USERNAME'@'$USER_HOST_RANGE' IDENTIFIED WITH mysql_native_password BY '$SAFE_MONITOR_PASSWORD';"
+    mysql_exec "$LINENO" "CREATE USER '$SAFE_MONITOR_USERNAME'@'$USER_HOST_RANGE' IDENTIFIED WITH ${AUTH_PLUGIN} BY '$SAFE_MONITOR_PASSWORD';"
     check_cmd $? "$LINENO"  "Failed to create the ProxySQL monitoring user."\
                           "\n-- Please check that '$CLUSTER_USERNAME'@'$CLUSTER_HOSTNAME' has the proper permissions to create the montioring user"
   fi

--- a/proxysql-admin
+++ b/proxysql-admin
@@ -525,7 +525,7 @@ function user_input_check() {
                            "\n-- Please check the ProxySQL connection parameters and status."
 
       if [[ -z "$precheck_user" ]]; then
-        mysql_exec "$LINENO" "CREATE USER '$safe_username'@'$USER_HOST_RANGE' IDENTIFIED WITH mysql_native_password BY '$safe_password';"
+        mysql_exec "$LINENO" "CREATE USER '$safe_username'@'$USER_HOST_RANGE' IDENTIFIED WITH ${AUTH_PLUGIN} BY '$safe_password';"
         check_cmd $? "$LINENO" "Failed to add the PXC application user to PXC: $username" \
                              "\n-- Please check if '$CLUSTER_USERNAME'@'$CLUSTER_HOSTNAME' has the proper permissions to create the montioring user"
 
@@ -901,7 +901,7 @@ function enable_proxysql() {
                        "\n-- Please check the PXC cluster connection parameters and status."
   if [[ -z "$check_user" ]]; then
     # No monitor user found in MySQL, create the monitor user
-    mysql_exec "$LINENO" "CREATE USER '$SAFE_MONITOR_USERNAME'@'$USER_HOST_RANGE' IDENTIFIED WITH mysql_native_password BY '$SAFE_MONITOR_PASSWORD';"
+    mysql_exec "$LINENO" "CREATE USER '$SAFE_MONITOR_USERNAME'@'$USER_HOST_RANGE' IDENTIFIED WITH ${AUTH_PLUGIN} BY '$SAFE_MONITOR_PASSWORD';"
     check_cmd $? "$LINENO"  "Failed to create the ProxySQL monitoring user."\
                           "\n-- Please check that '$CLUSTER_USERNAME'@'$CLUSTER_HOSTNAME' has the proper permissions to create the montioring user"
 
@@ -2422,6 +2422,13 @@ function parse_args() {
     error "" "Unable to set the writers-are-readers option"
     exit 1
   fi
+
+  if [[ $AUTH_PLUGIN != "caching_sha2_password" && $AUTH_PLUGIN != "mysql_native_password" ]]; then
+    error "" "Invalid AUTH_PLUGIN value: '$AUTH_PLUGIN'"
+    echo "Please use one of these values: 'caching_sha2_password', 'mysql_native_password'"
+    exit 1
+  fi
+  readonly AUTH_PLUGIN
 
   if [[ $NEEDS_WRITER_HOSTGROUP -eq 1 ]]; then
     if [[ -z $WRITER_HOSTGROUP_ID || $WRITER_HOSTGROUP_ID -eq -1 ]]; then

--- a/proxysql-admin-common
+++ b/proxysql-admin-common
@@ -70,7 +70,7 @@ function exec_sql() {
   local more_options=""
   local retvalue
   local retoutput
-  local default_auth=""
+  local auth_option=""
   local defaults=""
 
   if [[ $# -ge 7 ]]; then
@@ -84,7 +84,7 @@ function exec_sql() {
   debug "$lineno" "exec_sql : $user@$hostname:$port ==> $query"
 
   if [[ $MYSQL_CLIENT_VERSION == "8.0" ]]; then
-    default_auth="default-auth=mysql_native_password"
+    auth_option="default-auth=${AUTH_PLUGIN}"
   fi
 
   defaults=$(printf '[client]\nuser=%s\npassword="%s"\nhost=%s\nport=%s\nconnect-timeout=%s\n%s' \
@@ -93,7 +93,7 @@ function exec_sql() {
     "${hostname}" \
     "${port}" \
     "${TIMEOUT}" \
-    "${default_auth}"
+    "${auth_option}"
   )
 
   # shellcheck disable=SC2086
@@ -591,7 +591,7 @@ function syncusers() {
     5.5 | 5.6)
       password_field="Password"
       ;;
-    5.7 | 8.0 | 8.4)
+    5.7 | 8.0 | 8.4 | 9.6 | 9.7)
       password_field="authentication_string"
       ;;
     10.0 | 10.1 | 10.2 | 10.3 | 10.4 | 10.5 | 10.6 | 10.11)

--- a/proxysql-admin.cnf
+++ b/proxysql-admin.cnf
@@ -75,3 +75,9 @@ export USE_SSL='no'
 # the read hostgroup.
 #
 export WRITERS_ARE_READERS='backup'
+
+# --------------------------------
+# MySQL authentication plugin to use when creating users.
+# Valid values: 'caching_sha2_password' (default) or 'mysql_native_password'
+#
+export AUTH_PLUGIN='caching_sha2_password'

--- a/proxysql-common
+++ b/proxysql-common
@@ -47,10 +47,12 @@ fi
 #
 # Script parameters/constants
 #
-readonly    PROXYSQL_ADMIN_VERSION="3.0.6"
+readonly    PROXYSQL_ADMIN_VERSION="3.0.9"
 
 # The minimum required openssl version
 readonly    REQUIRED_OPENSSL_VERSION="3.0.0"
+
+declare    AUTH_PLUGIN="caching_sha2_password"
 
 # The name of the openssl binary packaged with proxysql-admin
 readonly    PROXYSQL_ADMIN_OPENSSL_NAME="proxysql-admin-openssl"
@@ -399,6 +401,10 @@ function get_mysql_version()
     echo "8.0"
   elif echo "$version_string" | grep -qe "[[:space:]]8\.4\."; then
     echo "8.4"
+  elif echo "$version_string" | grep -qe "[[:space:]]9\.6\."; then
+    echo "9.6"
+  elif echo "$version_string" | grep -qe "[[:space:]]9\.7\."; then
+    echo "9.7"
   elif echo "$version_string" | grep -qe "[[:space:]]10\.0\."; then
     echo "10.0"
   elif echo "$version_string" | grep -qe "[[:space:]]10\.1\."; then

--- a/proxysql-status
+++ b/proxysql-status
@@ -142,7 +142,7 @@ function mysql_exec() {
   local retvalue
   local retoutput
   local defaults=""
-  local default_auth=""
+  local auth_option=""
 
   # shellcheck disable=SC2086
   if [[ $CREDENTIALS_FROM_CLIENT_CONFIG -eq 0 ]]; then
@@ -151,7 +151,7 @@ function mysql_exec() {
       "${PASSWORD}" \
       "${HOST}" \
       "${PORT}" \
-      "${default_auth}"
+      "${auth_option}"
     )
 
     if [[ $USE_STDIN_FOR_CREDENTIALS -eq 1 ]]; then

--- a/tests/proxysql-admin-testsuite.bats
+++ b/tests/proxysql-admin-testsuite.bats
@@ -172,7 +172,7 @@ fi
   echo "$LINENO : Check query rule count for user(test_query_rule) found:$run_query_rule expect:0"  >&2
   [[ "$run_query_rule" -eq 0 ]]
 
-  mysql_exec "$HOST_IP" "$PORT_3" "create user test_query_rule@'%' identified by 'test';"
+  mysql_exec "$HOST_IP" "$PORT_3" "CREATE USER test_query_rule@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY 'test';"
   # Give the cluster some time for this to replicate
   sleep 3
 
@@ -226,20 +226,20 @@ fi
   else
     pass_field="authentication_string"
   fi
-  cluster_user_count=$(cluster_exec "select count(distinct user) from mysql.user where ${pass_field} != '' and user not in ('admin') and user not like 'mysql.%'" -Ns)
+  cluster_user_count=$(cluster_exec "select count(distinct user) from mysql.user where ${pass_field} != '' and user not in ('admin') and user not like 'mysql.%' and user not like 'percona.%'" -Ns)
 
   # HACK: this mismatch occurs because we are running the tests for cluster_two
   # right after the test for cluster_one (multi-cluster scenario), so the
   # user counts will be off (because user cluster_one will still be in proxysql users).
   if [[ $WSREP_CLUSTER_NAME == "cluster_two" ]]; then
-    proxysql_user_count=$(proxysql_exec "select count(distinct username) from runtime_mysql_users where username not in ('cluster_one')" | awk '{print $0}')
+    proxysql_user_count=$(proxysql_exec "select count(distinct username) from runtime_mysql_users where username not in ('cluster_one') and username not like 'percona.%'" | awk '{print $0}')
   else
-    proxysql_user_count=$(proxysql_exec "select count(distinct username) from runtime_mysql_users" | awk '{print $0}')
+    proxysql_user_count=$(proxysql_exec "select count(distinct username) from runtime_mysql_users where username not like 'percona.%'" | awk '{print $0}')
   fi
 
   # Dump the user lists for debugging
   echo "cluster users" >&2
-  cluster_exec "select user,host from mysql.user where ${pass_field} != '' and user not in ('admin') and user not like 'mysql.%'" >&2
+  cluster_exec "select user,host from mysql.user where ${pass_field} != '' and user not in ('admin') and user not like 'percona.%' and user not like 'mysql.%'" >&2
   echo "" >&2
   echo "proxysql users" >&2
   proxysql_exec "select * from runtime_mysql_users" "-t" >&2
@@ -259,7 +259,7 @@ fi
 
   # Step 1: Create the user in MySQL
   echo "$LINENO: Creating user '$user' in MySQL" >&2
-  mysql_exec "$HOST_IP" "$PORT_3" "CREATE USER '$user'@'%' IDENTIFIED WITH mysql_native_password BY '$initial_password';"
+  mysql_exec "$HOST_IP" "$PORT_3" "CREATE USER '$user'@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY '$initial_password';"
   mysql_exec "$HOST_IP" "$PORT_3" "GRANT ALL PRIVILEGES ON *.* TO '$user'@'%';"
   sleep 3  # Allow replication
 
@@ -319,15 +319,15 @@ fi
   else
     pass_field="authentication_string"
   fi
-  cluster_user_count=$(cluster_exec "select count(distinct user) from mysql.user where ${pass_field} != '' and user not in ('admin') and user not like 'mysql.%'" -Ns)
+  cluster_user_count=$(cluster_exec "select count(distinct user) from mysql.user where ${pass_field} != '' and user not in ('admin') and user not like 'mysql.%' and user not like 'percona.%'" -Ns)
 
   # HACK: this mismatch occurs because we are running the tests for cluster_two
   # right after the test for cluster_one (multi-cluster scenario), so the
   # user counts will be off (because user cluster_one will still be in proxysql users).
   if [[ $WSREP_CLUSTER_NAME == "cluster_two" ]]; then
-    proxysql_user_count=$(proxysql_exec "select count(distinct username) from runtime_mysql_users where username not in ('cluster_one')" | awk '{print $0}')
+    proxysql_user_count=$(proxysql_exec "select count(distinct username) from runtime_mysql_users where username not in ('cluster_one') and username not like 'percona.%'" | awk '{print $0}')
   else
-    proxysql_user_count=$(proxysql_exec "select count(distinct username) from runtime_mysql_users" | awk '{print $0}')
+    proxysql_user_count=$(proxysql_exec "select count(distinct username) from runtime_mysql_users where username not like 'percona.%'" | awk '{print $0}')
   fi
 
   # Verify that the user is not in ProxySQL
@@ -338,7 +338,7 @@ fi
   echo "Creating 1000 mysql users"
   for i in $(seq -w 1 1000)
   do
-    mysql_exec "$HOST_IP" "$PORT_3" "CREATE USER 'a - u0$i'@'%' IDENTIFIED WITH mysql_native_password BY 'Secret1!';"
+    mysql_exec "$HOST_IP" "$PORT_3" "CREATE USER 'a - u0$i'@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY 'Secret1!';"
   done
 
   # Give the cluster some time for this to replicate
@@ -359,8 +359,8 @@ fi
 
   echo "time taken: $time_taken seconds"
   # Expected time to process 1000 users is about 25 seconds.
-  # For this test, lets assume that it takes less than 2.5 minutes.
-  [[ $time_taken -le 150 ]]
+  # For this test, lets assume that it takes less than 4 minutes.
+  [[ $time_taken -le 240 ]]
 
   echo "$output" >&2
   [ "$status" -eq  0 ]
@@ -415,7 +415,7 @@ fi
   [[ $proxysql_count -eq 0 ]]
 
   # Create a user on the async node
-  mysql_exec "$HOST_IP" "$ASYNC_PORT" "CREATE USER '${server_user}'@'%' IDENTIFIED WITH mysql_native_password BY 'passwd';"
+  mysql_exec "$HOST_IP" "$ASYNC_PORT" "CREATE USER '${server_user}'@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY 'passwd';"
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --syncusers --server=${HOST_IP}:${ASYNC_PORT}
   echo "$output" >&2
@@ -444,7 +444,7 @@ fi
   [[ $proxysql_count -eq 0 ]]
 
   # Create a user on the async node
-  mysql_exec "$HOST_IP" "$ASYNC_PORT" "CREATE USER '${server_user}'@'%' IDENTIFIED WITH mysql_native_password BY 'passwd';"
+  mysql_exec "$HOST_IP" "$ASYNC_PORT" "CREATE USER '${server_user}'@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY 'passwd';"
 
   run sudo PATH=$WORKDIR:$PATH $WORKDIR/proxysql-admin --sync-multi-cluster-users --server=${HOST_IP}:${ASYNC_PORT}
   echo "$output" >&2

--- a/tests/proxysql-admin-testsuite.sh
+++ b/tests/proxysql-admin-testsuite.sh
@@ -16,6 +16,16 @@ TEST_SUITES+=("proxysql-admin-testsuite.bats")
 TEST_SUITES2=()
 TEST_SUITES2+=("scheduler-admin-testsuite.bats")
 
+# Tests to run to verify mysql_native_password auth plugin compatibility
+AUTH_COMPAT_TEST_NAMES=(
+  syncusers_big
+  syncusers_basic
+  syncusers_server
+  syncusers_multicluster_server
+  adduser
+  user_sync_password_update
+  add_query_rule
+)
 
 #
 # Variables
@@ -51,6 +61,13 @@ declare USE_IPVERSION="v4"
 declare ALLOW_SHUTDOWN="Yes"
 
 declare PROXYSQL_EXTRA_OPTIONS=""
+
+# MySQL authentication plugin; can be overridden by environment variable
+declare AUTH_PLUGIN="${AUTH_PLUGIN:-caching_sha2_password}"
+
+# Set to 1 to skip the auth plugin compatibility test pass
+# using mysql_native_password (runs by default)
+declare SKIP_AUTH_PLUGIN_COMPAT_TEST=0
 
 declare TEST_NAMES=""
 
@@ -100,6 +117,10 @@ Options:
   --proxysql-options=OPTIONS
                       Specify additional options that will be passed
                       to proxysql.
+  --skip-auth-plugin-compat-test
+                      Skip the additional test pass that verifies
+                      mysql_native_password compatibility.
+                      (default: compat test is run)
   --test=test1,test2  Specify a list of comma-separated test names to run.
 
 EOF
@@ -148,6 +169,9 @@ function parse_args() {
         --no-kill-proxysql)
           KILL_OLD_PROXYSQL=0
           ;;
+        --skip-auth-plugin-compat-test)
+          SKIP_AUTH_PLUGIN_COMPAT_TEST=1
+          ;;
         *)
           echo "ERROR: unknown parameter \"$param\""
           usage
@@ -188,6 +212,10 @@ function get_mysql_version() {
     echo "8.0"
   elif echo "$mysqld_version" | grep -qe "[[:space:]]8\.4\."; then
     echo "8.4"
+  elif echo "$mysqld_version" | grep -qe "[[:space:]]9\.6\."; then
+    echo "9.6"
+  elif echo "$mysqld_version" | grep -qe "[[:space:]]9\.7\."; then
+    echo "9.7"
   elif echo "$version_string" | grep -qe "[[:space:]]10\.1\."; then
     echo "10.1"
   elif echo "$version_string" | grep -qe "[[:space:]]10\.2\."; then
@@ -316,8 +344,12 @@ function start_pxc_node(){
   echo "log-bin" >> my.cnf
   echo "user=$OS_USER" >> my.cnf
   if compare_versions "5.6" "<" "$MYSQL_VERSION"; then
-    echo "wsrep_slave_threads=2" >> my.cnf
     echo "pxc_maint_transition_period=1" >> my.cnf
+  fi
+  if compare_versions "$MYSQL_VERSION" ">=" "8.0"; then
+    echo "wsrep_applier_threads=2" >> my.cnf
+  else
+    echo "wsrep_slave_threads=2" >> my.cnf
   fi
   if [[ $USE_IPVERSION == "v6" ]]; then
     echo "bind-address = ::" >> my.cnf
@@ -331,8 +363,9 @@ function start_pxc_node(){
     echo "log-error-verbosity=3" >> my.cnf
     echo "wsrep_sst_method=xtrabackup-v2" >> my.cnf
   fi
-  # Add 8.4+ options here
-  if compare_versions "$MYSQL_VERSION" ">=" "8.4"; then
+  # The mysql-native-password server option only exists in 8.4 and below.
+  # It was removed in MySQL 9.0 (along with the mysql_native_password plugin).
+  if compare_versions "$MYSQL_VERSION" ">=" "8.4" && compare_versions "$MYSQL_VERSION" "<" "9.0"; then
     echo "mysql-native-password=ON" >> my.cnf
   fi
 
@@ -472,8 +505,9 @@ function start_async_slave() {
   if compare_versions "$MYSQL_VERSION" ">=" "8.0"; then
     echo "log-error-verbosity=3" >> my-slave.cnf
   fi
-  # Add 8.4+ options here
-  if compare_versions "$MYSQL_VERSION" ">=" "8.4"; then
+  # The mysql-native-password server option only exists in 8.4 and below.
+  # It was removed in MySQL 9.0 (along with the mysql_native_password plugin).
+  if compare_versions "$MYSQL_VERSION" ">=" "8.4" && compare_versions "$MYSQL_VERSION" "<" "9.0"; then
     echo "mysql-native-password=ON" >> my-slave.cnf
   fi
 
@@ -694,12 +728,6 @@ if [[ ! -x $PROXYSQL_BASE/usr/bin/proxysql ]]; then
   exit 1
 fi
 
-echo "Removing the previous proxysql logs"
-rm -f $WORKDIR/proxysql_db/proxysql.log
-export PROXYSQL_DATADIR="$WORKDIR/proxysql_db"
-$PROXYSQL_BASE/usr/bin/proxysql -D $PROXYSQL_DATADIR $PROXYSQL_EXTRA_OPTIONS --foreground > $PROXYSQL_DATADIR/proxysql.log 2>&1 &
-echo "....ProxySQL started. Redirecting the logs to $PROXYSQL_DATADIR/proxysql.log"
-
 echo "Creating link: $WORKDIR/pxc-bin --> $PXC_BASEDIR"
 rm -f $WORKDIR/pxc-bin
 ln -s "$PXC_BASEDIR" "$WORKDIR/pxc-bin"
@@ -708,21 +736,37 @@ echo "Creating link: $WORKDIR/proxysql-bin --> $PROXYSQL_BASE"
 rm -f $WORKDIR/proxysql-bin
 ln -s "$PROXYSQL_BASE" "$WORKDIR/proxysql-bin"
 
-
 MYSQL_VERSION=$(get_mysql_version "${PXC_BASEDIR}/bin/mysqld")
 MYSQL_CLIENT_VERSION=$(get_mysql_version "${PXC_BASEDIR}/bin/mysql")
 
 echo "MySQL Version is $MYSQL_VERSION"
 echo "MySQL Client Version is $MYSQL_CLIENT_VERSION"
 
+if compare_versions "$MYSQL_VERSION" ">=" "9.0"; then
+  if [[ ${AUTH_PLUGIN} == "mysql_native_password" ]]; then
+    echo "ERROR: mysql_native_password plugin is not supported in MySQL 9.0 and above"
+    exit 1
+  elif [[ ${AUTH_PLUGIN} == "caching_sha2_password" ]]; then
+    echo "Using caching_sha2_password plugin for MySQL 9.0 and above"
+    echo "Creating a config file for proxysql with caching_sha2_password plugin"
+    printf "mysql_variables=\n{\n default_authentication_plugin=\"caching_sha2_password\"\n}\n" > "$PROXYSQL_BASE/etc/proxysql.cnf"
+    PROXYSQL_EXTRA_OPTIONS="--config $PROXYSQL_BASE/etc/proxysql.cnf --initial"
+  else
+    echo "ERROR: Unknown authentication plugin specified: ${AUTH_PLUGIN}"
+    exit 1
+  fi
+fi
+
+echo "Removing the previous proxysql logs"
+rm -f $WORKDIR/proxysql_db/proxysql.log
+export PROXYSQL_DATADIR="$WORKDIR/proxysql_db"
+$PROXYSQL_BASE/usr/bin/proxysql -D $PROXYSQL_DATADIR $PROXYSQL_EXTRA_OPTIONS --foreground > $PROXYSQL_DATADIR/proxysql.log 2>&1 &
+echo "....ProxySQL started. Redirecting the logs to $PROXYSQL_DATADIR/proxysql.log"
+
 echo "Initializing PXC..."
 if [[ $MYSQL_VERSION == "5.6" ]]; then
   MID="${PXC_BASEDIR}/scripts/mysql_install_db --no-defaults --basedir=${PXC_BASEDIR}"
-elif [[ $MYSQL_VERSION == "5.7" ]]; then
-  MID="${PXC_BASEDIR}/bin/mysqld --no-defaults --initialize-insecure --basedir=${PXC_BASEDIR}"
-elif [[ $MYSQL_VERSION == "8.0" ]]; then
-  MID="${PXC_BASEDIR}/bin/mysqld --no-defaults --initialize-insecure --basedir=${PXC_BASEDIR}"
-elif [[ $MYSQL_VERSION == "8.4" ]]; then
+elif [[ $MYSQL_VERSION == "5.7" || $MYSQL_VERSION == "8.0" || $MYSQL_VERSION == "8.4" || $MYSQL_VERSION == "9.6" || $MYSQL_VERSION == "9.7" ]]; then
   MID="${PXC_BASEDIR}/bin/mysqld --no-defaults --initialize-insecure --basedir=${PXC_BASEDIR}"
 else
   echo "Unknown/unexpected MySQL version: $MYSQL_VERSION"
@@ -757,9 +801,9 @@ EOF
 elif [[ $MYSQL_VERSION > "8.0" || $MYSQL_VERSION == "8.0" ]]; then
   # For 8.0+ separate out the user creation from the grant
   ${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/cluster_one1.sock <<EOF
-CREATE USER IF NOT EXISTS 'admin'@'%' IDENTIFIED WITH mysql_native_password BY 'admin';
+CREATE USER IF NOT EXISTS 'admin'@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY 'admin';
 GRANT ALL ON *.* TO admin@'%' WITH GRANT OPTION;
--- CREATE USER '${REPL_USER}'@'${LOCALHOST_NAME}' IDENTIFIED WITH mysql_native_password BY '${REPL_PASSWORD}';
+-- CREATE USER '${REPL_USER}'@'${LOCALHOST_NAME}' IDENTIFIED WITH ${AUTH_PLUGIN} BY '${REPL_PASSWORD}';
 -- GRANT REPLICATION SLAVE ON *.* TO '${REPL_USER}'@'${LOCALHOST_NAME}';
 FLUSH PRIVILEGES;
 EOF
@@ -788,7 +832,7 @@ EOF
 elif [[ $MYSQL_VERSION > "8.0" || $MYSQL_VERSION == "8.0" ]]; then
   # For 8.0+ separate out the user creation from the grant
   ${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/cluster_one_slave.sock <<EOF
-CREATE USER IF NOT EXISTS 'admin'@'%' IDENTIFIED WITH mysql_native_password BY 'admin';
+CREATE USER IF NOT EXISTS 'admin'@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY 'admin';
 GRANT ALL ON *.* TO admin@'%' WITH GRANT OPTION;
 CHANGE REPLICATION SOURCE TO SOURCE_HOST='$LOCALHOST_IP', SOURCE_PORT=4110, SOURCE_USER='${REPL_USER}', SOURCE_PASSWORD='${REPL_PASSWORD}', SOURCE_AUTO_POSITION=1 FOR CHANNEL 'source-a';
 FLUSH PRIVILEGES;
@@ -846,6 +890,9 @@ if [[ $RUN_TEST -eq 1 ]]; then
         bats $SCRIPT_DIR/scheduler-args.bats
   echo "================================================================"
   echo ""
+
+  # Disable scheduler admin after args test, since it will run in the background and interfere with the other tests
+  $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable >/dev/null 2>&1 || exit 1
 
   if [[ ${#TEST_SUITES[@]} -gt 0 ]]; then
     for test_file in ${TEST_SUITES[@]}; do
@@ -907,7 +954,7 @@ EOF
   elif [[ $MYSQL_VERSION > "8.0" || $MYSQL_VERSION == "8.0" ]]; then
     # For 8.0 separate out the user creation from the grant
     ${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/cluster_two1.sock <<EOF
-CREATE USER IF NOT EXISTS 'admin'@'%' IDENTIFIED WITH mysql_native_password BY 'admin';
+CREATE USER IF NOT EXISTS 'admin'@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY 'admin';
 GRANT ALL ON *.* TO admin@'%' WITH GRANT OPTION;
 FLUSH PRIVILEGES;
 EOF
@@ -932,7 +979,7 @@ EOF
   elif [[ $MYSQL_VERSION > "8.0" || $MYSQL_VERSION == "8.0" ]]; then
     # For 8.0 separate out the user creation from the grant
     ${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/cluster_two_slave.sock <<EOF
-CREATE USER IF NOT EXISTS 'admin'@'%' IDENTIFIED WITH mysql_native_password BY 'admin';
+CREATE USER IF NOT EXISTS 'admin'@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY 'admin';
 GRANT ALL ON *.* TO admin@'%' WITH GRANT OPTION;
 CHANGE REPLICATION SOURCE TO SOURCE_HOST='$LOCALHOST_IP', SOURCE_PORT=4210, SOURCE_USER='${REPL_USER}', SOURCE_PASSWORD='${REPL_PASSWORD}', SOURCE_AUTO_POSITION=1 FOR CHANNEL 'source-a';
 FLUSH PRIVILEGES;
@@ -982,6 +1029,45 @@ EOF
     done
     echo ""
   fi
+
+  if compare_versions "$MYSQL_VERSION" ">=" "9.0"; then
+    echo ""
+    echo "================================================================"
+    echo "Skipping auth plugin compatibility test:"
+    echo "mysql_native_password was removed in MySQL 9.0+"
+    echo "================================================================"
+    echo ""
+  elif [[ $SKIP_AUTH_PLUGIN_COMPAT_TEST -eq 0 ]]; then
+    echo ""
+    echo "================================================================"
+    echo "Auth plugin compatibility test (mysql_native_password)"
+
+    # Save the original value before switching
+    ORIG_AUTH_PLUGIN="$AUTH_PLUGIN"
+
+    AUTH_PLUGIN="mysql_native_password"
+    sudo sed -i "s|export AUTH_PLUGIN=.*|export AUTH_PLUGIN='mysql_native_password'|" /etc/proxysql-admin.cnf
+
+    sudo WORKDIR=$WORKDIR SCRIPTDIR=$SCRIPT_DIR USE_IPVERSION=$USE_IPVERSION \
+      TEST_NAME="$(IFS=,; echo "${AUTH_COMPAT_TEST_NAMES[*]}")" PATH=$PATH \
+      bats $SCRIPT_DIR/proxysql-admin-testsuite.bats
+    rc=$?
+
+    # Always restore, regardless of test outcome
+    AUTH_PLUGIN="$ORIG_AUTH_PLUGIN"
+    sudo sed -i "s|export AUTH_PLUGIN=.*|export AUTH_PLUGIN='${ORIG_AUTH_PLUGIN}'|" /etc/proxysql-admin.cnf
+
+    if [[ $rc -ne 0 ]]; then
+      echo "********************************"
+      echo "* Auth plugin compat test failed"
+      echo "* Servers will be left running for debugging."
+      echo "********************************"
+      ALLOW_SHUTDOWN="No"
+      exit 1
+    fi
+    echo "================================================================"
+    echo ""
+  fi
 fi
 
 
@@ -1023,6 +1109,15 @@ if [[ $RUN_TEST -eq 1 ]]; then
   fi
   echo "================================================================"
 
+  CLUSTER_ONE_PORT=$(${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/cluster_one1.sock -Bs -e "select @@port")
+  sudo sed -i "0,/^[ \t]*export CLUSTER_PORT[ \t]*=.*$/s|^[ \t]*export CLUSTER_PORT[ \t]*=.*$|export CLUSTER_PORT=\"$CLUSTER_ONE_PORT\"|" /etc/proxysql-admin.cnf
+  sudo sed -i "0,/^[ \t]*export CLUSTER_HOSTNAME[ \t]*=.*$/s|^[ \t]*export CLUSTER_HOSTNAME[ \t]*=.*$|export CLUSTER_HOSTNAME=\"${LOCALHOST_NAME}\"|" /etc/proxysql-admin.cnf
+  sudo sed -i "0,/^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$/s|^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$|export CLUSTER_APP_USERNAME=\"cluster_one\"|" /etc/proxysql-admin.cnf
+  sudo sed -i "0,/^[ \t]*export WRITER_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export WRITER_HOSTGROUP_ID[ \t]*=.*$|export WRITER_HOSTGROUP_ID=\"10\"|" /etc/proxysql-admin.cnf
+  sudo sed -i "0,/^[ \t]*export READER_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export READER_HOSTGROUP_ID[ \t]*=.*$|export READER_HOSTGROUP_ID=\"11\"|" /etc/proxysql-admin.cnf
+  sudo sed -i "0,/^[ \t]*export BACKUP_WRITER_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export BACKUP_WRITER_HOSTGROUP_ID[ \t]*=.*$|export BACKUP_WRITER_HOSTGROUP_ID=\"12\"|" /etc/proxysql-admin.cnf
+  sudo sed -i "0,/^[ \t]*export OFFLINE_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export OFFLINE_HOSTGROUP_ID[ \t]*=.*$|export OFFLINE_HOSTGROUP_ID=\"13\"|" /etc/proxysql-admin.cnf
+
   for test_file in ${TEST_SUITES2[@]}; do
     echo "cluster_one : $test_file"
     SECONDS=0
@@ -1055,6 +1150,23 @@ if [[ $RUN_TEST -eq 1 ]]; then
 
 
   if [[ $USE_CLUSTER_TWO -eq 1 ]]; then
+    # Switch to cluster two for the next tests
+    CLUSTER_TWO_PORT=$(${PXC_BASEDIR}/bin/mysql -uroot -S/tmp/cluster_two1.sock -Bs -e "select @@port")
+    sudo sed -i "0,/^[ \t]*export CLUSTER_PORT[ \t]*=.*$/s|^[ \t]*export CLUSTER_PORT[ \t]*=.*$|export CLUSTER_PORT=\"$CLUSTER_TWO_PORT\"|" /etc/proxysql-admin.cnf
+    sudo sed -i "0,/^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$/s|^[ \t]*export CLUSTER_APP_USERNAME[ \t]*=.*$|export CLUSTER_APP_USERNAME=\"cluster_two\"|" /etc/proxysql-admin.cnf
+    sudo sed -i "0,/^[ \t]*export WRITER_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export WRITER_HOSTGROUP_ID[ \t]*=.*$|export WRITER_HOSTGROUP_ID=\"20\"|" /etc/proxysql-admin.cnf
+    sudo sed -i "0,/^[ \t]*export READER_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export READER_HOSTGROUP_ID[ \t]*=.*$|export READER_HOSTGROUP_ID=\"21\"|" /etc/proxysql-admin.cnf
+    sudo sed -i "0,/^[ \t]*export BACKUP_WRITER_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export BACKUP_WRITER_HOSTGROUP_ID[ \t]*=.*$|export BACKUP_WRITER_HOSTGROUP_ID=\"22\"|" /etc/proxysql-admin.cnf
+    sudo sed -i "0,/^[ \t]*export OFFLINE_HOSTGROUP_ID[ \t]*=.*$/s|^[ \t]*export OFFLINE_HOSTGROUP_ID[ \t]*=.*$|export OFFLINE_HOSTGROUP_ID=\"23\"|" /etc/proxysql-admin.cnf
+
+
+    # Disable scheduler admin after for first cluster, since it will run in the background and interfere with the other tests
+    $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable >/dev/null 2>&1 || exit 1
+
+    sudo sed -i "0,/^[ \t]*clusterPort[ \t]*=.*$/s|^[ \t]*clusterPort[ \t]*=.*$|clusterPort=$CLUSTER_TWO_PORT|" $WORKDIR/testsuite.toml
+    sudo sed -i "0,/^[ \t]*hgW[ \t]*=.*$/s|^[ \t]*hgW[ \t]*=.*$|hgW = 200|" $WORKDIR/testsuite.toml
+    sudo sed -i "0,/^[ \t]*hgR[ \t]*=.*$/s|^[ \t]*hgR[ \t]*=.*$|hgR = 201|" $WORKDIR/testsuite.toml
+
     for test_file in ${TEST_SUITES2[@]}; do
       echo "cluster_two : $test_file"
       SECONDS=0
@@ -1085,5 +1197,10 @@ if [[ $RUN_TEST -eq 1 ]]; then
       echo ""
     done
     echo ""
+
+    # Reset the testsuite.toml to cluster one for any future runs
+    sudo sed -i "0,/^[ \t]*clusterPort[ \t]*=.*$/s|^[ \t]*clusterPort[ \t]*=.*$|clusterPort=$CLUSTER_ONE_PORT|" $WORKDIR/testsuite.toml
+    sudo sed -i "0,/^[ \t]*hgW[ \t]*=.*$/s|^[ \t]*hgW[ \t]*=.*$|hgW = 100|" $WORKDIR/testsuite.toml
+    sudo sed -i "0,/^[ \t]*hgR[ \t]*=.*$/s|^[ \t]*hgR[ \t]*=.*$|hgR = 101|" $WORKDIR/testsuite.toml
   fi
 fi

--- a/tests/scheduler-admin-testsuite.bats
+++ b/tests/scheduler-admin-testsuite.bats
@@ -7,6 +7,10 @@
 PXC_BASEDIR=$WORKDIR/pxc-bin
 PROXYSQL_BASEDIR=$WORKDIR/proxysql-bin
 
+# Source proxysql-admin.cnf for AUTH_PLUGIN and other shared settings
+source /etc/proxysql-admin.cnf
+AUTH_PLUGIN="${AUTH_PLUGIN:-caching_sha2_password}"
+
 # Declare some GLOBALS
 # These are used to return data from get_node_data()
 declare HOSTS=()
@@ -167,14 +171,14 @@ else
 fi
 
 # Ensure that the config file has the same options at start
-sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader = 1|" testsuite.toml
-sudo sed -i "0,/^[ \t]*singlePrimary[ \t]*=.*$/s|^[ \t]*singlePrimary[ \t]*=.*$|singlePrimary = true|" testsuite.toml
-sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|maxNumWriters = 1|" testsuite.toml
+sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader = 1|" $WORKDIR/testsuite.toml
+sudo sed -i "0,/^[ \t]*singlePrimary[ \t]*=.*$/s|^[ \t]*singlePrimary[ \t]*=.*$|singlePrimary = true|" $WORKDIR/testsuite.toml
+sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|maxNumWriters = 1|" $WORKDIR/testsuite.toml
 
 
 
 @test "run percona-scheduler-admin -d ($WSREP_CLUSTER_NAME)" {
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml -d
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml -d
   echo "$output" >&2
   [ "$status" -eq  0 ]
 }
@@ -182,7 +186,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
 @test "run percona-scheduler-admin -e ($WSREP_CLUSTER_NAME)" {
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml -e  <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml -e  <<< 'n'
   echo "$output" >&2
   [ "$status" -eq  0 ]
 
@@ -223,7 +227,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   echo "$LINENO : reader maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --is-enabled <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --is-enabled <<< 'n'
   echo "$output" >&2
   [ "$status" -eq  0 ]
 }
@@ -239,7 +243,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $proxysql_mysql_version ]]
 
   if [[ $mysql_version != $proxysql_mysql_version ]]; then
-    run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-mysql-version
+    run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-mysql-version
     echo "$output" >&2
     [ "$status" -eq  0 ]
 
@@ -248,7 +252,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
     echo "$LINENO: mysql_version:$mysql_version  proxysql_mysql_version:$proxysql_mysql_version" >&2
     [ "$mysql_version" = "$proxysql_mysql_version" ]
   else
-    run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-mysql-version
+    run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-mysql-version
     echo "$output" >&2
     [ "$status" -eq  0 ]
   fi
@@ -258,7 +262,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $TEST_NAME && ! $TEST_NAME =~ adduser ]] && skip;
   DEBUG_SQL_QUERY=1
 
-  printf "proxysql_test_user1\ntest_user\ny" | sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --adduser --debug >&2
+  printf "proxysql_test_user1\ntest_user\ny" | sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --adduser --debug >&2
   [[ $? -eq 0 ]]
 
   run_check_user_command=$(proxysql_exec "select 1 from runtime_mysql_users where username='proxysql_test_user1'" | head -1 | awk '{print $0}')
@@ -277,7 +281,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   echo "$LINENO : Check query rule count for user(test_query_rule) found:$run_query_rule expect:0"  >&2
   [[ "$run_query_rule" -eq 0 ]]
 
-  mysql_exec "$HOST_IP" "$PORT_3" "create user test_query_rule@'%' identified by 'test';"
+  mysql_exec "$HOST_IP" "$PORT_3" "CREATE USER test_query_rule@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY 'test';"
   # Give the cluster some time for this to replicate
   sleep 3
 
@@ -286,7 +290,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   echo "$LINENO" "cluster count for user test_query_rule found:${mysql_user_count}  expect:1" >&2
   [[ $mysql_user_count -eq 1 ]]
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --syncusers --add-query-rule
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --syncusers --add-query-rule
   echo "$output" >&2
   [ "$status" -eq  0 ]
 
@@ -310,7 +314,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   
   # Dropping user 'test_query_rule' from MySQL server to test the query rule delete operation 
   mysql_exec "$HOST_IP" "$PORT_3" "drop user test_query_rule@'%';"
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --syncusers --add-query-rule
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --syncusers --add-query-rule
   echo "$output" >&2
   [ "$status" -eq  0 ]
   run_check_user=$(proxysql_exec "select 1 from runtime_mysql_users where username='test_query_rule'" | awk '{print $0}')
@@ -369,9 +373,9 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ $proxysql_count -eq 0 ]]
 
   # Create a user on the async node
-  mysql_exec "$HOST_IP" "$ASYNC_PORT" "CREATE USER '${server_user}'@'%' IDENTIFIED WITH mysql_native_password BY 'passwd';"
+  mysql_exec "$HOST_IP" "$ASYNC_PORT" "CREATE USER '${server_user}'@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY 'passwd';"
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --syncusers --server=${HOST_IP}:${ASYNC_PORT}
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --syncusers --server=${HOST_IP}:${ASYNC_PORT}
   echo "$output" >&2
   [ "$status" -eq  0 ]
 
@@ -398,9 +402,9 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ $proxysql_count -eq 0 ]]
 
   # Create a user on the async node
-  mysql_exec "$HOST_IP" "$ASYNC_PORT" "CREATE USER '${server_user}'@'%' IDENTIFIED WITH mysql_native_password BY 'passwd';"
+  mysql_exec "$HOST_IP" "$ASYNC_PORT" "CREATE USER '${server_user}'@'%' IDENTIFIED WITH ${AUTH_PLUGIN} BY 'passwd';"
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --sync-multi-cluster-users --server=${HOST_IP}:${ASYNC_PORT}
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --sync-multi-cluster-users --server=${HOST_IP}:${ASYNC_PORT}
   echo "$output" >&2
   [ "$status" -eq  0 ]
 
@@ -421,11 +425,11 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # Cleaning existing configuration to test --force option as normal run
   dump_runtime_nodes $LINENO "before disable"
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
   dump_runtime_nodes $LINENO "before enable --force"
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml  --enable --force <<< n
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml  --enable --force <<< n
   echo "$output" >&2
   [ "$status" -eq 0 ]
   sleep 10
@@ -467,7 +471,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # Run 'percona-scheduler-admin --enable --force' without removing existing configuration
   echo "$LINENO : running --enable --force (without removing existing config)"  >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml  --enable --force <<< n
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml  --enable --force <<< n
   echo "$output" >&2
   [ "$status" -eq 0 ]
   sleep 10
@@ -508,14 +512,14 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # Check percona-scheduler-admin run status without --force option
   echo "$LINENO : running --disable"  >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml  --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml  --disable
   [ "$status" -eq 0 ]
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml  --enable <<< n
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml  --enable <<< n
   echo "$output" >&2
   [ "$status" -eq 0 ]
 
   # Check percona-scheduler-admin run status with following options
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml  --enable --update-cluster --force  <<< n
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml  --enable --update-cluster --force  <<< n
   echo "$output" >&2
   [ "$status" -eq 0 ]
   sleep 10
@@ -559,13 +563,13 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 @test "test for --writers-are-readers ($WSREP_CLUSTER_NAME)" {
   [[ -n $TEST_NAME && ! $TEST_NAME =~ writers_are_readers_basic ]] && skip;
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
   # Use default value for --writers-are-readers (default is 1 or yes)
   echo "$LINENO : percona-scheduler-admin --enable" >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable <<< 'n'
   [ "$status" -eq 0 ]
   sleep 10
   dump_runtime_nodes $LINENO "after enable"
@@ -584,13 +588,13 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   # -----------------------------------------------------------
   # Now run with --writers-are-readers=no
   echo "$LINENO : percona-scheduler-admin --disable" >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
-  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=0|" testsuite.toml
+  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=0|" $WORKDIR/testsuite.toml
 
   echo "$LINENO : percona-scheduler-admin --enable --writers-are-readers=no" >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable <<< 'n'
   [ "$status" -eq 0 ]
   sleep 5
   dump_runtime_nodes $LINENO "after enable (writers-are-readers=no)"
@@ -607,12 +611,12 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
 
   # restore the system
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
-  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=1|" testsuite.toml
+  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=1|" $WORKDIR/testsuite.toml
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable <<< 'n'
   [ "$status" -eq 0 ]
 
   sleep 5
@@ -623,7 +627,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 @test "test for --writers-are-readers with a read-only node ($WSREP_CLUSTER_NAME)" {
   [[ -n $TEST_NAME && ! $TEST_NAME =~ writes_are_readers_read_only ]] && skip;
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
@@ -637,7 +641,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   # This will fail because read-only nodes are not allowed in configurations
   # that use --writers-are-ready=yes (which is the default)
   echo "$LINENO : percona-scheduler-admin --enable" >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable <<< 'n'
   [ "$status" -eq 0 ]
   sleep 10
 
@@ -655,13 +659,13 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   # -----------------------------------------------------------
   # Now run with --writers-are-readers=no
   echo "$LINENO : percona-scheduler-admin --disable" >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
 
   echo "$LINENO : percona-scheduler-admin --enable --writers-are-readers=no" >&2
-  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=0|" testsuite.toml
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable <<< 'n'
+  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=0|" $WORKDIR/testsuite.toml
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable <<< 'n'
   [ "$status" -eq 0 ]
   sleep 10
 
@@ -683,12 +687,12 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [ "$?" -eq 0 ]
 
   # restore the system
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
-  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=1|" testsuite.toml
+  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=1|" $WORKDIR/testsuite.toml
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable <<< 'n'
   [ "$status" -eq 0 ]
   sleep 5
 
@@ -700,15 +704,15 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 @test "test for --mode=loadbal ($WSREP_CLUSTER_NAME)" {
   [[ -n $TEST_NAME && ! $TEST_NAME =~ loadbal_basic ]] && skip;
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
-  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=0|" testsuite.toml
-  sudo sed -i "0,/^[ \t]*singlePrimary[ \t]*=.*$/s|^[ \t]*singlePrimary[ \t]*=.*$|singlePrimary=false|" testsuite.toml
-  sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|maxNumWriters=9999|" testsuite.toml
+  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=0|" $WORKDIR/testsuite.toml
+  sudo sed -i "0,/^[ \t]*singlePrimary[ \t]*=.*$/s|^[ \t]*singlePrimary[ \t]*=.*$|singlePrimary=false|" $WORKDIR/testsuite.toml
+  sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|maxNumWriters=9999|" $WORKDIR/testsuite.toml
 
   echo "$LINENO : percona-scheduler-admin --enable --mode=loadbal" >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable <<< 'n'
   [ "$status" -eq 0 ]
   sleep 10
 
@@ -723,14 +727,14 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [ "$proxysql_cluster_count" -eq 3 ]
 
   # Reset the system
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
-  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=1|" testsuite.toml
-  sudo sed -i "0,/^[ \t]*singlePrimary[ \t]*=.*$/s|^[ \t]*singlePrimary[ \t]*=.*$|singlePrimary=true|" testsuite.toml
-  sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|maxNumWriters=1|" testsuite.toml
+  sudo sed -i "0,/^[ \t]*writerIsAlsoReader[ \t]*=.*$/s|^[ \t]*writerIsAlsoReader[ \t]*=.*$|writerIsAlsoReader=1|" $WORKDIR/testsuite.toml
+  sudo sed -i "0,/^[ \t]*singlePrimary[ \t]*=.*$/s|^[ \t]*singlePrimary[ \t]*=.*$|singlePrimary=true|" $WORKDIR/testsuite.toml
+  sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|maxNumWriters=1|" $WORKDIR/testsuite.toml
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable <<< 'n'
   [ "$status" -eq 0 ]
   sleep 5
 }
@@ -740,7 +744,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 @test "test --update-cluster ($WSREP_CLUSTER_NAME)" {
   [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_basic ]] && skip;
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
   # Stop node3
@@ -758,7 +762,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   # Startup proxysql
   # -----------------------------------------------------------
   echo "$LINENO : percona-scheduler-admin --enable" >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable  <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable  <<< 'n'
   echo "$output" >& 2
   [ "$status" -eq 0 ]
   sleep 10
@@ -784,7 +788,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   dump_runtime_nodes "$LINENO" "after cluster update (runtime)"
 
   # Run --update-cluster
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster
   echo "$LINENO : percona-scheduler-admin --update-cluster" >&2
   echo "$output" >& 2
   [ "$status" -eq 0 ]
@@ -809,7 +813,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 @test "test --enable --update-cluster ($WSREP_CLUSTER_NAME)" {
   [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_enable ]] && skip;
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
   # Stop node3
@@ -830,7 +834,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   # Startup proxysql
   # -----------------------------------------------------------
   echo "$LINENO : percona-scheduler-admin --enable --update-cluster" >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable --update-cluster <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable --update-cluster <<< 'n'
   echo "$output" >& 2
   [ "$status" -eq 0 ]
   sleep 10
@@ -855,7 +859,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   sleep 10
 
   # Run --update-cluster
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable --update-cluster
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable --update-cluster
   echo "$LINENO : percona-scheduler-admin --update-cluster" >&2
   echo "$output" >& 2
   [ "$status" -eq 0 ]
@@ -879,35 +883,35 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_basic ]] && skip;
 
   # Reset before the test
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --remove-all-servers
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --remove-all-servers
 
   # Save the existing writer node
   local saved_hgw_port writer_node
   saved_hgw_port=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
 
   # Test with PORT_1
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --write-node="$HOST_IP:$PORT_1"
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --write-node="$HOST_IP:$PORT_1"
   echo "$output" >&2
   writer_node=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
   [ "$writer_node" -eq "$PORT_1" ]
   [ "$status" -eq 0 ]
 
   # Test with PORT_2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --write-node="$HOST_IP:$PORT_2"
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --write-node="$HOST_IP:$PORT_2"
   echo "$output" >&2
   writer_node=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
   [ "$writer_node" -eq "$PORT_2" ]
   [ "$status" -eq 0 ]
 
   # Test with PORT_3
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --write-node="$HOST_IP:$PORT_3"
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --write-node="$HOST_IP:$PORT_3"
   echo "$output" >&2
   writer_node=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
   [ "$writer_node" -eq "$PORT_3" ]
   [ "$status" -eq 0 ]
 
   # Reset to saved_hgw_port
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --write-node="$HOST_IP:$saved_hgw_port"
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --write-node="$HOST_IP:$saved_hgw_port"
   writer_node=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
   [ "$writer_node" -eq "$saved_hgw_port" ]
   [ "$status" -eq 0 ]
@@ -916,7 +920,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
 @test "test upgrade from proxy-admin script ($WSREP_CLUSTER_NAME)" {
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml -d  <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml -d  <<< 'n'
   echo "$output" >&2
   [ "$status" -eq  0 ]
   local saved_hgw saved_hgr
@@ -936,7 +940,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   WRITER_HOSTGROUP_ID=$saved_hgw
   READER_HOSTGROUP_ID=$saved_hgr
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml -e  <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml -e  <<< 'n'
   echo "$output" >&2
   [ "$status" -eq  0 ]
 
@@ -977,7 +981,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   echo "$LINENO : reader maint count:$node_count expected:0" >&2
   [ "$node_count" -eq 0 ]
 
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --is-enabled <<< 'n'
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --is-enabled <<< 'n'
   echo "$output" >&2
   [ "$status" -eq  0 ]
 }
@@ -987,7 +991,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_basic ]] && skip;
 
   # Update node weight using --update-weight option
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --update-read-weight="$HOST_IP:$PORT_1,1234"
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --update-read-weight="$HOST_IP:$PORT_1,1234"
 
   # Validate
   node_weight=$(proxysql_exec "select weight from runtime_mysql_servers where hostname='$HOST_IP' AND port=$PORT_1 AND hostgroup_id = $READER_HOSTGROUP_ID " | awk '{print $0}')
@@ -999,7 +1003,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
   # Update node weight using --update-write-weight option
   writer_port=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --update-write-weight="$HOST_IP:$writer_port,2340"
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --update-write-weight="$HOST_IP:$writer_port,2340"
 
   # Validate
   node_weight=$(proxysql_exec "select weight from runtime_mysql_servers where hostname='$HOST_IP' AND port=$writer_port AND hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
@@ -1010,7 +1014,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [ "$status" -eq 0 ]
 
   # Reset weights
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --remove-all-servers
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --remove-all-servers
 }
 
 # Test --update-cluster with --auto-assign-weights
@@ -1018,7 +1022,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $TEST_NAME && ! $TEST_NAME =~ update_cluster_basic ]] && skip;
 
   # Update node weight using --update-weight option
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --auto-assign-weights
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --auto-assign-weights
 
   # There should be only one writer.
   writer_count=$(proxysql_exec "select count(*) from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
@@ -1055,7 +1059,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [ $writer_998_count -eq 1 ]
 
   # Reset weights
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --remove-all-servers
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --remove-all-servers
 }
 
 # Test --enable with --write-node
@@ -1063,9 +1067,9 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
 
 
   # Test with PORT_1
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable --write-node="$HOST_IP:$PORT_1"
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable --write-node="$HOST_IP:$PORT_1"
   [ "$status" -eq 0 ]
   writer_node=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
   writer_weight=$(proxysql_exec "select weight from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
@@ -1075,9 +1079,9 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [ "$status" -eq 0 ]
 
   # Test with PORT_2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable --write-node="$HOST_IP:$PORT_2"
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable --write-node="$HOST_IP:$PORT_2"
   [ "$status" -eq 0 ]
   writer_node=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
   writer_weight=$(proxysql_exec "select weight from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
@@ -1087,9 +1091,9 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [ "$status" -eq 0 ]
 
   # Test with PORT_3
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable --write-node="$HOST_IP:$PORT_3"
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable --write-node="$HOST_IP:$PORT_3"
   [ "$status" -eq 0 ]
   writer_node=$(proxysql_exec "select port from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
   writer_weight=$(proxysql_exec "select weight from runtime_mysql_servers where hostgroup_id = $WRITER_HOSTGROUP_ID " | awk '{print $0}')
@@ -1099,7 +1103,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [ "$status" -eq 0 ]
 
   # Reset
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --remove-all-servers
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --remove-all-servers
 }
 
 # Test singlewrite with --write-node is a read-only node
@@ -1107,7 +1111,7 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [[ -n $TEST_NAME && ! $TEST_NAME =~ singlewrite_read_only ]] && skip;
 
   # Disable
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --disable
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --disable
   [ "$status" -eq 0 ]
 
   # -----------------------------------------------------------
@@ -1119,13 +1123,13 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   # -----------------------------------------------------------
   # This should fail, since a write-node cannot be read-only
   echo "$LINENO : percona-scheduler-admin --enable --write-node=${HOST_IP}:${PORT_3}" >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable --write-node=${HOST_IP}:${PORT_3}
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable --write-node=${HOST_IP}:${PORT_3}
   [ "$status" -eq 1 ]
 
   # -----------------------------------------------------------
   # This should pass, since --force option suppresses error
   echo "$LINENO : percona-scheduler-admin --enable --write-node=${HOST_IP}:${PORT_3} --force" >&2
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --enable --write-node=${HOST_IP}:${PORT_3} --force
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --enable --write-node=${HOST_IP}:${PORT_3} --force
   [[ ${lines[10]} =~ ^WARNING.*The.specified.write.node.*is.read-only.$ ]]
   [ "$status" -eq 0 ]
 
@@ -1136,5 +1140,5 @@ sudo sed -i "0,/^[ \t]*maxNumWriters[ \t]*=.*$/s|^[ \t]*maxNumWriters[ \t]*=.*$|
   [ "$?" -eq 0 ]
 
   # Reset
-  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-cluster --remove-all-servers
+  run sudo PATH=$WORKDIR:$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-cluster --remove-all-servers
 }

--- a/tests/scheduler-args.bats
+++ b/tests/scheduler-args.bats
@@ -50,67 +50,67 @@ PROXYSQL_BASEDIR=$WORKDIR/proxysql-bin
 }
 
 @test "run percona-scheduler-admin --proxysql-username without parameters" {
-    run sudo $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --proxysql-username
+    run sudo $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --proxysql-username
     echo "$output" >&2
     [ "$status" -eq 1 ]
 }
 
 @test "run percona-scheduler-admin --proxysql-port without parameters" {
-    run sudo $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --proxysql-port
+    run sudo $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --proxysql-port
     echo "$output" >&2
     [ "$status" -eq 1 ]
 }
 
 @test "run percona-scheduler-admin --proxysql-hostname without parameters" {
-    run sudo $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --proxysql-hostname
+    run sudo $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --proxysql-hostname
     echo "$output" >&2
     [ "$status" -eq 1 ]
 }
 
 @test "run percona-scheduler-admin --cluster-username without parameters" {
-    run sudo $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --cluster-username
+    run sudo $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --cluster-username
     echo "$output" >&2
     [ "$status" -eq 1 ]
 }
 
 @test "run percona-scheduler-admin --cluster-port without parameters" {
-    run sudo $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --cluster-port
+    run sudo $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --cluster-port
     echo "$output" >&2
     [ "$status" -eq 1 ]
 }
 
 @test "run percona-scheduler-admin --cluster-hostname without parameters" {
-    run sudo $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --cluster-hostname
+    run sudo $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --cluster-hostname
     echo "$output" >&2
     [ "$status" -eq 1 ]
 }
 
 @test "run percona-scheduler-admin --cluster-app-username without parameters" {
-    run sudo $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --cluster-app-username
+    run sudo $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --cluster-app-username
     echo "$output" >&2
     [ "$status" -eq 1 ]
 }
 
 @test "run percona-scheduler-admin --monitor-username without parameters" {
-    run sudo $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --monitor-username
+    run sudo $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --monitor-username
     echo "$output" >&2
     [ "$status" -eq 1 ]
 }
 
 @test "run percona-scheduler-admin --write-node without parameters" {
-    run sudo $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --write-node
+    run sudo $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --write-node
     echo "$output" >&2
     [ "$status" -eq 1 ]
     [[ "${lines[0]}" =~ .*--write-node.* ]]
 }
 
 @test "run percona-scheduler-admin --write-node with missing port" {
-    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --write-node=1.1.1.1,2.2.2.2:44 --disable
+    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --write-node=1.1.1.1,2.2.2.2:44 --disable
     echo "$output" >&2
     [ "$status" -eq 1 ]
     [[ "${lines[0]}" =~ ERROR.*--write-node.*expects.* ]]
 
-    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --write-node=[1:1:1:1],[2:2:2:2]:44 --disable
+    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --write-node=[1:1:1:1],[2:2:2:2]:44 --disable
     echo "$output" >&2
     [ "$status" -eq 1 ]
     [[ "${lines[0]}" =~ ERROR.*--write-node.*expects.* ]]
@@ -129,17 +129,17 @@ PROXYSQL_BASEDIR=$WORKDIR/proxysql-bin
 
 # Mutually exclusive options
 @test "run percona-scheduler-admin --auto-assign-weights, write-node and --update-write-weight options" {
-    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --auto-assign-weights --write-node=1.1.1.1,2.2.2.2:44
+    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --auto-assign-weights --write-node=1.1.1.1,2.2.2.2:44
     echo "$output" >&2
     [ "$status" -eq 1 ]
     [[ "${lines[0]}" =~ ERROR.*options.are.mutually.exclusive.* ]]
 
-    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --write-node=2.2.2.2:44 --update-write-weight="[::1]:4130,2000"
+    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --write-node=2.2.2.2:44 --update-write-weight="[::1]:4130,2000"
     echo "$output" >&2
     [ "$status" -eq 1 ]
     [[ "${lines[0]}" =~ ERROR.*options.are.mutually.exclusive.* ]]
 
-    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-write-weight="[::1]:4130,2000" --auto-assign-weights
+    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-write-weight="[::1]:4130,2000" --auto-assign-weights
     echo "$output" >&2
     [ "$status" -eq 1 ]
     [[ "${lines[0]}" =~ ERROR.*options.are.mutually.exclusive.* ]]
@@ -147,12 +147,12 @@ PROXYSQL_BASEDIR=$WORKDIR/proxysql-bin
 
 # Malformed address in --update-write-weight
 @test "run percona-scheduler-admin --update-write-weight" {
-    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-write-weight="[::1]:4130av,20s00"
+    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-write-weight="[::1]:4130av,20s00"
     echo "$output" >&2
     [ "$status" -eq 1 ]
     [[ "${lines[0]}" =~ ERROR.*expected.address.in.format.* ]]
 
-    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=testsuite.toml --update-write-weight="[::1]:4130,20s00"
+    run sudo PATH=$PATH $WORKDIR/percona-scheduler-admin --config-file=$WORKDIR/testsuite.toml --update-write-weight="[::1]:4130,20s00"
     echo "$output" >&2
     [ "$status" -eq 1 ]
     [[ "${lines[0]}" =~ ERROR.*Weight.in.--update-write-weight.requires.a.number.* ]]

--- a/tests/setup_workdir.sh
+++ b/tests/setup_workdir.sh
@@ -89,7 +89,6 @@ VERSION="8.4"
 
 # Fetch PXC versions
 if [[ $VERSION == "8.0" ]]; then
-
     LATEST_VERSION=$(git ls-remote --refs --sort='version:refname' --tags https://github.com/percona/percona-xtradb-cluster | \
     grep 'Percona-XtraDB-Cluster-8.0' | tail -n1 | cut -d '/' -f3 | cut -d '-' -f4)
     VERSION_SUFFIX=$(git ls-remote --refs --sort='version:refname' --tags https://github.com/percona/percona-xtradb-cluster | \
@@ -99,6 +98,11 @@ elif [[ $VERSION == "8.4" ]]; then
     grep 'Percona-XtraDB-Cluster-8.4' | tail -n1 | cut -d '/' -f3 | cut -d '-' -f4)
     VERSION_SUFFIX=$(git ls-remote --refs --sort='version:refname' --tags https://github.com/percona/percona-xtradb-cluster | \
     grep 'Percona-XtraDB-Cluster-8.4' | tail -n1 | cut -d '/' -f3 | cut -d '-' -f5)
+elif [[ $VERSION == "9.6" ]]; then
+    LATEST_VERSION=$(git ls-remote --refs --sort='version:refname' --tags https://github.com/percona/percona-xtradb-cluster | \
+    grep 'Percona-XtraDB-Cluster-9.6' | tail -n1 | cut -d '/' -f3 | cut -d '-' -f4)
+    VERSION_SUFFIX=$(git ls-remote --refs --sort='version:refname' --tags https://github.com/percona/percona-xtradb-cluster | \
+    grep 'Percona-XtraDB-Cluster-9.6' | tail -n1 | cut -d '/' -f3 | cut -d '-' -f5)
 fi
 
 if [ -d "$WORKDIR" ]; then
@@ -156,6 +160,10 @@ if [[ ! $SKIP_DOWNLOAD -eq 1 ]];then
     wget -O $WORKDIR/Percona-XtraDB-Cluster_${LATEST_VERSION}_Linux.x86_64.glibc2.35-minimal.tar.gz http://downloads.percona.com/downloads/Percona-XtraDB-Cluster-80/Percona-XtraDB-Cluster-${LATEST_VERSION}/binary/tarball/Percona-XtraDB-Cluster_${LATEST_VERSION}-${VERSION_SUFFIX}_Linux.x86_64.glibc2.35-minimal.tar.gz
   elif [[ $VERSION == "8.4" ]]; then
     wget -O $WORKDIR/Percona-XtraDB-Cluster_${LATEST_VERSION}_Linux.x86_64.glibc2.35-minimal.tar.gz http://downloads.percona.com/downloads/Percona-XtraDB-Cluster-84/Percona-XtraDB-Cluster-${LATEST_VERSION}/binary/tarball/Percona-XtraDB-Cluster_${LATEST_VERSION}-${VERSION_SUFFIX}_Linux.x86_64.glibc2.35-minimal.tar.gz
+  elif [[ $VERSION == "9.6" ]]; then
+    wget -O $WORKDIR/Percona-XtraDB-Cluster_${LATEST_VERSION}_Linux.x86_64.glibc2.35-minimal.tar.gz http://downloads.percona.com/downloads/TESTING/pxc-9.6.0/Percona-XtraDB-Cluster_9.6.0-1.1_Linux.x86_64.glibc2.35-minimal.tar.gz
+  elif [[ $VERSION == "9.7" ]]; then
+    echo "Skipping download"
   fi
   echo "...Successful"
 fi


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PSQLADM-598

- Add support to run admin scripts with PXC 9.6 and 9.7.

This also covers PSQLADM-574

Add configurable AUTH_PLUGIN and stabilize scheduler test config selection
- Add AUTH_PLUGIN support across admin/scheduler SQL paths and user creation flows.
- The default AUTH_PLUGIN is set to caching_sha2_password in shared config/common layer.
- Validate AUTH_PLUGIN values and fail fast on unsupported plugins
- Update test suites to use AUTH_PLUGIN-aware CREATE USER statements
- Add auth plugin compatibility test to still test with mysql_native_password plugin which can be skipped by using skip-auth-plugin-compat-test option(disabled by default).
- Improve scheduler test orchestration by switching testsuite.toml clusterPort/hgW/hgR between cluster runs.
- Increase timeout for syncusers(many users) test.
- Add a filter to exclude percona.telemetry user in tests which use user count to check for failure.
- Updated absolute config path usage with $WORKDIR/testsuite.toml to makes the scheduler admin tests more deterministic.
- Disables scheduler admin after args tests and in between tests on clusters 1 and 2.
- wsrep_slave_threads is deprecated. Use wsrep_applier_threads for 8.0+ versions of PXC.